### PR TITLE
Update interface for verify_kzg_proof

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -33,7 +33,7 @@ public class Ckzg
     public static unsafe extern int verify_aggregate_kzg_proof(byte[] blobs, byte[] commitments, int blobCount, byte[] proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof_wrap", CallingConvention = CallingConvention.Cdecl)] // returns 0 on success
-    public static extern int verify_kzg_proof(byte[/*48*/] commitment, byte[/*32*/] x, byte[/*32*/] y, byte[/*48*/] proof, IntPtr ts);
+    public static extern int verify_kzg_proof(byte[/*48*/] commitment, byte[/*32*/] z, byte[/*32*/] y, byte[/*48*/] proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "load_trusted_setup_wrap")] // free result with free_trusted_setup()
     public static extern IntPtr load_trusted_setup(string filename);

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -63,15 +63,12 @@ C_KZG_RET compute_aggregate_kzg_proof_wrap(uint8_t out[48], const Blob blobs[], 
 int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t x[32], const uint8_t y[32], const uint8_t p[48], KZGSettings *s) {
   KZGCommitment commitment;
   KZGProof proof;
-  BLSFieldElement fx, fy;
   bool out;
 
-  bytes_to_bls_field(&fx, x);
-  bytes_to_bls_field(&fy, y);
   if (bytes_to_g1(&commitment, c) != C_KZG_OK) return -1;
   if (bytes_to_g1(&proof, p) != C_KZG_OK) return -1;
 
-  if (verify_kzg_proof(&out, &commitment, &fx, &fy, &proof, s) != C_KZG_OK)
+  if (verify_kzg_proof(&out, &commitment, x, y, &proof, s) != C_KZG_OK)
     return -2;
 
   return out ? 0 : 1;

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -60,7 +60,7 @@ C_KZG_RET compute_aggregate_kzg_proof_wrap(uint8_t out[48], const Blob blobs[], 
   return C_KZG_OK;
 }
 
-int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t x[32], const uint8_t y[32], const uint8_t p[48], KZGSettings *s) {
+int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t z[32], const uint8_t y[32], const uint8_t p[48], KZGSettings *s) {
   KZGCommitment commitment;
   KZGProof proof;
   bool out;
@@ -68,7 +68,7 @@ int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t x[32], const uint8_
   if (bytes_to_g1(&commitment, c) != C_KZG_OK) return -1;
   if (bytes_to_g1(&proof, p) != C_KZG_OK) return -1;
 
-  if (verify_kzg_proof(&out, &commitment, x, y, &proof, s) != C_KZG_OK)
+  if (verify_kzg_proof(&out, &commitment, z, y, &proof, s) != C_KZG_OK)
     return -2;
 
   return out ? 0 : 1;

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT 
+#define DLLEXPORT
 #endif
 
 DLLEXPORT KZGSettings* load_trusted_setup_wrap(const char* file);
@@ -19,4 +19,4 @@ DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const uint8_t 
 
 DLLEXPORT C_KZG_RET compute_aggregate_kzg_proof_wrap(uint8_t out[48], const Blob blobs[], size_t n, const KZGSettings *s);
 
-DLLEXPORT int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t x[32], const uint8_t y[32], const uint8_t p[48], KZGSettings *s);
+DLLEXPORT int verify_kzg_proof_wrap(const uint8_t c[48], const uint8_t z[32], const uint8_t y[32], const uint8_t p[48], KZGSettings *s);

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -306,10 +306,6 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
 
   auto kzg_settings = info[4].As<Napi::External<KZGSettings>>().Data();
 
-  BLSFieldElement fz, fy;
-  bytes_to_bls_field(&fz, z);
-  bytes_to_bls_field(&fy, y);
-
   KZGCommitment commitment;
   auto ret = bytes_to_g1(&commitment, polynomial_kzg);
   if (ret != C_KZG_OK) {
@@ -327,7 +323,7 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   }
 
   bool out;
-  if (verify_kzg_proof(&out, &commitment, &fz, &fy, &proof, kzg_settings) != C_KZG_OK) {
+  if (verify_kzg_proof(&out, &commitment, z, y, &proof, kzg_settings) != C_KZG_OK) {
     Napi::TypeError::New(env, "Failed to verify KZG proof").ThrowAsJavaScriptException();
     return env.Null();
   }

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -116,8 +116,8 @@ void blob_to_kzg_commitment(KZGCommitment *out,
 
 C_KZG_RET verify_kzg_proof(bool *out,
     const KZGCommitment *polynomial_kzg,
-    const BLSFieldElement *z,
-    const BLSFieldElement *y,
+    const uint8_t z[BYTES_PER_FIELD_ELEMENT],
+    const uint8_t y[BYTES_PER_FIELD_ELEMENT],
     const KZGProof *kzg_proof,
     const KZGSettings *s);
 


### PR DESCRIPTION
Match the public interface in the specs which takes bytes for the field elements.