### PR TITLE
NodeJS bindings version 1.0.7

### DIFF
--- a/bindings/node.js/Dockerfile
+++ b/bindings/node.js/Dockerfile
@@ -1,6 +1,9 @@
 # Exists as a test harness for building and running tests in Linux
 
-FROM node:16
+
+FROM node:16-alpine
+RUN apk update && apk add --no-cache g++ make python3
+
 
 COPY ./dist/ /app/dist/
 COPY test.ts /app

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -10,6 +10,7 @@ clean:
 
 build: kzg.cxx kzg.ts package.json binding.gyp Makefile
 	cd ../../src; make lib
+	yarn install
 	yarn node-gyp rebuild
 
 test: build

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -22,9 +22,13 @@ import {
 } from "c-kzg";
 ```
 
-Requirements
+# Requirements
 
-- The C and C++ code is compiled by node-gyp on installation, so your environment will need a compiler like GCC or clang
+The C and C++ code is compiled by node-gyp on installation. Your environment will need
+
+- A compiler like g++ or clang
+- `make`
+- `python3`
 
 # Contributing
 

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -9,8 +9,8 @@
 #include "blst.h"
 
 Napi::Value throw_invalid_arguments_count(
-  const uint expected,
-  const uint actual,
+  const unsigned int expected,
+  const unsigned int actual,
   const Napi::Env env
 ) {
   Napi::RangeError::New(

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",


### PR DESCRIPTION
This version will build on Alpine with newer g++, which is what EthereumJS requires.