### PR TITLE
Run NodeJS bindings unit tests in CI

### DIFF
--- a/.github/workflows/nodejs-bindings-test.yml
+++ b/.github/workflows/nodejs-bindings-test.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           submodules: recursive
       - name: Setup
-        run: cd src && make blst all
+        run: cd src && make blst
       - name: Test
         run: cd bindings/node.js && make build test

--- a/.github/workflows/nodejs-bindings-test.yml
+++ b/.github/workflows/nodejs-bindings-test.yml
@@ -1,0 +1,19 @@
+name: NodeJS bindings tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-ckzg:
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup
+        run: cd src && make blst all
+      - name: Test
+        run: cd bindings/node.js && make build test

--- a/.github/workflows/nodejs-bindings-test.yml
+++ b/.github/workflows/nodejs-bindings-test.yml
@@ -8,7 +8,8 @@ on:
       - main
 
 jobs:
-  build-ckzg:
+  test-nodejs-bindings:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -10,6 +10,7 @@ clean:
 
 build: kzg.cxx kzg.ts package.json binding.gyp Makefile
 	cd ../../src; make lib
+	yarn install
 	yarn node-gyp rebuild
 
 test: build

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -33,7 +33,6 @@ describe("C-KZG", () => {
   });
 
   it("computes the correct commitments and aggregate proof from blobs", () => {
-    expect(false).toBe(true);
     let blobs = new Array(2).fill(0).map(generateRandomBlob);
     let commitments = blobs.map(blobToKzgCommitment);
     let proof = computeAggregateKzgProof(blobs);

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -33,6 +33,7 @@ describe("C-KZG", () => {
   });
 
   it("computes the correct commitments and aggregate proof from blobs", () => {
+    expect(false).toBe(true);
     let blobs = new Array(2).fill(0).map(generateRandomBlob);
     let commitments = blobs.map(blobToKzgCommitment);
     let proof = computeAggregateKzgProof(blobs);

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 INCLUDE_DIRS = ../inc
-CFLAGS += -O2
+CFLAGS += -O2 -fPIC
 
 all: c_kzg_4844.o lib
 


### PR DESCRIPTION
Adds a GH actions workflow which runs the NodeJS bindings unit tests in CI.