### PR TITLE
Java binding compilation improvement for macos

### DIFF
--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -11,9 +11,9 @@ else
 	GRADLE_COMMAND=./gradlew
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
-	CLANG_FLAGS=-fPIC -shared
-	JNI_INCLUDE_FOLDER=linux
-	LIBRARY_RESOURCE=libckzg4844jni.so
+		CLANG_FLAGS=-fPIC -shared
+		JNI_INCLUDE_FOLDER=linux
+		LIBRARY_RESOURCE=libckzg4844jni.so
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		ifeq ($(JAVA_HOME),)
@@ -26,7 +26,7 @@ else
 endif
 
 ifeq ($(JAVA_HOME),)
-$(error JAVA_HOME is not set and autodetection failed)
+	$(error JAVA_HOME is not set and autodetection failed)
 endif
 
 all: build test

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -19,9 +19,9 @@ else
 		ifeq ($(JAVA_HOME),)
 			JAVA_HOME := $(shell /usr/libexec/java_home)
 		endif
-	CLANG_FLAGS=-dynamiclib
-	JNI_INCLUDE_FOLDER=darwin
-	LIBRARY_RESOURCE=libckzg4844jni.dylib
+		CLANG_FLAGS=-dynamiclib
+		JNI_INCLUDE_FOLDER=darwin
+		LIBRARY_RESOURCE=libckzg4844jni.dylib
 	endif
 endif
 

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -8,15 +8,18 @@ ifeq ($(OS),Windows_NT)
 	LIBRARY_RESOURCE=ckzg4844jni.dll
 else
 	CLANG_EXECUTABLE=clang
-    GRADLE_COMMAND=./gradlew
+    	GRADLE_COMMAND=./gradlew
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
-		CLANG_FLAGS=-fPIC -shared
+	CLANG_FLAGS=-fPIC -shared
     	JNI_INCLUDE_FOLDER=linux
     	LIBRARY_RESOURCE=libckzg4844jni.so
 	endif
 	ifeq ($(UNAME_S),Darwin)
-		CLANG_FLAGS=-dynamiclib
+		ifeq ($(JAVA_HOME),)
+			JAVA_HOME := $(shell /usr/libexec/java_home)
+		endif
+	CLANG_FLAGS=-dynamiclib
     	JNI_INCLUDE_FOLDER=darwin
     	LIBRARY_RESOURCE=libckzg4844jni.dylib
 	endif

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -8,21 +8,25 @@ ifeq ($(OS),Windows_NT)
 	LIBRARY_RESOURCE=ckzg4844jni.dll
 else
 	CLANG_EXECUTABLE=clang
-    	GRADLE_COMMAND=./gradlew
+	GRADLE_COMMAND=./gradlew
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
 	CLANG_FLAGS=-fPIC -shared
-    	JNI_INCLUDE_FOLDER=linux
-    	LIBRARY_RESOURCE=libckzg4844jni.so
+	JNI_INCLUDE_FOLDER=linux
+	LIBRARY_RESOURCE=libckzg4844jni.so
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		ifeq ($(JAVA_HOME),)
 			JAVA_HOME := $(shell /usr/libexec/java_home)
 		endif
 	CLANG_FLAGS=-dynamiclib
-    	JNI_INCLUDE_FOLDER=darwin
-    	LIBRARY_RESOURCE=libckzg4844jni.dylib
+	JNI_INCLUDE_FOLDER=darwin
+	LIBRARY_RESOURCE=libckzg4844jni.dylib
 	endif
+endif
+
+ifeq ($(JAVA_HOME),)
+$(error JAVA_HOME is not set and autodetection failed)
 endif
 
 all: build test


### PR DESCRIPTION
On Macos, tries to get `JAVA_HOME` automatically if not already set