### PR TITLE
Load trusted setup from arguments

### DIFF
--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -13,7 +13,7 @@ KZGSettings* load_trusted_setup_wrap(const char* file) {
 
   if (f == NULL) { free(out); return NULL; }
 
-  if (load_trusted_setup(out, f) != C_KZG_OK) { free(out); fclose(f); return NULL; }
+  if (load_trusted_setup_file(out, f) != C_KZG_OK) { free(out); fclose(f); return NULL; }
 
   fclose(f);
   return out;

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -48,7 +48,7 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup(JNIEn
     return;
   }
 
-  C_KZG_RET ret = load_trusted_setup(settings, f);
+  C_KZG_RET ret = load_trusted_setup_file(settings, f);
 
   if (ret != C_KZG_OK)
   {

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -90,7 +90,7 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo& info) {
     return env.Null();
   }
 
-  if (load_trusted_setup(kzg_settings, f) != C_KZG_OK) {
+  if (load_trusted_setup_file(kzg_settings, f) != C_KZG_OK) {
     free(kzg_settings);
     Napi::Error::New(env, "Error loading trusted setup file").ThrowAsJavaScriptException();
     return env.Null();

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -22,7 +22,7 @@ static PyObject* load_trusted_setup_wrap(PyObject *self, PyObject *args) {
 
   if (s == NULL) return PyErr_NoMemory();
 
-  if (load_trusted_setup(s, fopen(PyUnicode_AsUTF8(f), "r")) != C_KZG_OK) {
+  if (load_trusted_setup_file(s, fopen(PyUnicode_AsUTF8(f), "r")) != C_KZG_OK) {
     free(s);
     return PyErr_Format(PyExc_RuntimeError, "error loading trusted setup");
   }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -770,7 +770,7 @@ static void bytes_from_bls_field(uint8_t out[32], const BLSFieldElement *in) {
   blst_scalar_from_fr((blst_scalar*)out, in);
 }
 
-C_KZG_RET load_trusted_setup(KZGSettings *out, FILE *in) {
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
   uint64_t i;
   int j; uint8_t c[96];
   blst_p2_affine g2_affine;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -91,7 +91,7 @@ void bytes_from_g1(uint8_t out[48], const g1_t *in);
 
 void bytes_to_bls_field(BLSFieldElement *out, const uint8_t in[BYTES_PER_FIELD_ELEMENT]);
 
-C_KZG_RET load_trusted_setup(KZGSettings *out,
+C_KZG_RET load_trusted_setup_file(KZGSettings *out,
     FILE *in);
 
 void free_trusted_setup(

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -91,6 +91,12 @@ void bytes_from_g1(uint8_t out[48], const g1_t *in);
 
 void bytes_to_bls_field(BLSFieldElement *out, const uint8_t in[BYTES_PER_FIELD_ELEMENT]);
 
+C_KZG_RET load_trusted_setup(KZGSettings *out,
+    const uint8_t g1_bytes[], /* n1 * 48 bytes */
+    size_t n1,
+    const uint8_t g2_bytes[], /* n2 * 96 bytes */
+    size_t n2);
+
 C_KZG_RET load_trusted_setup_file(KZGSettings *out,
     FILE *in);
 


### PR DESCRIPTION
Avoid the need for a `FILE*`