### PR TITLE
Check that malloc'd settings isn't null

### DIFF
--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -49,6 +49,7 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup__Ljav
   if (settings == NULL)
   {
     throw_exception(env, "Failed to allocate memory for settings.");
+    return;
   }
 
   const char *file_native = (*env)->GetStringUTFChars(env, file, 0);
@@ -88,6 +89,7 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup___3BJ
   if (settings == NULL)
   {
     throw_exception(env, "Failed to allocate memory for settings.");
+    return;
   }
 
   jbyte *g1_native = (*env)->GetByteArrayElements(env, g1, NULL);

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -44,7 +44,12 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup__Ljav
     throw_exception(env, "Trusted Setup is already loaded. Free it before loading a new one.");
     return;
   }
+
   settings = malloc(sizeof(KZGSettings));
+  if (settings == NULL)
+  {
+    throw_exception(env, "Failed to allocate memory for settings.");
+  }
 
   const char *file_native = (*env)->GetStringUTFChars(env, file, 0);
 
@@ -78,7 +83,12 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup___3BJ
     throw_exception(env, "Trusted Setup is already loaded. Free it before loading a new one.");
     return;
   }
+  
   settings = malloc(sizeof(KZGSettings));
+  if (settings == NULL)
+  {
+    throw_exception(env, "Failed to allocate memory for settings.");
+  }
 
   jbyte *g1_native = (*env)->GetByteArrayElements(env, g1, NULL);
   jbyte *g2_native = (*env)->GetByteArrayElements(env, g2, NULL);


### PR DESCRIPTION
I think it's a good idea to check the return values for these two `malloc` calls.

In the event of memory exhaustion, it will provide a better error message than a segfault crash will.