### PR TITLE
Refactor error handling

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -811,10 +811,6 @@ C_KZG_RET load_trusted_setup(KZGSettings *out, const uint8_t g1_bytes[], size_t 
   if (ret != C_KZG_OK) goto error_free_out;
   ret = fft_g1(out->g1_values, g1_projective, true, n1, out->fs);
   if (ret != C_KZG_OK) goto error_free_out;
-
-  free(g1_projective);
-  g1_projective = NULL;
-
   ret = reverse_bit_order(out->g1_values, sizeof(g1_t), n1);
   if (ret != C_KZG_OK) goto error_free_out;
 
@@ -824,8 +820,8 @@ error_free_out:
   if (out->fs != NULL) free((void *)out->fs);
   if (out->g1_values != NULL) free(out->g1_values);
   if (out->g2_values != NULL) free(out->g2_values);
-  if (g1_projective != NULL) free(g1_projective);
 success_out:
+  if (g1_projective != NULL) free(g1_projective);
   return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1227,15 +1227,13 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
   KZGCommitment* commitments = NULL;
 
   commitments = calloc(n, sizeof(KZGCommitment));
-  if (0 < n && commitments == NULL)
-  {
+  if (0 < n && commitments == NULL) {
     ret = C_KZG_MALLOC;
     goto out;
   }
 
   polys = calloc(n, sizeof(Polynomial));
-  if (0 < n && polys == NULL)
-  {
+  if (0 < n && polys == NULL) {
     ret = C_KZG_MALLOC;
     goto out;
   }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1283,9 +1283,10 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
   KZGCommitment aggregated_poly_commitment;
   BLSFieldElement evaluation_challenge;
   ret = compute_aggregated_poly_and_commitment(aggregated_poly, &aggregated_poly_commitment, &evaluation_challenge, polys, expected_kzg_commitments, n);
+  if (ret != C_KZG_OK) goto free_out;
+  
   free(polys);
   polys = NULL;
-  if (ret != C_KZG_OK) goto free_out;
 
   BLSFieldElement y;
   ret = evaluate_polynomial_in_evaluation_form(&y, aggregated_poly, &evaluation_challenge, s);

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -803,13 +803,8 @@ C_KZG_RET load_trusted_setup(KZGSettings *out, const uint8_t g1_bytes[], size_t 
   unsigned int max_scale = 0;
   while (((uint64_t)1 << max_scale) < n1) max_scale++;
 
-  out->fs = (FFTSettings*)malloc(sizeof(FFTSettings));
-  if (out->fs == NULL)
-  {
-    ret = C_KZG_MALLOC;
-    goto error_free_out;
-  }
-
+  ret = c_kzg_malloc((void**)&out->fs, sizeof(FFTSettings));
+  if (ret != C_KZG_OK) goto error_free_out;
   ret = new_fft_settings((FFTSettings*)out->fs, max_scale);
   if (ret != C_KZG_OK) goto error_free_out;
   ret = fft_g1(out->g1_values, g1_projective, true, n1, out->fs);
@@ -1284,9 +1279,6 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
   BLSFieldElement evaluation_challenge;
   ret = compute_aggregated_poly_and_commitment(aggregated_poly, &aggregated_poly_commitment, &evaluation_challenge, polys, expected_kzg_commitments, n);
   if (ret != C_KZG_OK) goto free_out;
-  
-  free(polys);
-  polys = NULL;
 
   BLSFieldElement y;
   ret = evaluate_polynomial_in_evaluation_form(&y, aggregated_poly, &evaluation_challenge, s);

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -813,6 +813,10 @@ C_KZG_RET load_trusted_setup(KZGSettings *out, const uint8_t g1_bytes[], size_t 
   if (ret != C_KZG_OK) goto error_free_out;
   ret = fft_g1(out->g1_values, g1_projective, true, n1, out->fs);
   if (ret != C_KZG_OK) goto error_free_out;
+
+  free(g1_projective);
+  g1_projective = NULL;
+
   ret = reverse_bit_order(out->g1_values, sizeof(g1_t), n1);
   if (ret != C_KZG_OK) goto error_free_out;
 


### PR DESCRIPTION
I noticed that when the `TRY` macro is used, it doesn't free the previous allocations if there's a problem. The safer alternative is to have a single exit point & free the necessary variables there. I cleaned up those & a few other missing free calls.

Additionally, this PR will:

* Remove the `TRY` macro.
* Replace calls to `malloc` with `c_kzg_malloc`.
* Add some return value checks that were missing.

I know `goto` calls could be a point of contention, but personally I like them. Reduces code duplication and makes it more human readable. I'm somewhat used to Linux kernel development, so maybe I'm biased.

For example, this PR will convert this...

<img src="https://user-images.githubusercontent.com/95511699/208727730-b9c72707-c9b6-4c84-bebc-e829065e0b0b.jpg" width="500"/>

to something like this:

<img src="https://user-images.githubusercontent.com/95511699/208732328-6e47c46c-1673-4cd4-975f-3098b589ecb8.png" width="500"/>

In this example, there is a single exit point AND it frees the memory allocated for the trusted setup (`fs`, `g1_values`, and `g2_values`) if something goes wrong, like if the call to `reverse_bit_order` fails. This was not being done before.