### PR TITLE
Check ret of blob_to_kzg_commitment in c# bindings

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -23,7 +23,7 @@ public class Ckzg
     /// <summary>
     /// Calculates commitment for the blob
     /// </summary>
-    /// <param name="commitment">Prealocated buffer of <inheritdoc cref="CommitmentLength"/> bytes to receive the commitment</param>
+    /// <param name="commitment">Preallocated buffer of <inheritdoc cref="CommitmentLength"/> bytes to receive the commitment</param>
     /// <param name="blob">Flatten array of blob elements</param>
     /// <param name="ts">Trusted setup settings</param>
     /// <returns>Returns error code or <c>0</c> if successful</returns>
@@ -34,7 +34,7 @@ public class Ckzg
     /// <summary>
     /// Calculates aggregated proof for the blobs
     /// </summary>
-    /// <param name="proof">Prealocated buffer of <inheritdoc cref="ProofLength"/> bytes to receive the proof</param>
+    /// <param name="proof">Preallocated buffer of <inheritdoc cref="ProofLength"/> bytes to receive the proof</param>
     /// <param name="blobs">Blobs as a flatten byte array</param>
     /// <param name="count">Blobs count</param>
     /// <param name="ts">Trusted setup settings</param>

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -26,8 +26,9 @@ public class Ckzg
     /// <param name="commitment">Prealocated buffer of <inheritdoc cref="CommitmentLength"/> bytes to receive the commitment</param>
     /// <param name="blob">Flatten array of blob elements</param>
     /// <param name="ts">Trusted setup settings</param>
+    /// <returns>Returns error code or <c>0</c> if successful</returns>
     [DllImport("ckzg", EntryPoint = "blob_to_kzg_commitment_wrap", CallingConvention = CallingConvention.Cdecl)]
-    public unsafe static extern void BlobToKzgCommitment(byte* commitment, byte* blob, IntPtr ts);
+    public unsafe static extern int BlobToKzgCommitment(byte* commitment, byte* blob, IntPtr ts);
 
 
     /// <summary>
@@ -37,7 +38,7 @@ public class Ckzg
     /// <param name="blobs">Blobs as a flatten byte array</param>
     /// <param name="count">Blobs count</param>
     /// <param name="ts">Trusted setup settings</param>
-    /// <returns>Returns error code or <c>0</c> if succeed</returns>
+    /// <returns>Returns error code or <c>0</c> if successful</returns>
     [DllImport("ckzg", EntryPoint = "compute_aggregate_kzg_proof_wrap", CallingConvention = CallingConvention.Cdecl)] // returns 0 on success
     public unsafe static extern int ComputeAggregatedKzgProof(byte* proof, byte* blobs, int count, IntPtr ts);
 

--- a/bindings/csharp/Ckzg.Test/E2eTests.cs
+++ b/bindings/csharp/Ckzg.Test/E2eTests.cs
@@ -14,8 +14,8 @@ public class BasicKzgTests
         Assert.That(_ts, Is.Not.EqualTo(IntPtr.Zero));
     }
 
-    [TestCase(0xff, -1, -1)]
-    [TestCase(0x73, -1, -1)]
+    [TestCase(0xff, 1, -1)]
+    [TestCase(0x73, 1, -1)]
     [TestCase(0x72, 0, 0)]
     [TestCase(0x00, 0, 0)]
     public unsafe void Test_Computes_And_Verifies(byte highByteValue, int expectedProofComputed, int expectedProofVerified)

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -24,10 +24,13 @@ void free_trusted_setup_wrap(KZGSettings *s) {
   free(s);
 }
 
-void blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s) {
+C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s) {
   KZGCommitment c;
-  blob_to_kzg_commitment(&c, blob, s);
+  C_KZG_RET ret;
+  ret = blob_to_kzg_commitment(&c, blob, s);
+  if (ret != C_KZG_OK) return ret;
   bytes_from_g1(out, &c);
+  return C_KZG_OK;
 }
 
 int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const uint8_t commitments[], size_t n, const uint8_t proof[48], const KZGSettings *s) {
@@ -56,7 +59,7 @@ C_KZG_RET compute_aggregate_kzg_proof_wrap(uint8_t out[48], const Blob blobs[], 
   KZGProof f;
   C_KZG_RET ret;
   ret = compute_aggregate_kzg_proof(&f, blobs, n, s);
-  if (ret != C_KZG_OK) return -1;
+  if (ret != C_KZG_OK) return ret;
   bytes_from_g1(out, &f);
   return C_KZG_OK;
 }

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -13,7 +13,7 @@ DLLEXPORT KZGSettings* load_trusted_setup_wrap(const char* file);
 
 DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
 
-DLLEXPORT void blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s);
+DLLEXPORT C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s);
 
 DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const uint8_t commitments[], size_t n, const uint8_t proof[48], const KZGSettings *s);
 

--- a/bindings/csharp/kzg_tests.c
+++ b/bindings/csharp/kzg_tests.c
@@ -16,7 +16,7 @@ void calculate_proof_and_commitment(char * trusted_setup_path){
       n++;
    }
    int res0 = compute_aggregate_kzg_proof_wrap(proof, blob, 1, s);
-   blob_to_kzg_commitment_wrap(commitment, blob, s);
+   int res1 = blob_to_kzg_commitment_wrap(commitment, blob, s);
 
    FILE *f = fopen("output.txt", "wt");
    // commitment
@@ -34,7 +34,7 @@ void calculate_proof_and_commitment(char * trusted_setup_path){
    fclose(f);
    free(blob);
    free(commitment);
-   free(proof); 
+   free(proof);
    free_trusted_setup_wrap(s);
 }
 


### PR DESCRIPTION
This checks the return value from `blob_to_kzg_commitment` in the C# bindings, which includes:

* Change `blob_to_kzg_commitment_wrap` return type from `void` to `C_KZG_RET`.

Also:

* Fix several typos.
* In `compute_aggregate_kzg_proof_wrap`, relay the original return value instead of `-1` if there's an error.
  * `-1` isn't a valid `C_KZG_RET` enum value; it worked but it's a little confusing IMO.
  * As a result, the `expectedProofComputed` value in `Test_Computes_And_Verifies` needed to be updated.

Related to #57.