### PR TITLE
Convert Blob type to struct

### DIFF
--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -24,7 +24,7 @@ void free_trusted_setup_wrap(KZGSettings *s) {
   free(s);
 }
 
-C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s) {
+C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob *blob, const KZGSettings *s) {
   KZGCommitment c;
   C_KZG_RET ret;
   ret = blob_to_kzg_commitment(&c, blob, s);

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -13,7 +13,7 @@ DLLEXPORT KZGSettings* load_trusted_setup_wrap(const char* file);
 
 DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
 
-DLLEXPORT C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob blob, const KZGSettings *s);
+DLLEXPORT C_KZG_RET blob_to_kzg_commitment_wrap(uint8_t out[48], const Blob *blob, const KZGSettings *s);
 
 DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const uint8_t commitments[], size_t n, const uint8_t proof[48], const KZGSettings *s);
 

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -145,7 +145,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeAggregate
 
   KZGProof p;
 
-  C_KZG_RET ret = compute_aggregate_kzg_proof(&p, (uint8_t const(*)[BYTES_PER_BLOB])blobs_native, (size_t)count, settings);
+  C_KZG_RET ret = compute_aggregate_kzg_proof(&p, (const Blob *)blobs_native, (size_t)count, settings);
 
   (*env)->ReleaseByteArrayElements(env, blobs, blobs_native, JNI_ABORT);
 
@@ -222,7 +222,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
   jbyte *blobs_native = (*env)->GetByteArrayElements(env, blobs, NULL);
 
   bool out;
-  ret = verify_aggregate_kzg_proof(&out, (uint8_t const(*)[BYTES_PER_BLOB])blobs_native, c, count_native, &f, settings);
+  ret = verify_aggregate_kzg_proof(&out, (const Blob *)blobs_native, c, count_native, &f, settings);
 
   (*env)->ReleaseByteArrayElements(env, blobs, blobs_native, JNI_ABORT);
   free(c);
@@ -256,7 +256,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitm
   KZGCommitment c;
   C_KZG_RET ret;
 
-  ret = blob_to_kzg_commitment(&c, (uint8_t *)blob_native, settings);
+  ret = blob_to_kzg_commitment(&c, (const Blob *)blob_native, settings);
 
   (*env)->ReleaseByteArrayElements(env, blob, blob_native, JNI_ABORT);
 

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -134,7 +134,7 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
     return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
-  auto blob = extract_byte_array_from_param(info, 0, "blob");
+  Blob *blob = (Blob *)extract_byte_array_from_param(info, 0, "blob");
   if (env.IsExceptionPending()) {
     return env.Null();
   }
@@ -174,7 +174,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   for (uint32_t blob_index = 0; blob_index < blobs_count; blob_index++) {
     Napi::Value blob = blobs_param[blob_index];
     auto blob_bytes = blob.As<Napi::Uint8Array>().Data();
-    memcpy(blobs[blob_index], blob_bytes, BYTES_PER_BLOB);
+    memcpy(blobs[blob_index].data, blob_bytes, BYTES_PER_BLOB);
   }
 
   KZGProof proof;
@@ -225,7 +225,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
     Napi::Value blob = blobs_param[blob_index];
     auto blob_bytes = blob.As<Napi::Uint8Array>().Data();
 
-    memcpy(blobs[blob_index], blob_bytes, BYTES_PER_BLOB);
+    memcpy(blobs[blob_index].data, blob_bytes, BYTES_PER_BLOB);
 
     // Extract a G1 point for each commitment
     Napi::Value commitment = commitments_param[blob_index];

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -174,7 +174,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   for (uint32_t blob_index = 0; blob_index < blobs_count; blob_index++) {
     Napi::Value blob = blobs_param[blob_index];
     auto blob_bytes = blob.As<Napi::Uint8Array>().Data();
-    memcpy(blobs[blob_index].data, blob_bytes, BYTES_PER_BLOB);
+    memcpy(blobs[blob_index].bytes, blob_bytes, BYTES_PER_BLOB);
   }
 
   KZGProof proof;
@@ -225,7 +225,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
     Napi::Value blob = blobs_param[blob_index];
     auto blob_bytes = blob.As<Napi::Uint8Array>().Data();
 
-    memcpy(blobs[blob_index].data, blob_bytes, BYTES_PER_BLOB);
+    memcpy(blobs[blob_index].bytes, blob_bytes, BYTES_PER_BLOB);
 
     // Extract a G1 point for each commitment
     Napi::Value commitment = commitments_param[blob_index];

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -42,7 +42,7 @@ static PyObject* blob_to_kzg_commitment_wrap(PyObject *self, PyObject *args) {
   if (PyBytes_Size(b) != 32 * FIELD_ELEMENTS_PER_BLOB)
     return PyErr_Format(PyExc_ValueError, "expected 32 * FIELD_ELEMENTS_PER_BLOB bytes");
 
-  uint8_t* blob = (uint8_t*)PyBytes_AsString(b);
+  Blob *blob = (Blob*)PyBytes_AsString(b);
 
   KZGCommitment *k = (KZGCommitment*)malloc(sizeof(KZGCommitment));
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1000,7 +1000,7 @@ static C_KZG_RET poly_to_kzg_commitment(KZGCommitment *out, const Polynomial p, 
 static C_KZG_RET poly_from_blob(Polynomial p, const Blob *blob) {
     C_KZG_RET ret;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        ret = bytes_to_bls_field(&p[i], &blob->data[i * BYTES_PER_FIELD_ELEMENT]);
+        ret = bytes_to_bls_field(&p[i], &blob->bytes[i * BYTES_PER_FIELD_ELEMENT]);
         if (ret != C_KZG_OK) return ret;
     }
     return C_KZG_OK;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -47,7 +47,7 @@ typedef blst_fr fr_t;         /**< Internal Fr field element type */
 typedef g1_t KZGCommitment;
 typedef g1_t KZGProof;
 typedef fr_t BLSFieldElement;
-typedef uint8_t Blob[BYTES_PER_BLOB];
+typedef struct { uint8_t data[BYTES_PER_BLOB]; } Blob;
 
 /**
  * The common return type for all routines in which something can go wrong.
@@ -100,19 +100,19 @@ void free_trusted_setup(
     KZGSettings *s);
 
 C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
-                                      const Blob blobs[],
+                                      const Blob *blobs,
                                       size_t n,
                                       const KZGSettings *s);
 
 C_KZG_RET verify_aggregate_kzg_proof(bool *out,
-                                     const Blob blobs[],
-                                     const KZGCommitment expected_kzg_commitments[],
+                                     const Blob *blobs,
+                                     const KZGCommitment *expected_kzg_commitments,
                                      size_t n,
                                      const KZGProof *kzg_aggregated_proof,
                                      const KZGSettings *s);
 
 C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
-                                 const Blob blob,
+                                 const Blob *blob,
                                  const KZGSettings *s);
 
 C_KZG_RET verify_kzg_proof(bool *out,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -47,7 +47,7 @@ typedef blst_fr fr_t;         /**< Internal Fr field element type */
 typedef g1_t KZGCommitment;
 typedef g1_t KZGProof;
 typedef fr_t BLSFieldElement;
-typedef struct { uint8_t data[BYTES_PER_BLOB]; } Blob;
+typedef struct { uint8_t bytes[BYTES_PER_BLOB]; } Blob;
 
 /**
  * The common return type for all routines in which something can go wrong.


### PR DESCRIPTION
Convert the `Blob` type to a typedef'd anonymous struct. See #60 for rationale.