### PR TITLE
Remove mentions of to/from bytes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # C-KZG-4844: A minimal library for EIP-4844 Polynomial Commitments
 
-This is a copy of C-KZG stripped down to support the [Polynomial Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md) API:
+This is a copy of [C-KZG](https://github.com/benjaminion/c-kzg) stripped-down to support the
+[Polynomial Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md) API:
 
 - `compute_aggregate_kzg_proof`
 - `verify_aggregate_kzg_proof`
 - `blob_to_kzg_commitment`
 - `verify_kzg_proof`
 
-We also provide `load_trusted_setup` and `free_trusted_setup` to load the
-trusted setup data from a file into an object that can be passed to the API
-functions, and functions for converting commitments/proofs/points to/from bytes.
+We also provide functions for loading/freeing the trusted setup:
+
+- `load_trusted_setup`
+- `load_trusted_setup_file`
+- `free_trusted_setup`
 
 ## Installation
 
-Install the blst submodule
+Initialize the blst submodule:
 
 ```
 git submodule update --init
 ```
 
-Build blst
+Build blst:
 
 ```
 cd src
 make blst
 ```
 
-Build the C-KZG code
+Build the C-KZG code:
 
 ```
 cd src


### PR DESCRIPTION
This PR makes the following changes:

* Add link to original C-KZG for those that want to know.
* Add hyphen to "stripped-down."
* Removes sentence about "functions for converting commitments/proofs/points to/from bytes."
* Adds list of functions for dealing with trusted setups.
* Change "install" to "initialize" when talking about submodules.
* Add punctuation to installation sentences.