### PR TITLE
Rename poly_from_blob to match spec

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -996,7 +996,7 @@ static C_KZG_RET poly_to_kzg_commitment(g1_t *out, const Polynomial *p, const KZ
     return g1_lincomb(out, s->g1_values, (const fr_t *)(&p->evals), FIELD_ELEMENTS_PER_BLOB);
 }
 
-static C_KZG_RET poly_from_blob(Polynomial *p, const Blob *blob) {
+static C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
     C_KZG_RET ret;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         ret = bytes_to_bls_field(&p->evals[i], &blob->bytes[i * BYTES_PER_FIELD_ELEMENT]);
@@ -1010,7 +1010,7 @@ C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZG
     Polynomial p;
     g1_t commitment;
 
-    ret = poly_from_blob(&p, blob);
+    ret = blob_to_polynomial(&p, blob);
     if (ret != C_KZG_OK) return ret;
     ret = poly_to_kzg_commitment(&commitment, &p, s);
     if (ret != C_KZG_OK) return ret;
@@ -1301,7 +1301,7 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
     }
 
     for (size_t i = 0; i < n; i++) {
-        ret = poly_from_blob(&polys[i], &blobs[i]);
+        ret = blob_to_polynomial(&polys[i], &blobs[i]);
         if (ret != C_KZG_OK) goto out;
         ret = poly_to_kzg_commitment(&commitments[i], &polys[i], s);
         if (ret != C_KZG_OK) goto out;
@@ -1353,7 +1353,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
     for (size_t i = 0; i < n; i++) {
         ret = bytes_to_g1(&commitments[i], (uint8_t *)(&expected_kzg_commitments[i]));
         if (ret != C_KZG_OK) goto out;
-        ret = poly_from_blob(&polys[i], &blobs[i]);
+        ret = blob_to_polynomial(&polys[i], &blobs[i]);
         if (ret != C_KZG_OK) goto out;
     }
 


### PR DESCRIPTION
I believe this function should be named [`blob_to_polynomial`](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#blob_to_polynomial) to match the spec.