### PR TITLE
Minor rust bindings cleanup

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -122,7 +122,6 @@ impl Deref for KZGProof {
     }
 }
 
-pub const FIAT_SHAMIR_PROTOCOL_DOMAIN: &[u8; 16usize] = b"FSBLOBVERIFY_V1_";
 type g1_t = blst_p1;
 type g2_t = blst_p2;
 type fr_t = blst_fr;
@@ -186,7 +185,6 @@ unsafe impl Sync for KZGSettings {}
 unsafe impl Send for KZGSettings {}
 
 extern "C" {
-    #[doc = " Interface functions"]
     pub fn load_trusted_setup(
         out: *mut KZGSettings,
         g1_bytes: *const u8, /* n1 * 48 bytes */
@@ -194,22 +192,18 @@ extern "C" {
         g2_bytes: *const u8, /* n2 * 96 bytes */
         n2: usize,
     ) -> C_KZG_RET;
-}
-extern "C" {
+
     pub fn load_trusted_setup_file(out: *mut KZGSettings, in_: *mut FILE) -> C_KZG_RET;
-}
-extern "C" {
+
     pub fn free_trusted_setup(s: *mut KZGSettings);
-}
-extern "C" {
+
     pub fn compute_aggregate_kzg_proof(
         out: *mut KZGProof,
         blobs: *const Blob,
         n: usize,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
-}
-extern "C" {
+
     pub fn verify_aggregate_kzg_proof(
         out: *mut bool,
         blobs: *const Blob,
@@ -218,15 +212,13 @@ extern "C" {
         kzg_aggregated_proof: *const KZGProof,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
-}
-extern "C" {
+
     pub fn blob_to_kzg_commitment(
         out: *mut KZGCommitment,
         blob: *const Blob,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
-}
-extern "C" {
+
     pub fn verify_kzg_proof(
         out: *mut bool,
         polynomial_kzg: *const KZGCommitment,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -58,7 +58,7 @@ impl KZGSettings {
                 g1_bytes.as_ptr() as *const u8,
                 g1_bytes.len(),
                 g2_bytes.as_ptr() as *const u8,
-                g1_bytes.len(),
+                g2_bytes.len(),
             );
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(kzg_settings.assume_init())

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -53,15 +53,12 @@ impl KZGSettings {
         }
         let mut kzg_settings = MaybeUninit::<KZGSettings>::uninit();
         unsafe {
-            let n1 = g1_bytes.len();
-            let n2 = g2_bytes.len();
-
             let res = load_trusted_setup(
                 kzg_settings.as_mut_ptr(),
                 g1_bytes.as_ptr() as *const u8,
-                n1,
+                g1_bytes.len(),
                 g2_bytes.as_ptr() as *const u8,
-                n2,
+                g1_bytes.len(),
             );
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(kzg_settings.assume_init())


### PR DESCRIPTION
This PR makes a few minor nit fixes:

* Remove `FIAT_SHAMIR_PROTOCOL_DOMAIN` which doesn't need to be exposed.
* Remove "interface functions" doc which only showed up for `load_trusted_setup`.
* Use one `extern "C"` block instead of one for each function.
* Pass `g1_bytes.len()` and `g1_bytes.len()` instead of new variables.