### PR TITLE
Rename reverse_bit_order to bit_reversal_permutation

### DIFF
--- a/.github/workflows/rust-bindings-test.yml
+++ b/.github/workflows/rust-bindings-test.yml
@@ -27,5 +27,3 @@ jobs:
           cd bindings/rust
           cargo clean
           cargo test --all --release --features="minimal-spec" --tests
-
-  


### PR DESCRIPTION
This PR renames `reverse_bit_order` to [`bit_reversal_permutation`](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#bit_reversal_permutation) to match the spec.

Also:

* Remove blank lines from rust binding workflow.
* Remove padding spaces from `CHECK` macro (didn't notice the `\` there before).
* Move `log2_pow2` to the helper functions section.