### PR TITLE
Node.js fix trusted setup file transformation

### DIFF
--- a/bindings/node.js/kzg.ts
+++ b/bindings/node.js/kzg.ts
@@ -78,6 +78,7 @@ export async function transformTrustedSetupJSON(
   const file = fs.createWriteStream(textFilePath);
   file.write(`${FIELD_ELEMENTS_PER_BLOB}\n65\n`);
   file.write(data.setup_G1.map((p) => p.replace("0x", "")).join("\n"));
+  file.write("\n");
   file.write(data.setup_G2.map((p) => p.replace("0x", "")).join("\n"));
   file.end();
 


### PR DESCRIPTION
Currently, the generated trusted setup txt file does not match the trusted setup files used in other bindings, as the last g1 point is in the same line as the first g2 point.