### PR TITLE
Expose `compute_kzg_proof`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This is a copy of [C-KZG](https://github.com/benjaminion/c-kzg) stripped-down to support the
 [Polynomial Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md) API:
 
-- `compute_aggregate_kzg_proof`
-- `verify_aggregate_kzg_proof`
 - `blob_to_kzg_commitment`
+- `compute_kzg_proof`
+- `compute_aggregate_kzg_proof`
 - `verify_kzg_proof`
+- `verify_aggregate_kzg_proof`
 
 We also provide functions for loading/freeing the trusted setup:
 

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -32,7 +32,7 @@ int verify_aggregate_kzg_proof_wrap(const Blob *blobs, const KZGCommitment *comm
   return b ? 0 : 1;
 }
 
-int verify_kzg_proof_wrap(const KZGCommitment *c, const BLSFieldElement *z, const BLSFieldElement *y, const KZGProof *p, KZGSettings *s) {
+int verify_kzg_proof_wrap(const KZGCommitment *c, const Bytes32 *z, const Bytes32 *y, const KZGProof *p, KZGSettings *s) {
   bool out;
   if (verify_kzg_proof(&out, c, z, y, p, s) != C_KZG_OK)
     return -2;

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -19,4 +19,4 @@ DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const KZGCommi
 
 DLLEXPORT C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out, const Blob blobs[], size_t n, const KZGSettings *s);
 
-DLLEXPORT int verify_kzg_proof_wrap(const KZGCommitment *c, const BLSFieldElement *z, const BLSFieldElement *y, const KZGProof *p, KZGSettings *s);
+DLLEXPORT int verify_kzg_proof_wrap(const KZGCommitment *c, const Bytes32 *z, const Bytes32 *y, const KZGProof *p, KZGSettings *s);

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -249,8 +249,8 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNI
 
   KZGCommitment *commitment_native = (KZGCommitment *)(*env)->GetByteArrayElements(env, commitment, NULL);
   KZGProof *proof_native = (KZGProof *)(*env)->GetByteArrayElements(env, proof, NULL);
-  BLSFieldElement *z_native = (BLSFieldElement *)(*env)->GetByteArrayElements(env, z, NULL);
-  BLSFieldElement *y_native = (BLSFieldElement *)(*env)->GetByteArrayElements(env, y, NULL);
+  Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z, NULL);
+  Bytes32 *y_native = (Bytes32 *)(*env)->GetByteArrayElements(env, y, NULL);
 
   bool out;
   C_KZG_RET ret = verify_kzg_proof(&out, commitment_native, z_native, y_native, proof_native, settings);

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -266,7 +266,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, verification_result);
 }
 
-// verifyKzgProof: (polynomialKzg: KZGCommitment, z: BLSFieldElement, y: BLSFieldElement, kzgProof: KZGProof, setupHandle: SetupHandle) => boolean;
+// verifyKzgProof: (polynomialKzg: KZGCommitment, z: Bytes32, y: Bytes32, kzgProof: KZGProof, setupHandle: SetupHandle) => boolean;
 Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
@@ -290,8 +290,8 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   C_KZG_RET ret = verify_kzg_proof(
     &out,
     (KZGCommitment *)polynomial_kzg,
-    (BLSFieldElement *)z,
-    (BLSFieldElement *)y,
+    (Bytes32 *)z,
+    (Bytes32 *)y,
     (KZGProof *)kzg_proof,
     kzg_settings
   );

--- a/bindings/node.js/kzg.ts
+++ b/bindings/node.js/kzg.ts
@@ -5,7 +5,7 @@
 const kzg: KZG = require("./kzg.node");
 const fs = require("fs");
 
-export type BLSFieldElement = Uint8Array; // 32 bytes
+export type Bytes32 = Uint8Array; // 32 bytes
 export type KZGProof = Uint8Array; // 48 bytes
 export type KZGCommitment = Uint8Array; // 48 bytes
 export type Blob = Uint8Array; // 4096 * 32 bytes
@@ -37,8 +37,8 @@ type KZG = {
 
   verifyKzgProof: (
     polynomialKzg: KZGCommitment,
-    z: BLSFieldElement,
-    y: BLSFieldElement,
+    z: Bytes32,
+    y: Bytes32,
     kzgProof: KZGProof,
     setupHandle: SetupHandle,
   ) => boolean;
@@ -115,8 +115,8 @@ export function computeAggregateKzgProof(blobs: Blob[]): KZGProof {
 
 export function verifyKzgProof(
   polynomialKzg: KZGCommitment,
-  z: BLSFieldElement,
-  y: BLSFieldElement,
+  z: Bytes32,
+  y: Bytes32,
   kzgProof: KZGProof,
 ): boolean {
   return kzg.verifyKzgProof(

--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -79,12 +79,12 @@ struct blst_p2_affine {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct BLSFieldElement {
-    bytes: [u8; BYTES_PER_FIELD_ELEMENT],
+pub struct Bytes32 {
+    bytes: [u8; 32],
 }
 
-impl Deref for BLSFieldElement {
-    type Target = [u8; BYTES_PER_FIELD_ELEMENT];
+impl Deref for Bytes32 {
+    type Target = [u8; 32];
     fn deref(&self) -> &Self::Target {
         &self.bytes
     }
@@ -222,8 +222,8 @@ extern "C" {
     pub fn verify_kzg_proof(
         out: *mut bool,
         polynomial_kzg: *const KZGCommitment,
-        z: *const BLSFieldElement,
-        y: *const BLSFieldElement,
+        z: *const Bytes32,
+        y: *const Bytes32,
         kzg_proof: *const KZGProof,
         s: *const KZGSettings,
     ) -> C_KZG_RET;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -181,8 +181,8 @@ impl KZGProof {
     pub fn verify_kzg_proof(
         &self,
         kzg_commitment: KZGCommitment,
-        z: BLSFieldElement,
-        y: BLSFieldElement,
+        z: Bytes32,
+        y: Bytes32,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
@@ -257,8 +257,8 @@ impl From<[u8; BYTES_PER_BLOB]> for Blob {
     }
 }
 
-impl From<[u8; BYTES_PER_FIELD_ELEMENT]> for BLSFieldElement {
-    fn from(value: [u8; BYTES_PER_FIELD_ELEMENT]) -> Self {
+impl From<[u8; 32]> for Bytes32 {
+    fn from(value: [u8; 32]) -> Self {
         Self { bytes: value }
     }
 }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -931,7 +931,7 @@ out:
  *
  * @param[out] out The combined proof as a single G1 element
  * @param[in]  p   The polynomial in Lagrange form
- * @param[in]  x   The generator x-value for the evaluation points
+ * @param[in]  z   The generator z-value for the evaluation points
  * @param[in]  s   The settings containing the secrets, previously initialised with #new_kzg_settings
  * @retval C_KZG_OK      All is well
  * @retval C_KZG_MALLOC  Memory allocation failed

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1095,7 +1095,7 @@ out:
     return C_KZG_OK;
 }
 
-C_KZG_RET compute_aggregate_kzg_proof(KZGProof *proof,
+C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
                                       const Blob *blobs,
                                       size_t n,
                                       const KZGSettings *s) {
@@ -1134,7 +1134,7 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *proof,
     BLSFieldElement evaluation_challenge;
     bytes_from_bls_field(evaluation_challenge.bytes, &evaluation_challenge_fr);
 
-    ret = compute_kzg_proof(proof, &aggregated_poly, &evaluation_challenge, s);
+    ret = compute_kzg_proof(out, &aggregated_poly, &evaluation_challenge, s);
     if (ret != C_KZG_OK) goto out;
 
 out:

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -31,7 +31,7 @@
 // Types
 ///////////////////////////////////////////////////////////////////////////////
 
-typedef struct { fr_t evals[FIELD_ELEMENTS_PER_BLOB]; } PolynomialFr;
+typedef struct { fr_t evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
@@ -499,24 +499,6 @@ static void bytes_of_uint64(uint8_t out[8], uint64_t n) {
     }
 }
 
-/* Forward function definition */
-static C_KZG_RET bytes_to_bls_field(fr_t *out, const uint8_t bytes[32]);
-
-static C_KZG_RET polynomial_to_polynomial_fr(PolynomialFr *out, const Polynomial *in) {
-    C_KZG_RET ret;
-    for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        ret = bytes_to_bls_field(&out->evals[i], in->evals[i].bytes);
-        if (ret != C_KZG_OK) return ret;
-    }
-    return C_KZG_OK;
-}
-
-static void polynomial_fr_to_polynomial(Polynomial *out, const PolynomialFr *in) {
-    for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        bytes_from_bls_field(out->evals[i].bytes, &in->evals[i]);
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // SHA-256 Hash Functions
 ///////////////////////////////////////////////////////////////////////////////
@@ -640,7 +622,7 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const uint8_t bytes[32]) {
     return C_KZG_OK;
 }
 
-static C_KZG_RET blob_to_polynomial(PolynomialFr *p, const Blob *blob) {
+static C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
     C_KZG_RET ret;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         ret = bytes_to_bls_field(&p->evals[i], &blob->bytes[i * BYTES_PER_FIELD_ELEMENT]);
@@ -653,7 +635,7 @@ static C_KZG_RET blob_to_polynomial(PolynomialFr *p, const Blob *blob) {
 static void compute_powers(fr_t *out, fr_t *x, uint64_t n);
 
 static C_KZG_RET compute_challenges(fr_t *out, fr_t *r_powers,
-                                    const PolynomialFr *polys, const g1_t *comms, uint64_t n) {
+                                    const Polynomial *polys, const g1_t *comms, uint64_t n) {
     size_t i;
     uint64_t j;
     const size_t ni = 32; // len(FIAT_SHAMIR_PROTOCOL_DOMAIN) + 8 + 8
@@ -772,7 +754,7 @@ static C_KZG_RET g1_lincomb(g1_t *out, const g1_t *p, const fr_t *coeffs, const 
     return C_KZG_OK;
 }
 
-static void poly_lincomb(PolynomialFr *out, const PolynomialFr *vectors, const fr_t *scalars, uint64_t n) {
+static void poly_lincomb(Polynomial *out, const Polynomial *vectors, const fr_t *scalars, uint64_t n) {
     fr_t tmp;
     uint64_t i, j;
     for (j = 0; j < FIELD_ELEMENTS_PER_BLOB; j++)
@@ -798,7 +780,7 @@ static void compute_powers(fr_t *out, fr_t *x, uint64_t n) {
 // Polynomials Functions
 ///////////////////////////////////////////////////////////////////////////////
 
-static C_KZG_RET evaluate_polynomial_in_evaluation_form(fr_t *out, const PolynomialFr *p, const fr_t *x, const KZGSettings *s) {
+static C_KZG_RET evaluate_polynomial_in_evaluation_form(fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s) {
     C_KZG_RET ret;
     fr_t tmp;
     fr_t *inverses_in = NULL;
@@ -845,13 +827,13 @@ out:
 // KZG Functions
 ///////////////////////////////////////////////////////////////////////////////
 
-static C_KZG_RET poly_to_kzg_commitment(g1_t *out, const PolynomialFr *p, const KZGSettings *s) {
+static C_KZG_RET poly_to_kzg_commitment(g1_t *out, const Polynomial *p, const KZGSettings *s) {
     return g1_lincomb(out, s->g1_values, (const fr_t *)(&p->evals), FIELD_ELEMENTS_PER_BLOB);
 }
 
 C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZGSettings *s) {
     C_KZG_RET ret;
-    PolynomialFr p;
+    Polynomial p;
     g1_t commitment;
 
     ret = blob_to_polynomial(&p, blob);
@@ -915,8 +897,37 @@ static C_KZG_RET verify_kzg_proof_impl(bool *out, const g1_t *commitment, const 
     return C_KZG_OK;
 }
 
+/* Forward function declaration */
+C_KZG_RET compute_kzg_proof_impl(KZGProof *out, const Polynomial *polynomial, const fr_t *z, const KZGSettings *s);
+
 /**
  * Compute KZG proof for polynomial in Lagrange form at position x.
+ *
+ * @param[out] out  The combined proof as a single G1 element
+ * @param[in]  blob The blob (polynomial) to generate a proof for
+ * @param[in]  x    The generator x-value for the evaluation points
+ * @param[in]  s    The settings containing the secrets, previously initialised with #new_kzg_settings
+ * @retval C_KZG_OK      All is well
+ * @retval C_KZG_MALLOC  Memory allocation failed
+ */
+C_KZG_RET compute_kzg_proof(KZGProof *out, const Blob *blob, const BLSFieldElement *z, const KZGSettings *s) {
+    C_KZG_RET ret;
+    Polynomial polynomial;
+    fr_t frz;
+
+    ret = blob_to_polynomial(&polynomial, blob);
+    if (ret != C_KZG_OK) goto out;
+    ret = bytes_to_bls_field(&frz, z->bytes);
+    if (ret != C_KZG_OK) goto out;
+    ret = compute_kzg_proof_impl(out, &polynomial, &frz, s);
+    if (ret != C_KZG_OK) goto out;
+
+out:
+    return ret;
+}
+
+/**
+ * Helper function for compute_kzg_proof() and compute_aggregate_kzg_proof().
  *
  * @param[out] out The combined proof as a single G1 element
  * @param[in]  p   The polynomial in Lagrange form
@@ -925,25 +936,17 @@ static C_KZG_RET verify_kzg_proof_impl(bool *out, const g1_t *commitment, const 
  * @retval C_KZG_OK      All is well
  * @retval C_KZG_MALLOC  Memory allocation failed
  */
-C_KZG_RET compute_kzg_proof(KZGProof *out, const Polynomial *polynomial, const BLSFieldElement *x, const KZGSettings *s) {
+C_KZG_RET compute_kzg_proof_impl(KZGProof *out, const Polynomial *polynomial, const fr_t *z, const KZGSettings *s) {
     C_KZG_RET ret;
     fr_t y;
     fr_t *inverses_in = NULL;
     fr_t *inverses = NULL;
 
-    PolynomialFr p;
-    ret = polynomial_to_polynomial_fr(&p, polynomial);
-    if (ret != C_KZG_OK) goto out;
-
-    fr_t frx;
-    ret = bytes_to_bls_field(&frx, x->bytes);
-    if (ret != C_KZG_OK) goto out;
-
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &frx, s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, polynomial, z, s);
     if (ret != C_KZG_OK) goto out;
 
     fr_t tmp;
-    PolynomialFr q;
+    Polynomial q;
     const fr_t *roots_of_unity = s->fs->roots_of_unity;
     uint64_t i, m = 0;
 
@@ -953,13 +956,13 @@ C_KZG_RET compute_kzg_proof(KZGProof *out, const Polynomial *polynomial, const B
     if (ret != C_KZG_OK) goto out;
 
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        if (fr_equal(&frx, &roots_of_unity[i])) {
+        if (fr_equal(z, &roots_of_unity[i])) {
             m = i + 1;
             continue;
         }
         // (p_i - y) / (ω_i - x)
-        blst_fr_sub(&q.evals[i], &p.evals[i], &y);
-        blst_fr_sub(&inverses_in[i], &roots_of_unity[i], &frx);
+        blst_fr_sub(&q.evals[i], &polynomial->evals[i], &y);
+        blst_fr_sub(&inverses_in[i], &roots_of_unity[i], z);
     }
 
     ret = fr_batch_inv(inverses, inverses_in, FIELD_ELEMENTS_PER_BLOB);
@@ -974,13 +977,13 @@ C_KZG_RET compute_kzg_proof(KZGProof *out, const Polynomial *polynomial, const B
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
             if (i == m) continue;
             // (p_i - y) * ω_i / (x * (x - ω_i))
-            blst_fr_sub(&tmp, &frx, &roots_of_unity[i]);
-            blst_fr_mul(&inverses_in[i], &tmp, &frx);
+            blst_fr_sub(&tmp, z, &roots_of_unity[i]);
+            blst_fr_mul(&inverses_in[i], &tmp, z);
         }
         ret = fr_batch_inv(inverses, inverses_in, FIELD_ELEMENTS_PER_BLOB);
         if (ret != C_KZG_OK) goto out;
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-            blst_fr_sub(&tmp, &p.evals[i], &y);
+            blst_fr_sub(&tmp, &polynomial->evals[i], &y);
             blst_fr_mul(&tmp, &tmp, &roots_of_unity[i]);
             blst_fr_mul(&tmp, &tmp, &inverses[i]);
             blst_fr_add(&q.evals[m], &q.evals[m], &tmp);
@@ -999,8 +1002,8 @@ out:
     return ret;
 }
 
-static C_KZG_RET compute_aggregated_poly_and_commitment(PolynomialFr *poly_out, g1_t *comm_out, fr_t *chal_out,
-        const PolynomialFr *polys,
+static C_KZG_RET compute_aggregated_poly_and_commitment(Polynomial *poly_out, g1_t *comm_out, fr_t *chal_out,
+        const Polynomial *polys,
         const g1_t *kzg_commitments,
         size_t n) {
     fr_t* r_powers = calloc(n, sizeof(fr_t));
@@ -1024,7 +1027,7 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
                                       size_t n,
                                       const KZGSettings *s) {
     C_KZG_RET ret;
-    PolynomialFr* polys = NULL;
+    Polynomial* polys = NULL;
     g1_t* commitments = NULL;
 
     commitments = calloc(n, sizeof(g1_t));
@@ -1033,7 +1036,7 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
         goto out;
     }
 
-    polys = calloc(n, sizeof(PolynomialFr));
+    polys = calloc(n, sizeof(Polynomial));
     if (0 < n && polys == NULL) {
         ret = C_KZG_MALLOC;
         goto out;
@@ -1046,19 +1049,13 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
         if (ret != C_KZG_OK) goto out;
     }
 
-    PolynomialFr aggregated_poly_fr;
+    Polynomial aggregated_poly;
     g1_t aggregated_poly_commitment;
-    fr_t evaluation_challenge_fr;
-    ret = compute_aggregated_poly_and_commitment(&aggregated_poly_fr, &aggregated_poly_commitment, &evaluation_challenge_fr, polys, commitments, n);
+    fr_t evaluation_challenge;
+    ret = compute_aggregated_poly_and_commitment(&aggregated_poly, &aggregated_poly_commitment, &evaluation_challenge, polys, commitments, n);
     if (ret != C_KZG_OK) goto out;
 
-    Polynomial aggregated_poly;
-    polynomial_fr_to_polynomial(&aggregated_poly, &aggregated_poly_fr);
-
-    BLSFieldElement evaluation_challenge;
-    bytes_from_bls_field(evaluation_challenge.bytes, &evaluation_challenge_fr);
-
-    ret = compute_kzg_proof(out, &aggregated_poly, &evaluation_challenge, s);
+    ret = compute_kzg_proof_impl(out, &aggregated_poly, &evaluation_challenge, s);
     if (ret != C_KZG_OK) goto out;
 
 out:
@@ -1075,7 +1072,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
                                      const KZGSettings *s) {
     C_KZG_RET ret;
     g1_t* commitments = NULL;
-    PolynomialFr* polys = NULL;
+    Polynomial* polys = NULL;
 
     g1_t proof;
     ret = bytes_to_g1(&proof, (uint8_t *)(kzg_aggregated_proof));
@@ -1087,7 +1084,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
         goto out;
     }
 
-    polys = calloc(n, sizeof(PolynomialFr));
+    polys = calloc(n, sizeof(Polynomial));
     if (0 < n && polys == NULL) {
         ret = C_KZG_MALLOC;
         goto out;
@@ -1100,7 +1097,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
         if (ret != C_KZG_OK) goto out;
     }
 
-    PolynomialFr aggregated_poly;
+    Polynomial aggregated_poly;
     g1_t aggregated_poly_commitment;
     fr_t evaluation_challenge;
     ret = compute_aggregated_poly_and_commitment(&aggregated_poly, &aggregated_poly_commitment, &evaluation_challenge, polys, commitments, n);

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -543,8 +543,8 @@ static C_KZG_RET bytes_to_g1(g1_t* out, const uint8_t bytes[48]) {
     return C_KZG_OK;
 }
 
-static void bytes_from_bls_field(BLSFieldElement *out, const fr_t *in) {
-    blst_scalar_from_fr((blst_scalar*)out->bytes, in);
+static void bytes_from_bls_field(uint8_t out[32], const fr_t *in) {
+    blst_scalar_from_fr((blst_scalar*)out, in);
 }
 
 static void bytes_of_uint64(uint8_t out[8], uint64_t n) {
@@ -568,7 +568,7 @@ static C_KZG_RET polynomial_to_polynomial_fr(PolynomialFr *out, const Polynomial
 
 static void polynomial_fr_to_polynomial(Polynomial *out, const PolynomialFr *in) {
     for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        bytes_from_bls_field(&out->evals[i], &in->evals[i]);
+        bytes_from_bls_field(out->evals[i].bytes, &in->evals[i]);
     }
 }
 
@@ -747,7 +747,7 @@ static C_KZG_RET compute_challenges(fr_t *out, fr_t *r_powers,
     /* Copy polynomials */
     for (i = 0; i < n; i++)
         for (j = 0; j < FIELD_ELEMENTS_PER_BLOB; j++)
-            bytes_from_bls_field((BLSFieldElement *)&bytes[ni + BYTES_PER_FIELD_ELEMENT * (i * FIELD_ELEMENTS_PER_BLOB + j)], &polys[i].evals[j]);
+            bytes_from_bls_field(&bytes[ni + BYTES_PER_FIELD_ELEMENT * (i * FIELD_ELEMENTS_PER_BLOB + j)], &polys[i].evals[j]);
 
     /* Copy commitments */
     for (i = 0; i < n; i++)
@@ -1132,7 +1132,7 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *proof,
     polynomial_fr_to_polynomial(&aggregated_poly, &aggregated_poly_fr);
 
     BLSFieldElement evaluation_challenge;
-    bytes_from_bls_field(&evaluation_challenge, &evaluation_challenge_fr);
+    bytes_from_bls_field(evaluation_challenge.bytes, &evaluation_challenge_fr);
 
     ret = compute_kzg_proof(proof, &aggregated_poly, &evaluation_challenge, s);
     if (ret != C_KZG_OK) goto out;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -642,9 +642,9 @@ static C_KZG_RET bit_reversal_permutation(void *values, size_t size, uint64_t n)
  * @param[out] out The field element to store the result
  * @param[in] bytes A 32-byte array containing the input
  */
-static void hash_to_bls_field(fr_t *out, const Bytes32 *bytes) {
+static void hash_to_bls_field(fr_t *out, const Bytes32 *b) {
     blst_scalar tmp;
-    blst_scalar_from_lendian(&tmp, bytes->bytes);
+    blst_scalar_from_lendian(&tmp, b->bytes);
     blst_fr_from_scalar(out, &tmp);
 }
 
@@ -656,9 +656,9 @@ static void hash_to_bls_field(fr_t *out, const Bytes32 *bytes) {
  * @retval C_KZG_OK Deserialization successful
  * @retval C_KZG_BADARGS Input was not a valid scalar field element
  */
-static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *bytes) {
+static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
     blst_scalar tmp;
-    blst_scalar_from_lendian(&tmp, bytes->bytes);
+    blst_scalar_from_lendian(&tmp, b->bytes);
     if (!blst_scalar_fr_check(&tmp)) return C_KZG_BADARGS;
     blst_fr_from_scalar(out, &tmp);
     return C_KZG_OK;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -528,7 +528,7 @@ static bool pairings_verify(const g1_t *a1, const g2_t *a2, const g1_t *b1, cons
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Bytes Conversion Helper Functions
+// Conversion Helper Functions
 ///////////////////////////////////////////////////////////////////////////////
 
 static void bytes_from_g1(uint8_t out[48], const g1_t *in) {
@@ -554,6 +554,7 @@ static void bytes_of_uint64(uint8_t out[8], uint64_t n) {
     }
 }
 
+/* Forward function definition */
 static C_KZG_RET bytes_to_bls_field(fr_t *out, const uint8_t bytes[32]);
 
 static C_KZG_RET polynomial_to_polynomial_fr(PolynomialFr *out, const Polynomial *in) {

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -473,7 +473,7 @@ static int log2_pow2(uint32_t n) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Conversion Helper Functions
+// Bytes Conversion Helper Functions
 ///////////////////////////////////////////////////////////////////////////////
 
 static void bytes_from_g1(uint8_t out[48], const g1_t *in) {
@@ -858,13 +858,13 @@ C_KZG_RET verify_kzg_proof(bool *out,
     fr_t frz, fry;
     g1_t g1commitment, g1proof;
 
-    ret = bytes_to_g1(&g1commitment, (const uint8_t *)(commitment));
+    ret = bytes_to_g1(&g1commitment, commitment->bytes);
     if (ret != C_KZG_OK) return ret;
     ret = bytes_to_bls_field(&frz, z->bytes);
     if (ret != C_KZG_OK) return ret;
     ret = bytes_to_bls_field(&fry, y->bytes);
     if (ret != C_KZG_OK) return ret;
-    ret = bytes_to_g1(&g1proof, (const uint8_t *)(kzg_proof));
+    ret = bytes_to_g1(&g1proof, kzg_proof->bytes);
     if (ret != C_KZG_OK) return ret;
 
     return verify_kzg_proof_impl(out, &g1commitment, &frz, &fry, &g1proof, s);
@@ -901,11 +901,11 @@ static C_KZG_RET verify_kzg_proof_impl(bool *out, const g1_t *commitment, const 
 C_KZG_RET compute_kzg_proof_impl(KZGProof *out, const Polynomial *polynomial, const fr_t *z, const KZGSettings *s);
 
 /**
- * Compute KZG proof for polynomial in Lagrange form at position x.
+ * Compute KZG proof for polynomial in Lagrange form at position z.
  *
  * @param[out] out  The combined proof as a single G1 element
  * @param[in]  blob The blob (polynomial) to generate a proof for
- * @param[in]  x    The generator x-value for the evaluation points
+ * @param[in]  z    The generator z-value for the evaluation points
  * @param[in]  s    The settings containing the secrets, previously initialised with #new_kzg_settings
  * @retval C_KZG_OK      All is well
  * @retval C_KZG_MALLOC  Memory allocation failed
@@ -1075,7 +1075,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
     Polynomial* polys = NULL;
 
     g1_t proof;
-    ret = bytes_to_g1(&proof, (uint8_t *)(kzg_aggregated_proof));
+    ret = bytes_to_g1(&proof, kzg_aggregated_proof->bytes);
     if (ret != C_KZG_OK) goto out;
 
     commitments = calloc(n, sizeof(g1_t));
@@ -1091,7 +1091,7 @@ C_KZG_RET verify_aggregate_kzg_proof(bool *out,
     }
 
     for (size_t i = 0; i < n; i++) {
-        ret = bytes_to_g1(&commitments[i], (uint8_t *)(&expected_kzg_commitments[i]));
+        ret = bytes_to_g1(&commitments[i], expected_kzg_commitments[i].bytes);
         if (ret != C_KZG_OK) goto out;
         ret = blob_to_polynomial(&polys[i], &blobs[i]);
         if (ret != C_KZG_OK) goto out;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -44,9 +44,10 @@ typedef blst_p1 g1_t;         /**< Internal G1 group element type */
 typedef blst_p2 g2_t;         /**< Internal G2 group element type */
 typedef blst_fr fr_t;         /**< Internal Fr field element type */
 
+typedef struct { uint8_t bytes[BYTES_PER_FIELD_ELEMENT]; } BLSFieldElement;
 typedef struct { uint8_t bytes[BYTES_PER_COMMITMENT]; } KZGCommitment;
 typedef struct { uint8_t bytes[BYTES_PER_PROOF]; } KZGProof;
-typedef struct { uint8_t bytes[BYTES_PER_FIELD_ELEMENT]; } BLSFieldElement;
+typedef struct { BLSFieldElement evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
 typedef struct { uint8_t bytes[BYTES_PER_BLOB]; } Blob;
 
 /**
@@ -116,6 +117,11 @@ C_KZG_RET verify_kzg_proof(bool *out,
                            const BLSFieldElement *y,
                            const KZGProof *kzg_proof,
                            const KZGSettings *s);
+
+C_KZG_RET compute_kzg_proof(KZGProof *out,
+                            const Polynomial *p,
+                            const BLSFieldElement *x,
+                            const KZGSettings *s);
 
 #ifdef __cplusplus
 }

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -45,7 +45,6 @@ typedef blst_p2 g2_t;         /**< Internal G2 group element type */
 typedef blst_fr fr_t;         /**< Internal Fr field element type */
 
 typedef struct { uint8_t bytes[32]; } Bytes32;
-typedef struct { uint8_t bytes[BYTES_PER_FIELD_ELEMENT]; } BLSFieldElement;
 typedef struct { uint8_t bytes[BYTES_PER_COMMITMENT]; } KZGCommitment;
 typedef struct { uint8_t bytes[BYTES_PER_PROOF]; } KZGProof;
 typedef struct { uint8_t bytes[BYTES_PER_BLOB]; } Blob;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -44,6 +44,7 @@ typedef blst_p1 g1_t;         /**< Internal G1 group element type */
 typedef blst_p2 g2_t;         /**< Internal G2 group element type */
 typedef blst_fr fr_t;         /**< Internal Fr field element type */
 
+typedef struct { uint8_t bytes[32]; } Bytes32;
 typedef struct { uint8_t bytes[BYTES_PER_FIELD_ELEMENT]; } BLSFieldElement;
 typedef struct { uint8_t bytes[BYTES_PER_COMMITMENT]; } KZGCommitment;
 typedef struct { uint8_t bytes[BYTES_PER_PROOF]; } KZGProof;
@@ -112,14 +113,14 @@ C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
 
 C_KZG_RET verify_kzg_proof(bool *out,
                            const KZGCommitment *polynomial_kzg,
-                           const BLSFieldElement *z,
-                           const BLSFieldElement *y,
+                           const Bytes32 *z,
+                           const Bytes32 *y,
                            const KZGProof *kzg_proof,
                            const KZGSettings *s);
 
 C_KZG_RET compute_kzg_proof(KZGProof *out,
                             const Blob *p,
-                            const BLSFieldElement *z,
+                            const Bytes32 *z,
                             const KZGSettings *s);
 
 #ifdef __cplusplus

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -47,7 +47,6 @@ typedef blst_fr fr_t;         /**< Internal Fr field element type */
 typedef struct { uint8_t bytes[BYTES_PER_FIELD_ELEMENT]; } BLSFieldElement;
 typedef struct { uint8_t bytes[BYTES_PER_COMMITMENT]; } KZGCommitment;
 typedef struct { uint8_t bytes[BYTES_PER_PROOF]; } KZGProof;
-typedef struct { BLSFieldElement evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
 typedef struct { uint8_t bytes[BYTES_PER_BLOB]; } Blob;
 
 /**
@@ -119,8 +118,8 @@ C_KZG_RET verify_kzg_proof(bool *out,
                            const KZGSettings *s);
 
 C_KZG_RET compute_kzg_proof(KZGProof *out,
-                            const Polynomial *p,
-                            const BLSFieldElement *x,
+                            const Blob *p,
+                            const BLSFieldElement *z,
                             const KZGSettings *s);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This exposes the `compute_kzg_proof` in the way described here:

* https://github.com/ethereum/consensus-specs/pull/3219#pullrequestreview-1267235849

This PR will:

* Replace `BLSFieldElement` with `Bytes32` in many places.
  * These are not guaranteed to be valid field elements and what I did before was misleading. Sorry. 
* Add `compute_kzg_proof` to the readme.
  * Also sort the entries in a more logical order.
* Create `compute_kzg_proof_impl` and move bulk of work there.
  * This allows us to pass a polynomial to it from `compute_aggregate_kzg_proof`. 
* Use `f->bytes` for calls to `bytes_to_g1` & `bytes_to_bls_field`.
  * This is a lot cleaner in my opinion. 

Fixes #34.