### PR TITLE
Use Bytes48 for commitments/proofs

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -53,7 +53,7 @@ public class Ckzg
     /// <param name="ts">Trusted setup settings</param>
     /// <returns>Returns error code or <c>0</c> if the proof is correct</returns>
     [DllImport("ckzg", EntryPoint = "verify_aggregate_kzg_proof_wrap", CallingConvention = CallingConvention.Cdecl)]
-    public unsafe static extern int VerifyAggregatedKzgProof(byte* blobs, byte* commitments, int count, byte* proof, IntPtr ts);
+    public unsafe static extern int VerifyAggregatedKzgProof(byte* blobs, byte* commitments_bytes, int count, byte* aggregated_proof_bytes, IntPtr ts);
 
     /// <summary>
     /// Verify the proof by point evaluation for the given commitment
@@ -65,7 +65,7 @@ public class Ckzg
     /// <param name="ts">Trusted setup settings</param>
     /// <returns>Returns error code or <c>0</c> if the proof is correct</returns>
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof_wrap", CallingConvention = CallingConvention.Cdecl)]
-    public unsafe static extern int VerifyKzgProof(byte* commitment, byte* z, byte* y, byte* proof, IntPtr ts);
+    public unsafe static extern int VerifyKzgProof(byte* commitment_bytes, byte* z_bytes, byte* y_bytes, byte* proof_bytes, IntPtr ts);
 
     /// <summary>
     /// Load trusted setup settings from file

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -24,17 +24,17 @@ void free_trusted_setup_wrap(KZGSettings *s) {
   free(s);
 }
 
-int verify_aggregate_kzg_proof_wrap(const Blob *blobs, const KZGCommitment *commitments, size_t n, const KZGProof *proof, const KZGSettings *s) {
+int verify_aggregate_kzg_proof_wrap(const Blob *blobs, const Bytes48 *commitments_bytes, size_t n, const Bytes48 *aggregated_proof_bytes, const KZGSettings *s) {
   bool b;
-  C_KZG_RET ret = verify_aggregate_kzg_proof(&b, blobs, commitments, n, proof, s);
+  C_KZG_RET ret = verify_aggregate_kzg_proof(&b, blobs, commitments_bytes, n, aggregated_proof_bytes, s);
   if (ret != C_KZG_OK) return -1;
 
   return b ? 0 : 1;
 }
 
-int verify_kzg_proof_wrap(const KZGCommitment *c, const Bytes32 *z, const Bytes32 *y, const KZGProof *p, KZGSettings *s) {
+int verify_kzg_proof_wrap(const Bytes48 *commitment_bytes, const Bytes32 *z_bytes, const Bytes32 *y_bytes, const Bytes48 *proof_bytes, KZGSettings *s) {
   bool out;
-  if (verify_kzg_proof(&out, c, z, y, p, s) != C_KZG_OK)
+  if (verify_kzg_proof(&out, commitment_bytes, z_bytes, y_bytes, proof_bytes, s) != C_KZG_OK)
     return -2;
 
   return out ? 0 : 1;

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -15,8 +15,8 @@ DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
 
 DLLEXPORT C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZGSettings *s);
 
-DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const KZGCommitment *commitments, size_t n, const KZGProof *proof, const KZGSettings *s);
+DLLEXPORT int verify_aggregate_kzg_proof_wrap(const Blob blobs[], const Bytes48 *commitments_bytes, size_t n, const Bytes48 *aggregated_proof_bytes, const KZGSettings *s);
 
 DLLEXPORT C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out, const Blob blobs[], size_t n, const KZGSettings *s);
 
-DLLEXPORT int verify_kzg_proof_wrap(const KZGCommitment *c, const Bytes32 *z, const Bytes32 *y, const KZGProof *p, KZGSettings *s);
+DLLEXPORT int verify_kzg_proof_wrap(const Bytes48 *commitment_bytes, const Bytes32 *z_bytes, const Bytes32 *y_bytes, const Bytes48 *proof_bytes, KZGSettings *s);

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -160,7 +160,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeAggregate
   return proof;
 }
 
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blobs, jbyteArray expected_commitments_bytes, jlong count, jbyteArray proof_bytes)
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blobs, jbyteArray commitments_bytes, jlong count, jbyteArray proof_bytes)
 {
   if (settings == NULL)
   {
@@ -178,7 +178,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
     return 0;
   }
 
-  size_t commitments_size = (size_t)(*env)->GetArrayLength(env, expected_commitments_bytes);
+  size_t commitments_size = (size_t)(*env)->GetArrayLength(env, commitments_bytes);
   size_t expected_commitments_size = BYTES_PER_COMMITMENT * count_native;
   if (commitments_size != expected_commitments_size)
   {
@@ -187,14 +187,14 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
   }
 
   Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof_bytes, NULL);
-  Bytes48 *commitments_native = (Bytes48 *)(*env)->GetByteArrayElements(env, expected_commitments_bytes, NULL);
+  Bytes48 *commitments_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitments_bytes, NULL);
   jbyte *blobs_native = (*env)->GetByteArrayElements(env, blobs, NULL);
 
   bool out;
   C_KZG_RET ret = verify_aggregate_kzg_proof(&out, (const Blob *)blobs_native, commitments_native, count_native, proof_native, settings);
 
   (*env)->ReleaseByteArrayElements(env, proof_bytes, (jbyte *)proof_native, JNI_ABORT);
-  (*env)->ReleaseByteArrayElements(env, expected_commitments_bytes, (jbyte *)commitments_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, commitments_bytes, (jbyte *)commitments_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, blobs, blobs_native, JNI_ABORT);
 
   if (ret != C_KZG_OK)

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -239,7 +239,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitm
   return commitment;
 }
 
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNIEnv *env, jclass thisCls, jbyteArray expected_commitment_bytes, jbyteArray z_bytes, jbyteArray y_bytes, jbyteArray proof_bytes)
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNIEnv *env, jclass thisCls, jbyteArray commitment_bytes, jbyteArray z_bytes, jbyteArray y_bytes, jbyteArray proof_bytes)
 {
   if (settings == NULL)
   {
@@ -247,7 +247,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNI
     return 0;
   }
 
-  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, expected_commitment_bytes, NULL);
+  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitment_bytes, NULL);
   Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof_bytes, NULL);
   Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z_bytes, NULL);
   Bytes32 *y_native = (Bytes32 *)(*env)->GetByteArrayElements(env, y_bytes, NULL);
@@ -255,7 +255,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNI
   bool out;
   C_KZG_RET ret = verify_kzg_proof(&out, commitment_native, z_native, y_native, proof_native, settings);
 
-  (*env)->ReleaseByteArrayElements(env, expected_commitment_bytes, (jbyte *)commitment_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, commitment_bytes, (jbyte *)commitment_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, z_bytes, (jbyte *)z_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, y_bytes, (jbyte *)y_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, proof_bytes, (jbyte *)proof_native, JNI_ABORT);

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -160,7 +160,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeAggregate
   return proof;
 }
 
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blobs, jbyteArray commitments, jlong count, jbyteArray proof)
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blobs, jbyteArray expected_commitments_bytes, jlong count, jbyteArray proof_bytes)
 {
   if (settings == NULL)
   {
@@ -178,7 +178,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
     return 0;
   }
 
-  size_t commitments_size = (size_t)(*env)->GetArrayLength(env, commitments);
+  size_t commitments_size = (size_t)(*env)->GetArrayLength(env, expected_commitments_bytes);
   size_t expected_commitments_size = BYTES_PER_COMMITMENT * count_native;
   if (commitments_size != expected_commitments_size)
   {
@@ -186,15 +186,15 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
     return 0;
   }
 
-  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof, NULL);
-  Bytes48 *commitments_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitments, NULL);
+  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof_bytes, NULL);
+  Bytes48 *commitments_native = (Bytes48 *)(*env)->GetByteArrayElements(env, expected_commitments_bytes, NULL);
   jbyte *blobs_native = (*env)->GetByteArrayElements(env, blobs, NULL);
 
   bool out;
   C_KZG_RET ret = verify_aggregate_kzg_proof(&out, (const Blob *)blobs_native, commitments_native, count_native, proof_native, settings);
 
-  (*env)->ReleaseByteArrayElements(env, proof, (jbyte *)proof_native, JNI_ABORT);
-  (*env)->ReleaseByteArrayElements(env, commitments, (jbyte *)commitments_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, proof_bytes, (jbyte *)proof_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, expected_commitments_bytes, (jbyte *)commitments_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, blobs, blobs_native, JNI_ABORT);
 
   if (ret != C_KZG_OK)
@@ -239,7 +239,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitm
   return commitment;
 }
 
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNIEnv *env, jclass thisCls, jbyteArray commitment, jbyteArray z, jbyteArray y, jbyteArray proof)
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNIEnv *env, jclass thisCls, jbyteArray expected_commitment_bytes, jbyteArray z_bytes, jbyteArray y_bytes, jbyteArray proof_bytes)
 {
   if (settings == NULL)
   {
@@ -247,18 +247,18 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNI
     return 0;
   }
 
-  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitment, NULL);
-  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof, NULL);
-  Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z, NULL);
-  Bytes32 *y_native = (Bytes32 *)(*env)->GetByteArrayElements(env, y, NULL);
+  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, expected_commitment_bytes, NULL);
+  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof_bytes, NULL);
+  Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z_bytes, NULL);
+  Bytes32 *y_native = (Bytes32 *)(*env)->GetByteArrayElements(env, y_bytes, NULL);
 
   bool out;
   C_KZG_RET ret = verify_kzg_proof(&out, commitment_native, z_native, y_native, proof_native, settings);
 
-  (*env)->ReleaseByteArrayElements(env, commitment, (jbyte *)commitment_native, JNI_ABORT);
-  (*env)->ReleaseByteArrayElements(env, z, (jbyte *)z_native, JNI_ABORT);
-  (*env)->ReleaseByteArrayElements(env, y, (jbyte *)y_native, JNI_ABORT);
-  (*env)->ReleaseByteArrayElements(env, proof, (jbyte *)proof_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, expected_commitment_bytes, (jbyte *)commitment_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, z_bytes, (jbyte *)z_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, y_bytes, (jbyte *)y_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, proof_bytes, (jbyte *)proof_native, JNI_ABORT);
 
   if (ret != C_KZG_OK)
   {

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -186,8 +186,8 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyAggregateKzg
     return 0;
   }
 
-  KZGProof *proof_native = (KZGProof *)(*env)->GetByteArrayElements(env, proof, NULL);
-  KZGCommitment *commitments_native = (KZGCommitment *)(*env)->GetByteArrayElements(env, commitments, NULL);
+  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof, NULL);
+  Bytes48 *commitments_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitments, NULL);
   jbyte *blobs_native = (*env)->GetByteArrayElements(env, blobs, NULL);
 
   bool out;
@@ -247,8 +247,8 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(JNI
     return 0;
   }
 
-  KZGCommitment *commitment_native = (KZGCommitment *)(*env)->GetByteArrayElements(env, commitment, NULL);
-  KZGProof *proof_native = (KZGProof *)(*env)->GetByteArrayElements(env, proof, NULL);
+  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitment, NULL);
+  Bytes48 *proof_native = (Bytes48 *)(*env)->GetByteArrayElements(env, proof, NULL);
   Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z, NULL);
   Bytes32 *y_native = (Bytes32 *)(*env)->GetByteArrayElements(env, y, NULL);
 

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -155,7 +155,7 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyKzgProof(byte[] expected_commitment_bytes, byte[] z_bytes, byte[] y_bytes,
+  public static native boolean verifyKzgProof(byte[] commitment_bytes, byte[] z_bytes, byte[] y_bytes,
                                               byte[] proof_bytes);
 
 }

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -133,8 +133,8 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyAggregateKzgProof(byte[] blobs, byte[] commitments, long count,
-      byte[] proof);
+  public static native boolean verifyAggregateKzgProof(byte[] blobs, byte[] expected_commitments, long count,
+      byte[] aggregated_proof);
 
   /**
    * Calculates commitment for a given blob
@@ -155,6 +155,6 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyKzgProof(byte[] commitment, byte[] z, byte[] y, byte[] proof);
+  public static native boolean verifyKzgProof(byte[] expected_commitment, byte[] z, byte[] y, byte[] proof);
 
 }

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -126,15 +126,15 @@ public class CKZG4844JNI {
   /**
    * Verify aggregated proof and commitments for the given blobs
    *
-   * @param blobs       blobs as flattened bytes
-   * @param commitments commitments as flattened bytes
-   * @param count       the count of the blobs (should be same as the count of the commitments)
-   * @param proof       the proof that needs verifying
+   * @param blobs               blobs as flattened bytes
+   * @param commitments_bytes   commitments as flattened bytes
+   * @param count               the count of the blobs (should be same as the count of the commitments)
+   * @param proof_bytes         the proof that needs verifying
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyAggregateKzgProof(byte[] blobs, byte[] expected_commitments, long count,
-      byte[] aggregated_proof);
+  public static native boolean verifyAggregateKzgProof(byte[] blobs, byte[] commitments_bytes, long count,
+                                                       byte[] aggregated_proof_bytes);
 
   /**
    * Calculates commitment for a given blob
@@ -148,13 +148,14 @@ public class CKZG4844JNI {
   /**
    * Verify the proof by point evaluation for the given commitment
    *
-   * @param commitment commitment bytes
-   * @param z          Z
-   * @param y          Y
-   * @param proof      the proof that needs verifying
+   * @param commitment_bytes  commitment bytes
+   * @param z_bytes           Z
+   * @param y_bytes           Y
+   * @param proof_bytes       the proof that needs verifying
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyKzgProof(byte[] expected_commitment, byte[] z, byte[] y, byte[] proof);
+  public static native boolean verifyKzgProof(byte[] expected_commitment_bytes, byte[] z_bytes, byte[] y_bytes,
+                                              byte[] proof_bytes);
 
 }

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -197,7 +197,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   return napi_typed_array_from_bytes((uint8_t *)(&proof), BYTES_PER_PROOF, env);
 }
 
-// verifyAggregateKzgProof: (blobs: Blob[], commitmentsBytes: Bytes48[], aggregatedProof: Bytes48, setupHandle: SetupHandle) => boolean;
+// verifyAggregateKzgProof: (blobs: Blob[], commitmentsBytes: Bytes48[], aggregatedProofBytes: Bytes48, setupHandle: SetupHandle) => boolean;
 Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -197,7 +197,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   return napi_typed_array_from_bytes((uint8_t *)(&proof), BYTES_PER_PROOF, env);
 }
 
-// verifyAggregateKzgProof: (blobs: Blob[], expectedKzgCommitments: KZGCommitment[], kzgAggregatedProof: KZGProof, setupHandle: SetupHandle) => boolean;
+// verifyAggregateKzgProof: (blobs: Blob[], commitmentsBytes: Bytes48[], aggregatedProof: Bytes48, setupHandle: SetupHandle) => boolean;
 Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
@@ -221,7 +221,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
     return env.Null();
   };
 
-  auto commitments = (KZGCommitment*)calloc(blobs_count, sizeof(KZGCommitment));
+  auto commitments = (Bytes48*)calloc(blobs_count, sizeof(Bytes48));
   if (commitments == NULL) {
     free(blobs);
     Napi::Error::New(env, "Error while allocating memory for commitments").ThrowAsJavaScriptException();
@@ -248,7 +248,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
     blobs,
     commitments,
     blobs_count,
-    (KZGProof *)proof_bytes,
+    (Bytes48 *)proof_bytes,
     kzg_settings
   );
 
@@ -266,7 +266,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, verification_result);
 }
 
-// verifyKzgProof: (polynomialKzg: KZGCommitment, z: Bytes32, y: Bytes32, kzgProof: KZGProof, setupHandle: SetupHandle) => boolean;
+// verifyKzgProof: (commitmentBytes: Bytes48, zBytes: Bytes32, yBytes: Bytes32, proofBytes: Bytes48, setupHandle: SetupHandle) => boolean;
 Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   auto env = info.Env();
 
@@ -276,10 +276,10 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
     return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
-  auto polynomial_kzg = extract_byte_array_from_param(info, 0, "polynomialKzg");
-  auto z = extract_byte_array_from_param(info, 1, "z");
-  auto y = extract_byte_array_from_param(info, 2, "y");
-  auto kzg_proof = extract_byte_array_from_param(info, 3, "kzgProof");
+  auto commitment_bytes = extract_byte_array_from_param(info, 0, "commitmentBytes");
+  auto z_bytes = extract_byte_array_from_param(info, 1, "zBytes");
+  auto y_bytes = extract_byte_array_from_param(info, 2, "yBytes");
+  auto proof_bytes = extract_byte_array_from_param(info, 3, "proofBytes");
   auto kzg_settings = info[4].As<Napi::External<KZGSettings>>().Data();
 
   if (env.IsExceptionPending()) {
@@ -289,10 +289,10 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   bool out;
   C_KZG_RET ret = verify_kzg_proof(
     &out,
-    (KZGCommitment *)polynomial_kzg,
-    (Bytes32 *)z,
-    (Bytes32 *)y,
-    (KZGProof *)kzg_proof,
+    (Bytes48 *)commitment_bytes,
+    (Bytes32 *)z_bytes,
+    (Bytes32 *)y_bytes,
+    (Bytes48 *)proof_bytes,
     kzg_settings
   );
 

--- a/bindings/node.js/kzg.ts
+++ b/bindings/node.js/kzg.ts
@@ -6,6 +6,7 @@ const kzg: KZG = require("./kzg.node");
 const fs = require("fs");
 
 export type Bytes32 = Uint8Array; // 32 bytes
+export type Bytes48 = Uint8Array; // 48 bytes
 export type KZGProof = Uint8Array; // 48 bytes
 export type KZGCommitment = Uint8Array; // 48 bytes
 export type Blob = Uint8Array; // 4096 * 32 bytes
@@ -30,16 +31,16 @@ type KZG = {
 
   verifyAggregateKzgProof: (
     blobs: Blob[],
-    expectedKzgCommitments: KZGCommitment[],
-    kzgAggregatedProof: KZGProof,
+    commitmentsBytes: Bytes48[],
+    aggregatedProofBytes: Bytes48,
     setupHandle: SetupHandle,
   ) => boolean;
 
   verifyKzgProof: (
-    polynomialKzg: KZGCommitment,
-    z: Bytes32,
-    y: Bytes32,
-    kzgProof: KZGProof,
+    commitmentBytes: Bytes48,
+    zBytes: Bytes32,
+    yBytes: Bytes32,
+    proofBytes: Bytes48,
     setupHandle: SetupHandle,
   ) => boolean;
 };
@@ -114,29 +115,29 @@ export function computeAggregateKzgProof(blobs: Blob[]): KZGProof {
 }
 
 export function verifyKzgProof(
-  polynomialKzg: KZGCommitment,
-  z: Bytes32,
-  y: Bytes32,
-  kzgProof: KZGProof,
+  commitmentBytes: Bytes48,
+  zBytes: Bytes32,
+  yBytes: Bytes32,
+  proofBytes: Bytes48,
 ): boolean {
   return kzg.verifyKzgProof(
-    polynomialKzg,
-    z,
-    y,
-    kzgProof,
+    commitmentBytes,
+    zBytes,
+    yBytes,
+    proofBytes,
     requireSetupHandle(),
   );
 }
 
 export function verifyAggregateKzgProof(
   blobs: Blob[],
-  expectedKzgCommitments: KZGCommitment[],
-  kzgAggregatedProof: KZGProof,
+  commitmentsBytes: Bytes48[],
+  proofBytes: Bytes48,
 ): boolean {
   return kzg.verifyAggregateKzgProof(
     blobs,
-    expectedKzgCommitments,
-    kzgAggregatedProof,
+    commitmentsBytes,
+    proofBytes,
     requireSetupHandle(),
   );
 }

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -106,8 +106,8 @@ static PyObject* verify_aggregate_kzg_proof_wrap(PyObject *self, PyObject *args)
     return PyErr_Format(PyExc_ValueError, "expected same number of commitments as polynomials");
 
   const Blob* blobs = (Blob *)PyBytes_AsString(b);
-  const KZGProof *proof = (KZGProof *)PyBytes_AsString(p);
-  const KZGCommitment *commitments = (KZGCommitment *)PyBytes_AsString(c);
+  const Bytes48 *proof_bytes = (Bytes48 *)PyBytes_AsString(p);
+  const Bytes48 *commitments_bytes = (Bytes48 *)PyBytes_AsString(c);
 
   bool out;
   if (verify_aggregate_kzg_proof(&out,

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -111,7 +111,7 @@ static PyObject* verify_aggregate_kzg_proof_wrap(PyObject *self, PyObject *args)
 
   bool out;
   if (verify_aggregate_kzg_proof(&out,
-        blobs, commitments, n, proof,
+        blobs, commitments_bytes, n, proof_bytes,
         PyCapsule_GetPointer(s, "KZGSettings")) != C_KZG_OK) {
     return PyErr_Format(PyExc_RuntimeError, "verify_aggregate_kzg_proof failed");
   }

--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -30,11 +30,13 @@ struct blst_fr {
 struct blst_fp {
     l: [limb_t; 6usize],
 }
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct blst_fp2 {
     fp: [blst_fp; 2usize],
 }
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct blst_fp6 {
@@ -85,6 +87,19 @@ pub struct Bytes32 {
 
 impl Deref for Bytes32 {
     type Target = [u8; 32];
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Bytes48 {
+    bytes: [u8; 48],
+}
+
+impl Deref for Bytes48 {
+    type Target = [u8; 48];
     fn deref(&self) -> &Self::Target {
         &self.bytes
     }
@@ -207,9 +222,9 @@ extern "C" {
     pub fn verify_aggregate_kzg_proof(
         out: *mut bool,
         blobs: *const Blob,
-        expected_kzg_commitments: *const KZGCommitment,
+        expected_commitments: *const Bytes48,
         n: usize,
-        kzg_aggregated_proof: *const KZGProof,
+        aggregated_proof: *const Bytes48,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
 
@@ -221,10 +236,10 @@ extern "C" {
 
     pub fn verify_kzg_proof(
         out: *mut bool,
-        polynomial_kzg: *const KZGCommitment,
+        commitment: *const Bytes48,
         z: *const Bytes32,
         y: *const Bytes32,
-        kzg_proof: *const KZGProof,
+        proof: *const Bytes48,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
 }

--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -222,9 +222,9 @@ extern "C" {
     pub fn verify_aggregate_kzg_proof(
         out: *mut bool,
         blobs: *const Blob,
-        expected_commitments: *const Bytes48,
+        commitments_bytes: *const Bytes48,
         n: usize,
-        aggregated_proof: *const Bytes48,
+        aggregated_proof_bytes: *const Bytes48,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
 
@@ -236,10 +236,10 @@ extern "C" {
 
     pub fn verify_kzg_proof(
         out: *mut bool,
-        commitment: *const Bytes48,
-        z: *const Bytes32,
-        y: *const Bytes32,
-        proof: *const Bytes48,
+        commitment_bytes: *const Bytes48,
+        z_bytes: *const Bytes32,
+        y_bytes: *const Bytes32,
+        proof_bytes: *const Bytes48,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -185,14 +185,14 @@ impl KZGProof {
     pub fn verify_aggregate_kzg_proof(
         &self,
         blobs: &[Blob],
-        expected_commitments: &[Bytes48],
+        commitments_bytes: &[Bytes48],
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
-        if blobs.len() != expected_commitments.len() {
+        if blobs.len() != commitments_bytes.len() {
             return Err(Error::MismatchLength(format!(
                 "There are {} blobs and {} commitments",
                 blobs.len(),
-                expected_commitments.len()
+                commitments_bytes.len()
             )));
         }
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
@@ -200,7 +200,7 @@ impl KZGProof {
             let res = verify_aggregate_kzg_proof(
                 verified.as_mut_ptr(),
                 blobs.as_ptr(),
-                expected_commitments.as_ptr(),
+                commitments_bytes.as_ptr(),
                 blobs.len(),
                 &self.to_bytes48(),
                 kzg_settings,
@@ -215,18 +215,18 @@ impl KZGProof {
 
     pub fn verify_kzg_proof(
         &self,
-        commitment: Bytes48,
-        z: Bytes32,
-        y: Bytes32,
+        commitment_bytes: Bytes48,
+        z_bytes: Bytes32,
+        y_bytes: Bytes32,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
         unsafe {
             let res = verify_kzg_proof(
                 verified.as_mut_ptr(),
-                &commitment,
-                &z,
-                &y,
+                &commitment_bytes,
+                &z_bytes,
+                &y_bytes,
                 &self.to_bytes48(),
                 kzg_settings,
             );

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -670,7 +670,7 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
  */
 static C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b) {
     /* Fast check without needing to uncompress */
-    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(b)) != 0)
+    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(b)) == 0)
         return C_KZG_OK;
 
     /* Convert the bytes to a p1 point */

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -37,16 +37,6 @@ typedef struct { fr_t evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
 
-/** Serialized form of the point at infinity on the G1 group. */
-static const Bytes48 G1_POINT_AT_INFINITY = {
-    0xc1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
-
 /** Deserialized form of the G1 identity/infinity point. */
 static const g1_t G1_IDENTITY = {{0L, 0L, 0L, 0L, 0L, 0L}, {0L, 0L, 0L, 0L, 0L, 0L}, {0L, 0L, 0L, 0L, 0L, 0L}};
 
@@ -669,17 +659,13 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
  *     the function name is a bit misleading.
  */
 static C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b) {
-    /* Fast check without needing to uncompress */
-    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(b)) == 0)
-        return C_KZG_OK;
-
     /* Convert the bytes to a p1 point */
     blst_p1_affine p1_affine;
     if (blst_p1_uncompress(&p1_affine, b->bytes) != BLST_SUCCESS)
         return C_KZG_BADARGS;
     blst_p1_from_affine(out, &p1_affine);
 
-    /* Duplicate check, just in case */
+    /* Check if it's the point at infinity */
     if (blst_p1_is_inf(out))
         return C_KZG_OK;
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -497,22 +497,6 @@ static void bytes_from_g1(Bytes48 *out, const g1_t *in) {
 }
 
 /**
- * Deserialize bytes into a G1 group element.
- *
- * @param[out] out The G1 element to store the deserialized data
- * @param[in] bytes A 48-byte array containing the serialized G1 element
- * @retval C_KZG_OK Deserialization successful
- * @retval C_KZG_BADARGS Input bytes were not a valid G1 element
- */
-static C_KZG_RET bytes_to_g1(g1_t* out, const Bytes48 *b) {
-    blst_p1_affine tmp;
-    if (blst_p1_uncompress(&tmp, b->bytes) != BLST_SUCCESS)
-        return C_KZG_BADARGS;
-    blst_p1_from_affine(out, &tmp);
-    return C_KZG_OK;
-}
-
-/**
  * Serialize a BLS field element into bytes.
  *
  * @param[out] out A 32-byte array to store the serialized field element
@@ -1561,7 +1545,7 @@ C_KZG_RET load_trusted_setup(KZGSettings *out, const uint8_t *g1_bytes, size_t n
     if (ret != C_KZG_OK) goto out_error;
 
     for (i = 0; i < n1; i++) {
-        ret = bytes_to_g1(&g1_projective[i], (Bytes48 *)&g1_bytes[48 * i]);
+        ret = validate_kzg_g1(&g1_projective[i], (Bytes48 *)&g1_bytes[48 * i]);
         if (ret != C_KZG_OK) goto out_error;
     }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -37,7 +37,17 @@ typedef struct { fr_t evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
 
-/** The G1 identity/infinity. */
+/** Serialized form of the point at infinity on the G1 group. */
+static const Bytes48 G1_POINT_AT_INFINITY = {
+    0xc1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+/** Deserialized form of the G1 identity/infinity point. */
 static const g1_t g1_identity = {{0L, 0L, 0L, 0L, 0L, 0L}, {0L, 0L, 0L, 0L, 0L, 0L}, {0L, 0L, 0L, 0L, 0L, 0L}};
 
 /** The G1 generator. */
@@ -669,8 +679,12 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
  */
 static C_KZG_RET validate_kzg_g1(const Bytes48 *b) {
     blst_p1_affine tmp;
+
+    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(Bytes48)) != 0)
+        return C_KZG_OK;
     if (blst_p1_uncompress(&tmp, b->bytes) != BLST_SUCCESS)
         return C_KZG_BADARGS;
+
     return C_KZG_OK;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -657,7 +657,7 @@ static void hash_to_bls_field(fr_t *out, const Bytes32 *b) {
 }
 
 /**
- * Deserialize bytes into a BLS field element.
+ * Convert untrusted bytes to a trusted and validated BLS scalar field element.
  *
  * @param[out] out The field element to store the deserialized data
  * @param[in] bytes A 32-byte array containing the serialized field element

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -680,10 +680,10 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
 static C_KZG_RET validate_kzg_g1(const Bytes48 *b) {
     blst_p1_affine tmp;
 
-    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(Bytes48)) != 0)
+    if (memcmp(G1_POINT_AT_INFINITY.bytes, b->bytes, sizeof(b)) != 0)
         return C_KZG_OK;
-    if (blst_p1_uncompress(&tmp, b->bytes) != BLST_SUCCESS)
-        return C_KZG_BADARGS;
+
+    // TODO: validate the point.
 
     return C_KZG_OK;
 }

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -45,9 +45,11 @@ typedef blst_p2 g2_t;         /**< Internal G2 group element type */
 typedef blst_fr fr_t;         /**< Internal Fr field element type */
 
 typedef struct { uint8_t bytes[32]; } Bytes32;
-typedef struct { uint8_t bytes[BYTES_PER_COMMITMENT]; } KZGCommitment;
-typedef struct { uint8_t bytes[BYTES_PER_PROOF]; } KZGProof;
+typedef struct { uint8_t bytes[48]; } Bytes48;
 typedef struct { uint8_t bytes[BYTES_PER_BLOB]; } Blob;
+
+typedef Bytes48 KZGCommitment;
+typedef Bytes48 KZGProof;
 
 /**
  * The common return type for all routines in which something can go wrong.
@@ -101,9 +103,9 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
 
 C_KZG_RET verify_aggregate_kzg_proof(bool *out,
                                      const Blob *blobs,
-                                     const KZGCommitment *expected_kzg_commitments,
+                                     const Bytes48 *expected_commitments,
                                      size_t n,
-                                     const KZGProof *kzg_aggregated_proof,
+                                     const Bytes48 *aggregated_proof,
                                      const KZGSettings *s);
 
 C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
@@ -111,10 +113,10 @@ C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
                                  const KZGSettings *s);
 
 C_KZG_RET verify_kzg_proof(bool *out,
-                           const KZGCommitment *polynomial_kzg,
+                           const Bytes48 *commitment,
                            const Bytes32 *z,
                            const Bytes32 *y,
-                           const KZGProof *kzg_proof,
+                           const Bytes48 *proof,
                            const KZGSettings *s);
 
 C_KZG_RET compute_kzg_proof(KZGProof *out,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -103,9 +103,9 @@ C_KZG_RET compute_aggregate_kzg_proof(KZGProof *out,
 
 C_KZG_RET verify_aggregate_kzg_proof(bool *out,
                                      const Blob *blobs,
-                                     const Bytes48 *expected_commitments,
+                                     const Bytes48 *commitments_bytes,
                                      size_t n,
-                                     const Bytes48 *aggregated_proof,
+                                     const Bytes48 *aggregated_proof_bytes,
                                      const KZGSettings *s);
 
 C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
@@ -113,15 +113,15 @@ C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out,
                                  const KZGSettings *s);
 
 C_KZG_RET verify_kzg_proof(bool *out,
-                           const Bytes48 *commitment,
-                           const Bytes32 *z,
-                           const Bytes32 *y,
-                           const Bytes48 *proof,
+                           const Bytes48 *commitment_bytes,
+                           const Bytes32 *z_bytes,
+                           const Bytes32 *y_bytes,
+                           const Bytes48 *proof_bytes,
                            const KZGSettings *s);
 
 C_KZG_RET compute_kzg_proof(KZGProof *out,
-                            const Blob *p,
-                            const Bytes32 *z,
+                            const Blob *blobs,
+                            const Bytes32 *z_bytes,
                             const KZGSettings *s);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR implements the changes defined here:

* https://github.com/ethereum/consensus-specs/pull/3224

Notable:

* `KZGProof`/`KZGCommitment` are considered trusted types. `Bytes48` is untrusted.
  * Technically they are the same value though, it's just a typedef.
* [deviation] Used `z_bytes` instead of `z` for consistency, this will be renamed later anyway.
* Renamed all of the static constants to be ALL_UPPER_CASE.
* Removed `bytes_to_g1` function (`bytes_from_g1` is still required).
* There's a duplicate check in `validate_kzg_g1`. Not sure which is better.