### PR TITLE
Add compute_kzg_proof to rust bindings

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -212,6 +212,13 @@ extern "C" {
 
     pub fn free_trusted_setup(s: *mut KZGSettings);
 
+    pub fn compute_kzg_proof(
+        out: *mut KZGProof,
+        blob: *const Blob,
+        z_bytes: *const Bytes32,
+        s: *const KZGSettings,
+    ) -> C_KZG_RET;
+
     pub fn compute_aggregate_kzg_proof(
         out: *mut KZGProof,
         blobs: *const Blob,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -161,6 +161,27 @@ impl KZGProof {
         hex::encode(self.bytes)
     }
 
+    pub fn compute_kzg_proof(
+        blob: &[Blob],
+        z_bytes: Bytes32,
+        kzg_settings: &KZGSettings,
+    ) -> Result<Self, Error> {
+        let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
+        unsafe {
+            let res = compute_kzg_proof(
+                kzg_proof.as_mut_ptr(),
+                blob.as_ptr(),
+                &z_bytes,
+                kzg_settings,
+            );
+            if let C_KZG_RET::C_KZG_OK = res {
+                Ok(kzg_proof.assume_init())
+            } else {
+                Err(Error::CError(res))
+            }
+        }
+    }
+
     pub fn compute_aggregate_kzg_proof(
         blobs: &[Blob],
         kzg_settings: &KZGSettings,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -120,7 +120,7 @@ C_KZG_RET verify_kzg_proof(bool *out,
                            const KZGSettings *s);
 
 C_KZG_RET compute_kzg_proof(KZGProof *out,
-                            const Blob *blobs,
+                            const Blob *blob,
                             const Bytes32 *z_bytes,
                             const KZGSettings *s);
 


### PR DESCRIPTION
Going to make a PR for each language binding. This is the rust one.

Also fixes a typo (copy paste issue) in the C headers.

I would like to add tests later.