### PR TITLE
Add compute_kzg_proof to nodejs bindings

### DIFF
--- a/bindings/node.js/kzg.ts
+++ b/bindings/node.js/kzg.ts
@@ -24,6 +24,12 @@ type KZG = {
 
   blobToKzgCommitment: (blob: Blob, setupHandle: SetupHandle) => KZGCommitment;
 
+  computeKzgProof: (
+    blob: Blob,
+    zBytes: Bytes32,
+    setupHandle: SetupHandle,
+  ) => KZGProof;
+
   computeAggregateKzgProof: (
     blobs: Blob[],
     setupHandle: SetupHandle,
@@ -108,6 +114,10 @@ export function freeTrustedSetup(): void {
 
 export function blobToKzgCommitment(blob: Blob): KZGCommitment {
   return kzg.blobToKzgCommitment(blob, requireSetupHandle());
+}
+
+export function computeKzgProof(blob: Blob, zBytes: Bytes32): KZGProof {
+  return kzg.computeKzgProof(blob, zBytes, requireSetupHandle());
 }
 
 export function computeAggregateKzgProof(blobs: Blob[]): KZGProof {

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -6,6 +6,7 @@ import {
   freeTrustedSetup,
   blobToKzgCommitment,
   verifyKzgProof,
+  computeKzgProof,
   computeAggregateKzgProof,
   verifyAggregateKzgProof,
   BYTES_PER_FIELD_ELEMENT,
@@ -43,6 +44,13 @@ describe("C-KZG", () => {
 
   afterAll(() => {
     freeTrustedSetup();
+  });
+
+  it("computes a proof from blob", () => {
+    let blob = generateRandomBlob();
+    const zBytes = new Uint8Array(32).fill(0);
+    computeKzgProof(blob, zBytes);
+    // No check, just make sure it doesn't crash.
   });
 
   it("computes the correct commitments and aggregate proof from blobs", () => {


### PR DESCRIPTION
This adds `computeKzgProof` to Node.js + a test to make sure it doesn't immediately segfault.

Also, the diff is a little weird because I changed the `computeAggregateKzgProof` error message.