### PR TITLE
Clean up the test file a little

### DIFF
--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1,81 +1,89 @@
-/* Tests for myfunctions.c, using TinyTest. */
-
+/*
+ * This file contains unit tests for C-KZG-4844.
+ */
 #define UNIT_TESTS
 
 #include "tinytest.h"
 #include "blst.h"
-
 #include "c_kzg_4844.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
 
 KZGSettings s;
 
-void load_setup() {
-  FILE *fp;
-  C_KZG_RET ret;
-  fp = fopen("trusted_setup.txt", "r");
+static void setup(void) {
+    FILE *fp;
+    C_KZG_RET ret;
 
-  ret = load_trusted_setup_file(&s, fp);
-  assert(ret == C_KZG_OK);
+    fp = fopen("trusted_setup.txt", "r");
+    assert(fp != NULL);
 
-  fclose(fp);
+    ret = load_trusted_setup_file(&s, fp);
+    assert(ret == C_KZG_OK);
+
+    fclose(fp);
 }
 
-void get_32_rand_bytes(uint8_t *out) {
-  static uint64_t seed = 0;
-  seed++;
-  blst_sha256(out, (uint8_t*)&seed, sizeof(seed));
+static void teardown(void) {
+    free_trusted_setup(&s);
 }
 
-void get_rand_field_element(Bytes32 *out) {
-  fr_t tmp;
-  Bytes32 tmp_rand;
+static void get_32_rand_bytes(uint8_t *out) {
+    static uint64_t seed = 0;
+    seed++;
+    blst_sha256(out, (uint8_t*)&seed, sizeof(seed));
+}
 
-  memset(out, 0, sizeof(Bytes32));
+static void get_rand_field_element(Bytes32 *out) {
+    fr_t tmp_fr;
+    Bytes32 tmp_bytes;
 
-  // Take 32 random bytes, make them an Fr, and then turn the Fr back to a bytes array
-  get_32_rand_bytes((uint8_t *) &tmp_rand);
-  hash_to_bls_field(&tmp, &tmp_rand);
-  bytes_from_bls_field(out, &tmp);
+    memset(out, 0, sizeof(Bytes32));
+
+    /*
+     * Take 32 random bytes, make them an Fr, and then
+     * turn the Fr back to a bytes array.
+     */
+    get_32_rand_bytes((uint8_t *)&tmp_bytes);
+    hash_to_bls_field(&tmp_fr, &tmp_bytes);
+    bytes_from_bls_field(out, &tmp_fr);
 }
 
 void get_rand_blob(Blob *out) {
-  memset(out, 0, sizeof(Blob));
+    memset(out, 0, sizeof(Blob));
 
-  uint8_t *blob_bytes = (uint8_t *) out;
-  for (int i = 0; i < 128; i++) {
-    get_rand_field_element((Bytes32 *)&blob_bytes[i * 32]);
-  }
+    uint8_t *blob_bytes = (uint8_t *) out;
+    for (int i = 0; i < 128; i++) {
+        get_rand_field_element((Bytes32 *)&blob_bytes[i * 32]);
+    }
 }
 
-void test_compute_kzg_proof() {
-  C_KZG_RET ret;
-  Bytes48 proof;
-  Bytes32 z;
-  KZGCommitment c;
-  Blob blob;
+static void test_compute_kzg_proof(void) {
+    C_KZG_RET ret;
+    Bytes48 proof;
+    Bytes32 z;
+    KZGCommitment c;
+    Blob blob;
 
-  get_rand_field_element(&z);
-  get_rand_blob(&blob);
+    get_rand_field_element(&z);
+    get_rand_blob(&blob);
 
-  ret = blob_to_kzg_commitment(&c, &blob, &s);
-  ASSERT_EQUALS(ret, C_KZG_OK);
+    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
-  ret = compute_kzg_proof(&proof, &blob, &z, &s);
-  ASSERT_EQUALS(ret, C_KZG_OK);
+    ret = compute_kzg_proof(&proof, &blob, &z, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
-  // XXX now verify it!
+    // XXX now verify it!
 }
 
-/* test runner */
-int main()
+int main(void)
 {
-  load_setup();
+    setup();
+    RUN(test_compute_kzg_proof);
+    teardown();
 
-  RUN(test_compute_kzg_proof);
-
-  free_trusted_setup(&s);
-  return TEST_REPORT();
+    return TEST_REPORT();
 }


### PR DESCRIPTION
Fixing a few little nits:

* Check that `fp` isn't null.
* Use 4 spaces for tabs instead of 2.
* Rename funcs to `setup` and `teardown` which are more generic.
* Make everything but main static.
* Add "void" to funcs with no parameters.