### PR TITLE
Make get_rand_blob return a full blob

### DIFF
--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -40,8 +40,6 @@ static void get_rand_field_element(Bytes32 *out) {
     fr_t tmp_fr;
     Bytes32 tmp_bytes;
 
-    memset(out, 0, sizeof(Bytes32));
-
     /*
      * Take 32 random bytes, make them an Fr, and then
      * turn the Fr back to a bytes array.
@@ -52,10 +50,8 @@ static void get_rand_field_element(Bytes32 *out) {
 }
 
 void get_rand_blob(Blob *out) {
-    memset(out, 0, sizeof(Blob));
-
-    uint8_t *blob_bytes = (uint8_t *) out;
-    for (int i = 0; i < 128; i++) {
+    uint8_t *blob_bytes = (uint8_t *)out;
+    for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         get_rand_field_element((Bytes32 *)&blob_bytes[i * 32]);
     }
 }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -50,9 +50,8 @@ static void get_rand_field_element(Bytes32 *out) {
 }
 
 void get_rand_blob(Blob *out) {
-    uint8_t *blob_bytes = (uint8_t *)out;
     for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        get_rand_field_element((Bytes32 *)&blob_bytes[i * 32]);
+        get_rand_field_element((Bytes32 *)&out->bytes[i * 32]);
     }
 }
 


### PR DESCRIPTION
These memsets were required because only the first 128 field elements in the blob were being populated. The remaining field elements had "random" and were most likely were invalid. Do all 4096 (FIELD_ELEMENTS_PER_BLOB).