### PR TITLE
Clean up the header file

### DIFF
--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -14,8 +14,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Test
+      - name: Build
         run: |
           cd src
           make blst
+          make
+      - name: Test
+        run: |
+          cd src
           make test

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -14,12 +14,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Build
-        run: |
-          cd src
-          make blst
-          make
       - name: Test
         run: |
           cd src
+          make blst
           make test

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,10 +27,10 @@ lib: c_kzg_4844.o Makefile
 	cp *.o ../bindings/node.js
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c Makefile
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) -L ../lib -lblst -o test_c_kzg_4844 $<
+	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) -L../lib -lblst -o test_c_kzg_4844 $<
 
 test: test_c_kzg_4844
-		./test_c_kzg_4844
+	./test_c_kzg_4844
 
 clean:
-		rm -f  *.o test_c_kzg_4844
+	rm -f  *.o test_c_kzg_4844

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,8 +27,7 @@ lib: c_kzg_4844.o Makefile
 	cp *.o ../bindings/node.js
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c Makefile
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) -DUNIT_TESTS $(CFLAGS) -c c_kzg_4844.c -o test_c_kzg_4844.o
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) test_c_kzg_4844.o -L ../lib -lblst -o test_c_kzg_4844 $<
+	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) -L ../lib -lblst -o test_c_kzg_4844 $<
 
 test: test_c_kzg_4844
 		./test_c_kzg_4844

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -38,7 +38,6 @@ extern "C" {
 #define BYTES_PER_PROOF 48
 #define BYTES_PER_FIELD_ELEMENT 32
 #define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
-static const char *FIAT_SHAMIR_PROTOCOL_DOMAIN = "FSBLOBVERIFY_V1_";
 
 typedef blst_p1 g1_t;         /**< Internal G1 group element type */
 typedef blst_p2 g2_t;         /**< Internal G2 group element type */
@@ -123,20 +122,6 @@ C_KZG_RET compute_kzg_proof(KZGProof *out,
                             const Blob *blob,
                             const Bytes32 *z_bytes,
                             const KZGSettings *s);
-
-typedef struct { fr_t evals[FIELD_ELEMENTS_PER_BLOB]; } Polynomial;
-
-#ifdef UNIT_TESTS
-
-void hash_to_bls_field(fr_t *out, const Bytes32 *b);
-void bytes_from_bls_field(Bytes32 *out, const fr_t *in);
-C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b);
-void bytes_from_g1(Bytes48 *out, const g1_t *in);
-C_KZG_RET evaluate_polynomial_in_evaluation_form(fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s);
-C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob);
-C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b);
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -4,7 +4,6 @@
 #define UNIT_TESTS
 
 #include "tinytest.h"
-#include "blst.h"
 #include "c_kzg_4844.c"
 
 #include <stdio.h>

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -6,7 +6,6 @@
 #include "tinytest.h"
 #include "blst.h"
 #include "c_kzg_4844.c"
-#include "c_kzg_4844.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -5,6 +5,7 @@
 
 #include "tinytest.h"
 #include "blst.h"
+#include "c_kzg_4844.c"
 #include "c_kzg_4844.h"
 
 #include <stdio.h>


### PR DESCRIPTION
Instead of building `test_c_kzg_4844.o`, build the test binary with `c_kzg_4844.c` which makes everything accessible. No need to export internal functions in the header. Also, move `Polynomial` back to the C file and `FIAT_SHAMIR_PROTOCOL_DOMAIN` to the C file since it's only used internally. Also, make everything that was `static` -> `STATIC` so it can be tested.