### PR TITLE
Generate coverage report

### DIFF
--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -34,8 +34,3 @@ jobs:
         with:
           name: coverage
           path: src/coverage.html
-      - name: Check coverage
-        run: |
-          cd src
-          make test_cov
-          make test_cov | grep TOTAL | awk '{print $4" "$7" "$10}' | grep -q "100.00% 100.00% 100.00%"

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -24,17 +24,18 @@ jobs:
           cd src
           make test
       - name: Install LLVM
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "14.0"
-      - name: Test Coverage
+        uses: egor-tensin/setup-clang@v1
+      - name: Generate coverage report
         run: |
           cd src
           make test_cov
-          make test_cov | grep TOTAL | awk '{print $4" "$7" "$10}' | grep -q "100.00% 100.00% 100.00%"
       - name: Save coverage report
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: |
-            coverage.html
+          path: coverage.html
+      - name: Check coverage
+        run: |
+          cd src
+          make test_cov
+          make test_cov | grep TOTAL | awk '{print $4" "$7" "$10}' | grep -q "100.00% 100.00% 100.00%"

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -28,3 +28,9 @@ jobs:
           cd src
           make test_cov
           make test_cov | grep TOTAL | awk '{print $4" "$7" "$10}' | grep -q "100.00% 100.00% 100.00%"
+      - name: Save coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: |
+            coverage.html

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: coverage.html
+          path: src/coverage.html
       - name: Check coverage
         run: |
           cd src

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           cd src
           make test
+      - name: Install LLVM
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
       - name: Test Coverage
         run: |
           cd src

--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -23,3 +23,8 @@ jobs:
         run: |
           cd src
           make test
+      - name: Test Coverage
+        run: |
+          cd src
+          make test_cov
+          make test_cov | grep TOTAL | awk '{print $4" "$7" "$10}' | grep -q "100.00% 100.00% 100.00%"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 test_c_kzg_4844
+*.profraw
+*.profdata
 *.o
 *.s
 *.a
@@ -6,6 +8,7 @@ test_c_kzg_4844
 inc/blst.h*
 inc/blst_aux.h*
 .vscode/
+.idea/
 .clang-format
 *bindings/*/*.so
 *bindings/rust/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test_c_kzg_4844
+coverage.html
 *.profraw
 *.profdata
 *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,6 +45,7 @@ test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c Makefile
 test_cov: test_c_kzg_4844_cov
 	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
+	@$(XCRUN) llvm-cov show ./test_c_kzg_4844 --instr-profile=ckzg.profdata --format=html c_kzg_4844.c > coverage.html
 	@$(XCRUN) llvm-cov report ./test_c_kzg_4844 --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
 
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,6 @@ else
 	CFLAGS += -O2 -fPIC
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		CCFLAGS += -D OSX
 		XCRUN = xcrun
 	endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,4 +49,4 @@ test_cov: test_c_kzg_4844_cov
 	@$(XCRUN) llvm-cov report ./test_c_kzg_4844 --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
 
 clean:
-	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata
+	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata *.html

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,11 @@ ifeq ($(OS),Windows_NT)
 	CFLAGS += -O2
 else
 	CFLAGS += -O2 -fPIC
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CCFLAGS += -D OSX
+		XCRUN = xcrun
+	endif
 endif
 
 CLANG_EXECUTABLE=clang
@@ -31,7 +36,16 @@ test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c Makefile
 	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) test_c_kzg_4844.o -L ../lib -lblst -o test_c_kzg_4844 $<
 
 test: test_c_kzg_4844
-		./test_c_kzg_4844
+	./test_c_kzg_4844
+
+test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c Makefile
+	@${CLANG_EXECUTABLE} -fprofile-instr-generate -fcoverage-mapping -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) -DUNIT_TESTS $(CFLAGS) -c c_kzg_4844.c -o test_c_kzg_4844.o
+	@${CLANG_EXECUTABLE} -fprofile-instr-generate -fcoverage-mapping -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) test_c_kzg_4844.o -L../lib -lblst -o test_c_kzg_4844 $<
+
+test_cov: test_c_kzg_4844_cov
+	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844
+	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
+	@$(XCRUN) llvm-cov report ./test_c_kzg_4844 --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
 
 clean:
-		rm -f  *.o test_c_kzg_4844
+	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata


### PR DESCRIPTION
* Generate coverage report for the tests.
* There is a generated html report available via CI artifact.
* For now, this doesn't fail if it's not 100% covered.
* You should be able to run `make test_cov` for a detailed view.