### PR TITLE
Remove duplicate p1_on_curve check

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -646,14 +646,13 @@ static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
 static C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b) {
     /* Convert the bytes to a p1 point */
     blst_p1_affine p1_affine;
+    /* The uncompress routine also checks that the point is on the curve */
     if (blst_p1_uncompress(&p1_affine, b->bytes) != BLST_SUCCESS)
         return C_KZG_BADARGS;
     blst_p1_from_affine(out, &p1_affine);
 
     /* The point at infinity is accepted! */
     if (blst_p1_is_inf(out)) return C_KZG_OK;
-    /* The point must be on the curve */
-    if (!blst_p1_on_curve(out)) return C_KZG_BADARGS;
     /* The point must be on the right subgroup */
     if (!blst_p1_in_g1(out)) return C_KZG_BADARGS;
 


### PR DESCRIPTION
[asn edit:] We probably don't need `blst_p1_on_curve()` since we are checking `blst_p1_uncompress()`'s retval. 

In reference to the comment below, this PR removes this check.

* https://github.com/ethereum/c-kzg-4844/pull/106#issuecomment-1411237332

Also, there's a test for this here:

https://github.com/ethereum/c-kzg-4844/blob/471245001daf2c3f4990351e600b0cb2c4d2a3ac/src/test_c_kzg_4844.c#L232-L240