### PR TITLE
Run clang-format on test code

### DIFF
--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  test:
+  test-ckzg:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/format-test.yml
+++ b/.github/workflows/format-test.yml
@@ -16,5 +16,6 @@ jobs:
           submodules: recursive
       - name: Check formatting
         run: |
+          cd src
           make format
           git diff --exit-code

--- a/.github/workflows/format-test.yml
+++ b/.github/workflows/format-test.yml
@@ -1,0 +1,20 @@
+name: Formatting tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Check formatting
+        run: |
+          make format
+          git diff --exit-code

--- a/.github/workflows/go-bindings-test.yml
+++ b/.github/workflows/go-bindings-test.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  test:
+  test-go-bindings:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ inc/blst.h*
 inc/blst_aux.h*
 .vscode/
 .idea/
-.clang-format
 *bindings/*/*.so
 *bindings/rust/target
 *bindings/csharp/*.exe

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: llvm
+IndentWidth: 4
+AllowAllParametersOfDeclarationOnNextLine: True
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: OnlyFirstIf

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -3,3 +3,8 @@ IndentWidth: 4
 AllowAllParametersOfDeclarationOnNextLine: True
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: OnlyFirstIf
+AlignAfterOpenBracket: BlockIndent
+AlignEscapedNewlines: DontAlign
+AlwaysBreakAfterDefinitionReturnType: None
+BinPackArguments: False
+BinPackParameters: False

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,3 +49,6 @@ test_cov: test_c_kzg_4844_cov
 
 clean:
 	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata *.html
+
+format:
+	clang-format -i --sort-includes test_c_kzg_4844.c

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -3,13 +3,12 @@
  */
 #define UNIT_TESTS
 
-#include "tinytest.h"
-#include "blst.h"
 #include "c_kzg_4844.h"
+#include "tinytest.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Globals
@@ -23,7 +22,7 @@ KZGSettings s;
 
 static void get_rand_bytes32(Bytes32 *out) {
     static uint64_t seed = 0;
-    blst_sha256(out->bytes, (uint8_t*)&seed, sizeof(seed));
+    blst_sha256(out->bytes, (uint8_t *)&seed, sizeof(seed));
     seed++;
 }
 
@@ -62,7 +61,7 @@ static void get_rand_g1_bytes(Bytes48 *out) {
 static void bytes32_from_hex(Bytes32 *out, const char *hex) {
     int matches;
     for (int i = 0; i < sizeof(Bytes32); i++) {
-        matches = sscanf(hex + i*2, "%2hhx", &out->bytes[i]);
+        matches = sscanf(hex + i * 2, "%2hhx", &out->bytes[i]);
         ASSERT_EQUALS(matches, 1);
     }
 }
@@ -70,7 +69,7 @@ static void bytes32_from_hex(Bytes32 *out, const char *hex) {
 static void bytes48_from_hex(Bytes48 *out, const char *hex) {
     int matches;
     for (int i = 0; i < sizeof(Bytes48); i++) {
-        matches = sscanf(hex + i*2, "%2hhx", &out->bytes[i]);
+        matches = sscanf(hex + i * 2, "%2hhx", &out->bytes[i]);
         ASSERT_EQUALS(matches, 1);
     }
 }
@@ -97,7 +96,8 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
      *
      * int(BLS_MODULUS - 1).to_bytes(32, 'little').hex()
      */
-    bytes32_from_hex(&b, "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+    bytes32_from_hex(
+        &b, "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -117,7 +117,8 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
      *
      * int(BLS_MODULUS).to_bytes(32, 'little').hex()
      */
-    bytes32_from_hex(&b, "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+    bytes32_from_hex(
+        &b, "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -137,7 +138,8 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
      *
      * int(BLS_MODULUS + 1).to_bytes(32, 'little').hex()
      */
-    bytes32_from_hex(&b, "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+    bytes32_from_hex(
+        &b, "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -162,7 +164,9 @@ static void test_blob_to_kzg_commitment__succeeds_point_at_infinity(void) {
     /*
      * The commitment should be the serialized point at infinity.
      */
-    bytes48_from_hex(&point_at_infinity, "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    bytes48_from_hex(&point_at_infinity,
+                     "c00000000000000000000000000000000000000000000000000000000"
+                     "000000000000000000000000000000000000000");
     diff = memcmp(c.bytes, point_at_infinity.bytes, BYTES_PER_COMMITMENT);
     ASSERT_EQUALS(diff, 0);
 }
@@ -185,7 +189,9 @@ static void test_blob_to_kzg_commitment__succeeds_consistent_commitment(void) {
      * We expect the commitment to match. If it doesn't
      * match, something important has changed.
      */
-    bytes48_from_hex(&expected_commitment, "af19e460169c57959c04786c958e01f984c195bc56e99b04c07e0c9747e5dfa566a4771b8b138cd8eed67efa81165663");
+    bytes48_from_hex(&expected_commitment,
+                     "af19e460169c57959c04786c958e01f984c195bc56e99b04c07e0c974"
+                     "7e5dfa566a4771b8b138cd8eed67efa81165663");
     diff = memcmp(c.bytes, expected_commitment.bytes, BYTES_PER_COMMITMENT);
     ASSERT_EQUALS(diff, 0);
 }
@@ -214,7 +220,8 @@ static void test_validate_kzg_g1__succeeds_correct_point(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a");
+    bytes48_from_hex(&b, "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368"
+                         "dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
@@ -224,7 +231,8 @@ static void test_validate_kzg_g1__fails_not_in_g1(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef01234"
+                         "56789abcdef0123456789abcdef0123456789abcdef");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -234,7 +242,8 @@ static void test_validate_kzg_g1__fails_not_in_curve(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde0");
+    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef01234"
+                         "56789abcdef0123456789abcdef0123456789abcde0");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -244,7 +253,8 @@ static void test_validate_kzg_g1__fails_x_equal_to_modulus(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
+    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d"
+                         "2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -254,7 +264,8 @@ static void test_validate_kzg_g1__fails_x_greater_than_modulus(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac");
+    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d"
+                         "2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -264,7 +275,8 @@ static void test_validate_kzg_g1__succeeds_infinity_with_true_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    bytes48_from_hex(&b, "c0000000000000000000000000000000000000000000000000000"
+                         "0000000000000000000000000000000000000000000");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
@@ -274,7 +286,8 @@ static void test_validate_kzg_g1__fails_infinity_with_true_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    bytes48_from_hex(&b, "c0100000000000000000000000000000000000000000000000000"
+                         "0000000000000000000000000000000000000000000");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -284,7 +297,8 @@ static void test_validate_kzg_g1__fails_infinity_with_false_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    bytes48_from_hex(&b, "80000000000000000000000000000000000000000000000000000"
+                         "0000000000000000000000000000000000000000000");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -294,7 +308,8 @@ static void test_validate_kzg_g1__fails_with_wrong_c_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(&b, "0123456789abcdef0123456789abcdef0123456789abcdef01234"
+                         "56789abcdef0123456789abcdef0123456789abcdef");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -304,7 +319,8 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_x_nonzero(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(&b, "c123456789abcdef0123456789abcdef0123456789abcdef01234"
+                         "56789abcdef0123456789abcdef0123456789abcdef");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -314,7 +330,8 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    bytes48_from_hex(&b, "e0000000000000000000000000000000000000000000000000000"
+                         "0000000000000000000000000000000000000000000");
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -88,7 +88,7 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
     Blob blob;
-    Bytes32 b;
+    Bytes32 field_element;
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -97,11 +97,12 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
      * int(BLS_MODULUS - 1).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+        &field_element,
+        "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
     );
 
     memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
+    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, &blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
@@ -110,7 +111,7 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
     Blob blob;
-    Bytes32 b;
+    Bytes32 field_element;
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -119,11 +120,12 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
      * int(BLS_MODULUS).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+        &field_element,
+        "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
     );
 
     memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
+    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, &blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -132,7 +134,7 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
     Blob blob;
-    Bytes32 b;
+    Bytes32 field_element;
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -141,11 +143,12 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
      * int(BLS_MODULUS + 1).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+        &field_element,
+        "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
     );
 
     memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
+    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, &blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -224,155 +227,155 @@ static void test_validate_kzg_g1__succeeds_round_trip(void) {
 
 static void test_validate_kzg_g1__succeeds_correct_point(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e264"
         "4f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
 
 static void test_validate_kzg_g1__fails_not_in_g1(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "8123456789abcdef0123456789abcdef0123456789abcdef"
         "0123456789abcdef0123456789abcdef0123456789abcdef"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_not_in_curve(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "8123456789abcdef0123456789abcdef0123456789abcdef"
         "0123456789abcdef0123456789abcdef0123456789abcde0"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_x_equal_to_modulus(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf"
         "6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_x_greater_than_modulus(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf"
         "6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__succeeds_infinity_with_true_b_flag(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "c00000000000000000000000000000000000000000000000"
         "000000000000000000000000000000000000000000000000"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
 
 static void test_validate_kzg_g1__fails_infinity_with_true_b_flag(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "c01000000000000000000000000000000000000000000000"
         "000000000000000000000000000000000000000000000000"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_infinity_with_false_b_flag(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "800000000000000000000000000000000000000000000000"
         "000000000000000000000000000000000000000000000000"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_with_wrong_c_flag(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "0123456789abcdef0123456789abcdef0123456789abcdef"
         "0123456789abcdef0123456789abcdef0123456789abcdef"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_with_b_flag_and_x_nonzero(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "c123456789abcdef0123456789abcdef0123456789abcdef"
         "0123456789abcdef0123456789abcdef0123456789abcdef"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true(void) {
     C_KZG_RET ret;
-    Bytes48 b;
+    Bytes48 g1_bytes;
     g1_t g1;
 
     bytes48_from_hex(
-        &b,
+        &g1_bytes,
         "e00000000000000000000000000000000000000000000000"
         "000000000000000000000000000000000000000000000000"
     );
-    ret = validate_kzg_g1(&g1, &b);
+    ret = validate_kzg_g1(&g1, &g1_bytes);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -97,7 +97,8 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
      * int(BLS_MODULUS - 1).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+        &b, "00000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+    );
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -118,7 +119,8 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
      * int(BLS_MODULUS).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+        &b, "01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+    );
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -139,7 +141,8 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
      * int(BLS_MODULUS + 1).to_bytes(32, 'little').hex()
      */
     bytes32_from_hex(
-        &b, "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73");
+        &b, "02000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+    );
 
     memset(&blob, 0, sizeof(blob));
     memcpy(blob.bytes, b.bytes, BYTES_PER_FIELD_ELEMENT);
@@ -164,9 +167,11 @@ static void test_blob_to_kzg_commitment__succeeds_point_at_infinity(void) {
     /*
      * The commitment should be the serialized point at infinity.
      */
-    bytes48_from_hex(&point_at_infinity,
-                     "c00000000000000000000000000000000000000000000000000000000"
-                     "000000000000000000000000000000000000000");
+    bytes48_from_hex(
+        &point_at_infinity,
+        "c00000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000"
+    );
     diff = memcmp(c.bytes, point_at_infinity.bytes, BYTES_PER_COMMITMENT);
     ASSERT_EQUALS(diff, 0);
 }
@@ -189,9 +194,11 @@ static void test_blob_to_kzg_commitment__succeeds_consistent_commitment(void) {
      * We expect the commitment to match. If it doesn't
      * match, something important has changed.
      */
-    bytes48_from_hex(&expected_commitment,
-                     "af19e460169c57959c04786c958e01f984c195bc56e99b04c07e0c974"
-                     "7e5dfa566a4771b8b138cd8eed67efa81165663");
+    bytes48_from_hex(
+        &expected_commitment,
+        "af19e460169c57959c04786c958e01f984c195bc56e99b04"
+        "c07e0c9747e5dfa566a4771b8b138cd8eed67efa81165663"
+    );
     diff = memcmp(c.bytes, expected_commitment.bytes, BYTES_PER_COMMITMENT);
     ASSERT_EQUALS(diff, 0);
 }
@@ -220,8 +227,11 @@ static void test_validate_kzg_g1__succeeds_correct_point(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368"
-                         "dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a");
+    bytes48_from_hex(
+        &b,
+        "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e264"
+        "4f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
@@ -231,8 +241,11 @@ static void test_validate_kzg_g1__fails_not_in_g1(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef01234"
-                         "56789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(
+        &b,
+        "8123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -242,8 +255,11 @@ static void test_validate_kzg_g1__fails_not_in_curve(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "8123456789abcdef0123456789abcdef0123456789abcdef01234"
-                         "56789abcdef0123456789abcdef0123456789abcde0");
+    bytes48_from_hex(
+        &b,
+        "8123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcde0"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -253,8 +269,11 @@ static void test_validate_kzg_g1__fails_x_equal_to_modulus(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d"
-                         "2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab");
+    bytes48_from_hex(
+        &b,
+        "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf"
+        "6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -264,8 +283,11 @@ static void test_validate_kzg_g1__fails_x_greater_than_modulus(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d"
-                         "2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac");
+    bytes48_from_hex(
+        &b,
+        "9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf"
+        "6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -275,8 +297,11 @@ static void test_validate_kzg_g1__succeeds_infinity_with_true_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c0000000000000000000000000000000000000000000000000000"
-                         "0000000000000000000000000000000000000000000");
+    bytes48_from_hex(
+        &b,
+        "c00000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
@@ -286,8 +311,11 @@ static void test_validate_kzg_g1__fails_infinity_with_true_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c0100000000000000000000000000000000000000000000000000"
-                         "0000000000000000000000000000000000000000000");
+    bytes48_from_hex(
+        &b,
+        "c01000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -297,8 +325,11 @@ static void test_validate_kzg_g1__fails_infinity_with_false_b_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "80000000000000000000000000000000000000000000000000000"
-                         "0000000000000000000000000000000000000000000");
+    bytes48_from_hex(
+        &b,
+        "800000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -308,8 +339,11 @@ static void test_validate_kzg_g1__fails_with_wrong_c_flag(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "0123456789abcdef0123456789abcdef0123456789abcdef01234"
-                         "56789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(
+        &b,
+        "0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -319,8 +353,11 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_x_nonzero(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "c123456789abcdef0123456789abcdef0123456789abcdef01234"
-                         "56789abcdef0123456789abcdef0123456789abcdef");
+    bytes48_from_hex(
+        &b,
+        "c123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
@@ -330,8 +367,11 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true(void) {
     Bytes48 b;
     g1_t g1;
 
-    bytes48_from_hex(&b, "e0000000000000000000000000000000000000000000000000000"
-                         "0000000000000000000000000000000000000000000");
+    bytes48_from_hex(
+        &b,
+        "e00000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000"
+    );
     ret = validate_kzg_g1(&g1, &b);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }


### PR DESCRIPTION
I'm wanting to use `clang-format` on all of the C code eventually, but I thought it would be good to start with the test code. The formatting configuration is based on `llvm` with minor changes.

* Add new `make format` target to the Makefile.
* Add CI check that runs `make format` and checks if there are differences.
* Update rule name for other checks so it's more descriptive than "test."
* Remove `blst.h` import because it's not necessary.
* Fix formatting (mostly lines were too long) in the test code.

Edit: Maybe controversial, put the `);` on a new line when a function calls arguments overflow to another line. This is my preference, but its not a hill I'm going to die on.