### PR TITLE
Format the implementation C files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,4 +51,4 @@ clean:
 	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata *.html
 
 format:
-	clang-format -i --sort-includes test_c_kzg_4844.c
+	clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c


### PR DESCRIPTION
Sorry, this is a lot. This PR formats the main C files (`c_kzg_4844.c` & `c_kzg_4844.h`).

* Add section headers to the header file.
* Move `FIAT_SHAMIR_PROTOCOL_DOMAIN` to the C file.
  * This is only used internally.
* Add documentation for the types missing it.
* Shorten doc for `C_KZG_ERROR` just so it looks better.
  * This still isn't used anywhere by the way.
*  Add doxygen `@file` header to the main C file.
  * So the functions are visible in doxygen.
* Disable clang formatting for constants section.
  * These aren't very pretty from the auto-formatter.
* Remove all of the duplicative `@retval` docs for `C_KZG_RET`.
* Add `[in]` and `[out]` to parameters missing them.
* Add extra `*` to some of the trusted setup funcs to make them doxygen.
* Shorten a whole bunch of comments. 