### PR TITLE
Fix python bindings on macOS

### DIFF
--- a/.github/workflows/python-bindings-test.yml
+++ b/.github/workflows/python-bindings-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Python bindings
         run: |
           cd bindings/python
-          make ckzg.so
+          make install
       - name: Test
         run: |
           cd bindings/python

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -4,14 +4,16 @@ INCLUDE_PY = $(shell python3 -c 'import sysconfig; print(sysconfig.get_config_va
 FIELD_ELEMENTS_PER_BLOB?=4096
 
 .PHONY: all
+all: install test ecc_test
 
-all: test ecc_test
+.PHONY: test
+install: setup.py ckzg.c
+	python3 setup.py install
 
-test: tests.py ckzg.so
+.PHONY: test
+test: tests.py
 	python3 $<
 
-ecc_test: py_ecc_tests.py ckzg.so
+.PHONY: ecc_test
+ecc_test: py_ecc_tests.py
 	python3 $<
-
-ckzg.so: ckzg.c ../../src/c_kzg_4844.o ../../lib/libblst.a
-	clang -O -Wall -shared -fPIC -Wl,-Bsymbolic -I${INCLUDE_PY} ${addprefix -I,${INCLUDE_DIRS}} -DFIELD_ELEMENTS_PER_BLOB=${FIELD_ELEMENTS_PER_BLOB} -o $@ $^

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 all: install test ecc_test
 
-.PHONY: test
+.PHONY: install
 install: setup.py ckzg.c
 	python3 setup.py install
 

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,8 +1,3 @@
-INCLUDE_DIRS = .. ../../src ../../inc
-INCLUDE_PY = $(shell python3 -c 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))')
-
-FIELD_ELEMENTS_PER_BLOB?=4096
-
 .PHONY: all
 all: install test ecc_test
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,0 +1,18 @@
+from distutils.core import setup, Extension
+
+def main():
+    setup(
+        name="ckzg",
+        version="1.0.0",
+        description="Python interface for C-KZG-4844",
+        ext_modules=[
+            Extension(
+                "ckzg",
+                sources=["ckzg.c", "../../src/c_kzg_4844.c"],
+                include_dirs=['../../inc'],
+                define_macros=[('FIELD_ELEMENTS_PER_BLOB', '4096')],
+                library_dirs=['../../lib'],
+                libraries=['blst'])])
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -9,10 +9,10 @@ def main():
             Extension(
                 "ckzg",
                 sources=["ckzg.c", "../../src/c_kzg_4844.c"],
-                include_dirs=['../../inc'],
-                define_macros=[('FIELD_ELEMENTS_PER_BLOB', '4096')],
-                library_dirs=['../../lib'],
-                libraries=['blst'])])
+                include_dirs=["../../inc", "../../src"],
+                define_macros=[("FIELD_ELEMENTS_PER_BLOB", "4096")],
+                library_dirs=["../../lib"],
+                libraries=["blst"])])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This works on Linux & macOS. Ran into issues removing the `-Bsymbolic` flag and linking the Python library.

I was able to get things working by making my own `distutils` setup file.
 
Fixes #81.