### PR TITLE
Cleanup the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test_c_kzg_4844
+test_c_kzg_4844_cov
 coverage.html
 *.profraw
 *.profdata

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -9,7 +9,7 @@ clean:
 	rm -f *.o
 
 build: kzg.cxx kzg.ts package.json binding.gyp Makefile
-	cd ../../src; make lib
+	cd ../../src && make c_kzg_4844.o && cp c_kzg_4844.o ../bindings/node.js
 	yarn install
 	yarn node-gyp rebuild
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ CC ?= clang
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
 #
-# The base compiler flags. Can be added on command line.
+# The base compiler flags. More can be added on command line.
 #
 CFLAGS += -I../inc
 CFLAGS += -Wall -Wextra -Werror -O2

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,40 +47,39 @@ endif
 all: c_kzg_4844.o
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $<
+	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	$(CC) $(CFLAGS) -o $@ $< $(BLST) 
+	@$(CC) $(CFLAGS) -o $@ $< $(BLST) 
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
+	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
 
 .PHONY: blst
 blst:
-	cd ../blst; \
+	@cd ../blst && \
 	./build.sh && \
 	cp libblst.a ../lib && \
 	cp bindings/*.h ../inc
 
 .PHONY: test
 test: test_c_kzg_4844
-	./test_c_kzg_4844
+	@./test_c_kzg_4844
 
 .PHONY: test_cov
 test_cov: test_c_kzg_4844_cov
-	LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844_cov
-	$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
-	$(XCRUN) llvm-cov show ./test_c_kzg_4844_cov \
-            --instr-profile=ckzg.profdata --format=html \
-            c_kzg_4844.c > coverage.html
-	$(XCRUN) llvm-cov report ./test_c_kzg_4844_cov \
-            --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
+	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844_cov
+	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
+	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \
+	    $< c_kzg_4844.c > coverage.html
+	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
+	    --show-functions $< c_kzg_4844.c
 
 .PHONY: clean
 clean:
-	rm -f  *.o *.profraw *.profdata *.html test_c_kzg_4844 \
-            test_c_kzg_4844_cov
+	@rm -f *.o *.profraw *.profdata *.html \
+	    test_c_kzg_4844 test_c_kzg_4844_cov
 
 .PHONY: format
 format:
-	clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c
+	@clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,54 +1,75 @@
-INCLUDE_DIRS = ../inc
+###############################################################################
+# Configuration Options
+###############################################################################
 
-ifeq ($(OS),Windows_NT)
-	CFLAGS += -O2
-else
-	CFLAGS += -O2 -fPIC
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
-		XCRUN = xcrun
-	endif
-endif
-
-CLANG_EXECUTABLE=clang
-BLST_BUILD_SCRIPT=./build.sh
+CC=clang
 FIELD_ELEMENTS_PER_BLOB?=4096
 
-all: c_kzg_4844.o lib
+#
+# Gather the compiler flags.
+#
+CFLAGS += -I../inc
+CFLAGS += -Wall -Wextra -Werror -O2
+CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 
-# If you change FIELD_ELEMENTS_PER_BLOB, remember to rm c_kzg_4844.o and make again
-c_kzg_4844.o: c_kzg_4844.c Makefile
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) -c $<
+#
+# Compiler flags for specific actions.
+#
+BLST = -L../lib -lblst
+TEST = -DUNIT_TESTS
+COVERAGE = -fprofile-instr-generate -fcoverage-mapping
 
+#
+# Platform specific options.
+#
+ifneq ($(OS),Windows_NT)
+    CFLAGS += -fPIC
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+        XCRUN = xcrun
+    endif
+endif
+
+###############################################################################
+# Makefile Rules
+###############################################################################
+
+all: c_kzg_4844.o
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
+
+test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
+	$(CC) $(CFLAGS) $(BLST) $(TEST) -o $@ $^
+
+test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
+	$(CC) $(CFLAGS) $(BLST) $(COVERAGE) $(TEST) -o $@ $^
+
+.PHONY: blst
 blst:
 	cd ../blst; \
-	${BLST_BUILD_SCRIPT} && \
+	./build.sh && \
 	cp libblst.a ../lib && \
 	cp bindings/*.h ../inc
 
-# Make sure c_kzg_4844.o is built and copy it for the NodeJS bindings
-lib: c_kzg_4844.o Makefile
-	cp *.o ../bindings/node.js
-
-test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c Makefile
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) -DUNIT_TESTS $(CFLAGS) -c c_kzg_4844.c -o test_c_kzg_4844.o
-	${CLANG_EXECUTABLE} -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) test_c_kzg_4844.o -L ../lib -lblst -o test_c_kzg_4844 $<
-
+.PHONY: test
 test: test_c_kzg_4844
 	./test_c_kzg_4844
 
-test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c Makefile
-	@${CLANG_EXECUTABLE} -fprofile-instr-generate -fcoverage-mapping -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) -DUNIT_TESTS $(CFLAGS) -c c_kzg_4844.c -o test_c_kzg_4844.o
-	@${CLANG_EXECUTABLE} -fprofile-instr-generate -fcoverage-mapping -Wall -I$(INCLUDE_DIRS) -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB) $(CFLAGS) test_c_kzg_4844.o -L../lib -lblst -o test_c_kzg_4844 $<
-
+.PHONY: test_cov
 test_cov: test_c_kzg_4844_cov
-	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844
-	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
-	@$(XCRUN) llvm-cov show ./test_c_kzg_4844 --instr-profile=ckzg.profdata --format=html c_kzg_4844.c > coverage.html
-	@$(XCRUN) llvm-cov report ./test_c_kzg_4844 --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
+	LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844_cov
+	$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
+	$(XCRUN) llvm-cov show ./test_c_kzg_4844_cov \
+            --instr-profile=ckzg.profdata --format=html \
+            c_kzg_4844.c > coverage.html
+	$(XCRUN) llvm-cov report ./test_c_kzg_4844_cov \
+            --instr-profile=ckzg.profdata --show-functions c_kzg_4844.c
 
+.PHONY: clean
 clean:
 	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata *.html
 
+.PHONY: format
 format:
 	clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,9 +3,9 @@
 ###############################################################################
 
 #
-# By default, we use clang. GCC should work too though.
+# We use clang. Some versions of GCC report missing-braces warnings.
 #
-CC ?= clang
+CC = clang
 
 #
 # By default, this is set to the mainnet value.

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,7 +78,8 @@ test_cov: test_c_kzg_4844_cov
 
 .PHONY: clean
 clean:
-	rm -f  *.o test_c_kzg_4844 test_c_kzg_4844_cov *.profraw *.profdata *.html
+	rm -f  *.o *.profraw *.profdata *.html test_c_kzg_4844 \
+            test_c_kzg_4844_cov
 
 .PHONY: format
 format:

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,15 @@
 # Configuration Options
 ###############################################################################
 
-CC=clang
-FIELD_ELEMENTS_PER_BLOB?=4096
+#
+# By default, we use clang. GCC should work too though.
+#
+CC = clang
+
+#
+# By default, this is set to the mainnet value.
+#
+FIELD_ELEMENTS_PER_BLOB ?= 4096
 
 #
 # Gather the compiler flags.
@@ -13,10 +20,13 @@ CFLAGS += -Wall -Wextra -Werror -O2
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 
 #
-# Compiler flags for specific actions.
+# Compiler flags for including blst. Must be put after the module.
 #
 BLST = -L../lib -lblst
-TEST = -DUNIT_TESTS
+
+#
+# Compiler flags for generating coverage data.
+#
 COVERAGE = -fprofile-instr-generate -fcoverage-mapping
 
 #
@@ -40,10 +50,10 @@ all: c_kzg_4844.o
 	$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	$(CC) $(CFLAGS) $(BLST) $(TEST) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $< $(BLST) 
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	$(CC) $(CFLAGS) $(BLST) $(COVERAGE) $(TEST) -o $@ $^
+	$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
 
 .PHONY: blst
 blst:
@@ -68,7 +78,7 @@ test_cov: test_c_kzg_4844_cov
 
 .PHONY: clean
 clean:
-	rm -f  *.o test_c_kzg_4844 *.profraw *.profdata *.html
+	rm -f  *.o test_c_kzg_4844 test_c_kzg_4844_cov *.profraw *.profdata *.html
 
 .PHONY: format
 format:

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 #
 # By default, we use clang. GCC should work too though.
 #
-CC = clang
+CC ?= clang
 
 #
 # By default, this is set to the mainnet value.
@@ -13,7 +13,7 @@ CC = clang
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
 #
-# Gather the compiler flags.
+# The base compiler flags. Can be added on command line.
 #
 CFLAGS += -I../inc
 CFLAGS += -Wall -Wextra -Werror -O2

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -810,7 +810,7 @@ static C_KZG_RET compute_challenges(
  * We do the second of these to save memory here.
  */
 static C_KZG_RET
-g1_lincomb(g1_t *out, const g1_t *p, const fr_t *coeffs, const uint64_t len) {
+g1_lincomb(g1_t *out, const g1_t *p, const fr_t *coeffs, uint64_t len) {
     C_KZG_RET ret = C_KZG_MALLOC;
     void *scratch = NULL;
     blst_p1_affine *p_affine = NULL;
@@ -839,7 +839,7 @@ g1_lincomb(g1_t *out, const g1_t *p, const fr_t *coeffs, const uint64_t len) {
         blst_p1s_to_affine(p_affine, p_arg, len);
 
         // Transform the field elements to 256-bit scalars
-        for (int i = 0; i < len; i++) {
+        for (uint64_t i = 0; i < len; i++) {
             blst_scalar_from_fr(&scalars[i], &coeffs[i]);
         }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -32,12 +32,6 @@
 #define CHECK(cond) \
     if (!(cond)) return C_KZG_BADARGS
 
-#ifdef UNIT_TESTS
-#define STATIC
-#else /* !defined(UNIT_TESTS) */
-#define STATIC static
-#endif /* defined(UNIT_TESTS) */
-
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
@@ -210,7 +204,7 @@ static C_KZG_RET new_fr_array(fr_t **x, size_t n) {
  *
  * @return The index of the highest set bit
  */
-STATIC int log_2_byte(byte b) {
+static int log_2_byte(byte b) {
     if (b < 2) return 0;
     if (b < 4) return 1;
     if (b < 8) return 2;
@@ -476,7 +470,7 @@ static int log2_pow2(uint32_t n) {
  * @param[out] out A 48-byte array to store the serialized G1 element
  * @param[in]  in  The G1 element to be serialized
  */
-STATIC void bytes_from_g1(Bytes48 *out, const g1_t *in) {
+static void bytes_from_g1(Bytes48 *out, const g1_t *in) {
     blst_p1_compress(out->bytes, in);
 }
 
@@ -486,7 +480,7 @@ STATIC void bytes_from_g1(Bytes48 *out, const g1_t *in) {
  * @param[out] out A 32-byte array to store the serialized field element
  * @param[in] in The field element to be serialized
  */
-STATIC void bytes_from_bls_field(Bytes32 *out, const fr_t *in) {
+static void bytes_from_bls_field(Bytes32 *out, const fr_t *in) {
     blst_scalar_from_fr((blst_scalar *)out->bytes, in);
 }
 
@@ -550,7 +544,7 @@ static bool is_power_of_two(uint64_t n) {
  * @param[in] a The integer to be reversed
  * @return An integer with the bits of @p a reversed
  */
-STATIC uint32_t reverse_bits(uint32_t a) {
+static uint32_t reverse_bits(uint32_t a) {
     return rev_4byte(a);
 }
 
@@ -598,7 +592,7 @@ bit_reversal_permutation(void *values, size_t size, uint64_t n) {
  * @param[out] out   The field element to store the result
  * @param[in]  bytes A 32-byte array containing the input
  */
-STATIC void hash_to_bls_field(fr_t *out, const Bytes32 *b) {
+static void hash_to_bls_field(fr_t *out, const Bytes32 *b) {
     blst_scalar tmp;
     blst_scalar_from_lendian(&tmp, b->bytes);
     blst_fr_from_scalar(out, &tmp);
@@ -614,7 +608,7 @@ STATIC void hash_to_bls_field(fr_t *out, const Bytes32 *b) {
  * @retval C_KZG_OK      Deserialization successful
  * @retval C_KZG_BADARGS Input was not a valid scalar field element
  */
-STATIC C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
+static C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
     blst_scalar tmp;
     blst_scalar_from_lendian(&tmp, b->bytes);
     if (!blst_scalar_fr_check(&tmp)) return C_KZG_BADARGS;
@@ -635,7 +629,7 @@ STATIC C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
  * @retval C_KZG_OK      Deserialization successful
  * @retval C_KZG_BADARGS Invalid input bytes
  */
-STATIC C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b) {
+static C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b) {
     /* Convert the bytes to a p1 point */
     blst_p1_affine p1_affine;
     if (blst_p1_uncompress(&p1_affine, b->bytes) != BLST_SUCCESS)
@@ -690,7 +684,7 @@ static C_KZG_RET bytes_to_kzg_proof(g1_t *out, const Bytes48 *b) {
  * @retval C_KZG_OK      Deserialization successful
  * @retval C_KZG_BADARGS Invalid input bytes
  */
-STATIC C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
+static C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
     C_KZG_RET ret;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         ret = bytes_to_bls_field(
@@ -702,7 +696,7 @@ STATIC C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
 }
 
 /* Forward function definition */
-STATIC void compute_powers(fr_t *out, fr_t *x, uint64_t n);
+static void compute_powers(fr_t *out, fr_t *x, uint64_t n);
 
 /**
  * Return the Fiat-Shamir challenges required by the rest of the protocol.
@@ -896,7 +890,7 @@ static void poly_lincomb(
  * @param[in]  x   The field element to raise to powers
  * @param[in]  n   The number of powers to compute
  */
-STATIC void compute_powers(fr_t *out, fr_t *x, uint64_t n) {
+static void compute_powers(fr_t *out, fr_t *x, uint64_t n) {
     fr_t current_power = FR_ONE;
     for (uint64_t i = 0; i < n; i++) {
         out[i] = current_power;
@@ -919,7 +913,7 @@ STATIC void compute_powers(fr_t *out, fr_t *x, uint64_t n) {
  * @retval C_KZG_OK Evaluation successful
  * @retval C_KZG_MALLOC Memory allocation failed
  */
-STATIC C_KZG_RET evaluate_polynomial_in_evaluation_form(
+static C_KZG_RET evaluate_polynomial_in_evaluation_form(
     fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s
 ) {
     C_KZG_RET ret;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -177,23 +177,4 @@ C_KZG_RET compute_kzg_proof(
     const KZGSettings *s
 );
 
-#ifdef UNIT_TESTS
-void hash_to_bls_field(fr_t *out, const Bytes32 *b);
-void bytes_from_bls_field(Bytes32 *out, const fr_t *in);
-C_KZG_RET validate_kzg_g1(g1_t *out, const Bytes48 *b);
-void bytes_from_g1(Bytes48 *out, const g1_t *in);
-C_KZG_RET evaluate_polynomial_in_evaluation_form(
-    fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s
-);
-C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob);
-C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b);
-uint32_t reverse_bits(uint32_t a);
-void compute_powers(fr_t *out, fr_t *x, uint64_t n);
-int log_2_byte(byte b);
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
 #endif /* C_KZG_4844_H */

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -177,4 +177,8 @@ C_KZG_RET compute_kzg_proof(
     const KZGSettings *s
 );
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* C_KZG_4844_H */

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1,8 +1,6 @@
 /*
  * This file contains unit tests for C-KZG-4844.
  */
-#define UNIT_TESTS
-
 #include "c_kzg_4844.h"
 #include "tinytest.h"
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -58,7 +58,7 @@ static void get_rand_g1_bytes(Bytes48 *out) {
 
 static void bytes32_from_hex(Bytes32 *out, const char *hex) {
     int matches;
-    for (int i = 0; i < sizeof(Bytes32); i++) {
+    for (size_t i = 0; i < sizeof(Bytes32); i++) {
         matches = sscanf(hex + i * 2, "%2hhx", &out->bytes[i]);
         ASSERT_EQUALS(matches, 1);
     }
@@ -66,7 +66,7 @@ static void bytes32_from_hex(Bytes32 *out, const char *hex) {
 
 static void bytes48_from_hex(Bytes48 *out, const char *hex) {
     int matches;
-    for (int i = 0; i < sizeof(Bytes48); i++) {
+    for (size_t i = 0; i < sizeof(Bytes48); i++) {
         matches = sscanf(hex + i * 2, "%2hhx", &out->bytes[i]);
         ASSERT_EQUALS(matches, 1);
     }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1,7 +1,7 @@
 /*
  * This file contains unit tests for C-KZG-4844.
  */
-#include "c_kzg_4844.h"
+#include "c_kzg_4844.c"
 #include "tinytest.h"
 
 #include <assert.h>


### PR DESCRIPTION
Okay, so the main purpose of this PR was to cleanup the Makefile but it evolved a bit:

* Split the Makefile into two sections (configuration options & rules).
* Do my best to simplify all of the Makefile rules.
* All lines are fewer than 80 chars in width.
* Added `test_c_kzg_4844_cov` to the clean rule.
* Remove the `lib` rule that was only used for node.js bindings.
* Don't echo the commands being run (personal preference).
* Rid ourselves of the `UNIT_TESTS` macro & section of exported test functions.
  * We no longer need to differentiate between `STATIC` and `static` now too.
* Add `-Wextra -Werror` to the compiler flags.
  * I noticed a warning for this while fixing the python bindings for macOS.
  * Fix a few `sign-compare` warnings, like this:

```
../../src/c_kzg_4844.c:825:27: warning: comparison of integers of different signs: 'int' and 'const uint64_t' (aka 'const unsigned long long') [-Wsign-compare]
        for (int i = 0; i < len; i++) {
                        ~ ^ ~~~
1 warning generated.
```

PS: I tried this before but ran into issues on Linux. The issue was the blst library needed to be specified after the source files. See this link for a little more information. What a dumb issue 🤦
* https://stackoverflow.com/a/2487723