### PR TITLE
Add profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 test_c_kzg_4844
-test_c_kzg_4844_cov
+test_c_kzg_4844_*
 coverage.html
 *.profraw
 *.profdata
+*.prof
+*.pdf
 *.o
 *.s
 *.a

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -42,6 +42,10 @@ var (
 	settings = C.KZGSettings{}
 )
 
+///////////////////////////////////////////////////////////////////////////////
+// Public functions
+///////////////////////////////////////////////////////////////////////////////
+
 /*
 LoadTrustedSetup is the binding for:
 
@@ -230,4 +234,25 @@ func VerifyAggregateKZGProof(blobs []Blob, commitmentsBytes []Bytes48, aggregate
 		(*C.Bytes48)(unsafe.Pointer(&aggregatedProofBytes)),
 		&settings)
 	return bool(result), CKzgRet(ret)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Private functions
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+sha256 is the binding for:
+
+	void blst_sha256(
+		byte out[32],
+		const byte *msg,
+		size_t msg_len);
+*/
+func sha256(msg []byte) Bytes32 {
+	var out Bytes32
+	C.blst_sha256(
+		(*C.byte)(unsafe.Pointer(&out)),
+		*(**C.byte)(unsafe.Pointer(&msg)),
+		(C.size_t)(len(msg)))
+	return out
 }

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -226,8 +226,8 @@ func Benchmark(b *testing.B) {
 	///////////////////////////////////////////////////////////////////////////
 
 	for i := 2; i <= 20; i += 2 {
-		var bytes = make([]byte, 1<<i)
-		numBytes := int64(1 << i)
+		var numBytes = int64(1 << i)
+		var bytes = make([]byte, numBytes)
 		b.Run(fmt.Sprintf("sha256(size=%v)", HumanBytes(numBytes)), func(b *testing.B) {
 			b.SetBytes(numBytes)
 			for n := 0; n < b.N; n++ {

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -160,6 +160,11 @@ func Benchmark(b *testing.B) {
 	y := Bytes32{4, 5, 6}
 	trustedProof, _ := ComputeAggregateKZGProof(blobs[:1])
 	proof := Bytes48(trustedProof)
+	randBytes := blobs[0][:]
+
+	///////////////////////////////////////////////////////////////////////////
+	// Public functions
+	///////////////////////////////////////////////////////////////////////////
 
 	b.Run("BlobToKZGCommitment", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -199,4 +204,14 @@ func Benchmark(b *testing.B) {
 			}
 		})
 	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// Private functions
+	///////////////////////////////////////////////////////////////////////////
+
+	b.Run("sha256", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			sha256(randBytes)
+		}
+	})
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,7 +87,7 @@ test_cov: test_c_kzg_4844_cov
 	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
 	    --show-functions $< c_kzg_4844.c
 
-# Don't make it phony. It only needs to be run once.
+.PHONY: run_profiler
 run_profiler: test_c_kzg_4844_prof
 	@$(PROFILER_OPTS) ./$<
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,10 +59,10 @@ all: c_kzg_4844.o
 	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(BLST) 
+	@$(CC) $(CFLAGS) -o $@ $< $(BLST)
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
+	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST)
 
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
@@ -100,7 +100,9 @@ profile_%: run_profiler
 profile: \
 	profile_blob_to_kzg_commitment \
 	profile_verify_kzg_proof \
-	profile_verify_aggregate_kzg_proof
+	profile_verify_aggregate_kzg_proof \
+	profile_compute_kzg_proof \
+	profile_compute_aggregate_kzg_proof
 
 .PHONY: clean
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,8 +94,8 @@ run_profiler: test_c_kzg_4844_prof
 .PHONY: profile_%
 profile_%: run_profiler
 	@echo Profiling $*...
-	@pprof --pdf --nodefraction=0.0001 --edgefraction=0.0001 \
-	    --focus=$* ./test_c_kzg_4844_prof $*.prof > $*.pdf
+	@pprof --pdf --nodefraction=0.00001 --edgefraction=0.00001 \
+	    ./test_c_kzg_4844_prof $*.prof > $*.pdf
 
 .PHONY: profile
 profile: \

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,8 @@ ifneq ($(OS),Windows_NT)
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Darwin)
         XCRUN = xcrun
+        PROFILE += -L$(shell brew --prefix gperftools)/lib
+        PROFILE += -I$(shell brew --prefix gperftools)/include
     endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,13 @@ BLST = -L../lib -lblst
 COVERAGE = -fprofile-instr-generate -fcoverage-mapping
 
 #
+# Settings for performance profiling.
+#
+PROFILE = -DPROFILE
+PROFILER = -lprofiler
+PROFILER_OPTS = CPUPROFILE_FREQUENCY=1000000000 CPUPROFILE_REALTIME=1
+
+#
 # Platform specific options.
 #
 ifneq ($(OS),Windows_NT)
@@ -55,6 +62,9 @@ test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
 
+test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
+	@$(CC) $(CFLAGS) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
+
 .PHONY: blst
 blst:
 	@cd ../blst && \
@@ -68,17 +78,32 @@ test: test_c_kzg_4844
 
 .PHONY: test_cov
 test_cov: test_c_kzg_4844_cov
-	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844_cov
+	@LLVM_PROFILE_FILE="ckzg.profraw" ./$<
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
 	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \
 	    $< c_kzg_4844.c > coverage.html
 	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
 	    --show-functions $< c_kzg_4844.c
 
+# Don't make it phony. It only needs to be run once.
+run_profiler: test_c_kzg_4844_prof
+	@$(PROFILER_OPTS) ./$<
+
+.PHONY: profile_%
+profile_%: run_profiler
+	@echo Profiling $*...
+	@pprof --pdf --focus=$* ./test_c_kzg_4844_prof $*.prof > $*.pdf
+
+.PHONY: profile
+profile: \
+	profile_blob_to_kzg_commitment \
+	profile_verify_kzg_proof \
+	profile_verify_aggregate_kzg_proof
+
 .PHONY: clean
 clean:
-	@rm -f *.o *.profraw *.profdata *.html \
-	    test_c_kzg_4844 test_c_kzg_4844_cov
+	@rm -f *.o *.profraw *.profdata *.html xray-log.* *.prof *.pdf \
+	    test_c_kzg_4844 test_c_kzg_4844_cov test_c_kzg_4844_prof
 
 .PHONY: format
 format:

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ COVERAGE = -fprofile-instr-generate -fcoverage-mapping
 #
 PROFILE = -DPROFILE
 PROFILER = -lprofiler
-PROFILER_OPTS = CPUPROFILE_FREQUENCY=1000000000 CPUPROFILE_REALTIME=1
+PROFILER_OPTS = CPUPROFILE_FREQUENCY=1000000000
 
 #
 # Platform specific options.
@@ -94,7 +94,8 @@ run_profiler: test_c_kzg_4844_prof
 .PHONY: profile_%
 profile_%: run_profiler
 	@echo Profiling $*...
-	@pprof --pdf --focus=$* ./test_c_kzg_4844_prof $*.prof > $*.pdf
+	@pprof --pdf --nodefraction=0.0001 --edgefraction=0.0001 \
+	    --focus=$* ./test_c_kzg_4844_prof $*.prof > $*.pdf
 
 .PHONY: profile
 profile: \

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -23,7 +23,6 @@ brew install gperftools ghostscript graphviz
 ### Generating profiling graphs
 
 There is a Makefile rule that should just auto-magically work:
-
 ```
 make profile
 ```
@@ -35,7 +34,6 @@ human-friendly graph that generated from that profiling data.
 #### Errors on macOS
 
 Note, on macOS there may a lot of "errors" like:
-
 ```
 otool-classic: can't open file: /usr/lib/libc++.1.dylib
 ```
@@ -70,7 +68,6 @@ can infer the relative time each function uses by counting the number of samples
 that are in each function. 
 
 Given a box containing:
-
 ```
 my_func 189 (0.6%) of 28758 (96.8%)
 ```

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -28,9 +28,21 @@ There is a Makefile rule that should just auto-magically work:
 make profile
 ```
 
-For each profiled function, this will produce two files (a `.prof` and `.pdf`
-file). The `.prof` file is the raw profiling data and the `.pdf` is the
+For each profiled function, this will produce two files (a PROF and PDF
+file). The PROF file is the raw profiling data and the PDF is the
 human-friendly graph that generated from that profiling data.
+
+#### Errors on macOS
+
+Note, on macOS there may a lot of "errors" like:
+
+```
+otool-classic: can't open file: /usr/lib/libc++.1.dylib
+```
+
+In my experience, you can ignore these. It's somewhat a known issue and may be
+resolved later. The PDFs should still generate successfully. I think it's the
+reason some function names are a hexadecimal address though.
 
 ### Viewing profiling graphs
 

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -73,6 +73,7 @@ my_func 189 (0.6%) of 28758 (96.8%)
 ```
 
 * Each box is a unique function.
+* Bigger boxes are more expensive.
 * Lines between boxes are function calls.
 * 189 is the number of profiling samples in this function.
 * 0.6% is the percentage of profiling samples in the functions.

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -1,0 +1,72 @@
+# Profiling
+
+We use [`gperftools`](https://github.com/gperftools/gperftools) (Google
+Performance Tools) for profiling. Note, we also considered using
+[`llvm-xray`](https://llvm.org/docs/XRay.html) but found it lacking in
+comparison.
+
+## Prequisities
+
+On Linux (Debian), you need to install:
+```
+sudo apt install gperftools graphviz
+```
+
+On macOS, you need to install (via [homebrew](https://brew.sh)):
+```
+brew install gperftools ghostscript graphviz
+```
+
+## How to run
+
+### Generating profiling graphs
+
+There is a Makefile rule that should just auto-magically work:
+
+```
+make profile
+```
+
+For each profiled function, this will produce two files (a `.prof` and `.pdf`
+file). The `.prof` file is the raw profiling data and the `.pdf` is the
+human-friendly graph that generated from that profiling data.
+
+### Viewing profiling graphs
+
+On Linux, you can open an individual PDF file like:
+```
+xdg-open blob_to_kzg_commitment.pdf
+```
+
+On macOS, you can open an individual PDF file like:
+```
+open blob_to_kzg_commitment.pdf
+```
+
+Or, you can open all the PDF files like:
+```
+open *.pdf
+```
+
+### Interpreting the profiling graphs
+
+These might not make much sense without guidance. From a high-level, this works
+by polling the instruction pointer (what's being executed) at a specific rate
+(like once every 5 nanoseconds) and tracking this information. From this, you
+can infer the relative time each function uses by counting the number of samples
+that are in each function. To be clear, this will not tell you how long (wall
+clock time) each function took, but it will help you determine which functions
+are the most expensive.
+
+Given a box containing:
+
+```
+my_func 189 (0.6%) of 28758 (96.8%)
+```
+
+* Each box is a unique function.
+* Lines between boxes are function calls.
+* 189 is the number of profiling samples in this function.
+* 0.6% is the percentage of profiling samples in the functions.
+* 28758 is the number of profiling samples in this function and its callees.
+* 96.8% is the percentage of profiling samples in this function and its callees.

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -3,7 +3,8 @@
 We use [`gperftools`](https://github.com/gperftools/gperftools) (Google
 Performance Tools) for profiling. Note, we also considered using
 [`llvm-xray`](https://llvm.org/docs/XRay.html) but found it lacking in
-comparison.
+comparison. This will not tell you how long (wall clock time) each function
+took, but it will help you determine which functions are the most expensive.
 
 ## Prequisities
 
@@ -54,9 +55,7 @@ These might not make much sense without guidance. From a high-level, this works
 by polling the instruction pointer (what's being executed) at a specific rate
 (like once every 5 nanoseconds) and tracking this information. From this, you
 can infer the relative time each function uses by counting the number of samples
-that are in each function. To be clear, this will not tell you how long (wall
-clock time) each function took, but it will help you determine which functions
-are the most expensive.
+that are in each function. 
 
 Given a box containing:
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -600,9 +600,9 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
 
 #ifdef PROFILE
 static void profile_blob_to_kzg_commitment(void) {
-    KZGCommitment c;
     Blob blob;
     Bytes32 field_element;
+    KZGCommitment c;
 
     get_rand_field_element(&field_element);
     memset(&blob, 0, sizeof(blob));
@@ -616,8 +616,8 @@ static void profile_blob_to_kzg_commitment(void) {
 }
 
 static void profile_verify_kzg_proof(void) {
-    Bytes48 commitment, proof;
     Bytes32 z, y;
+    Bytes48 commitment, proof;
     bool out;
 
     get_rand_g1_bytes(&commitment);
@@ -626,7 +626,7 @@ static void profile_verify_kzg_proof(void) {
     get_rand_g1_bytes(&proof);
 
     ProfilerStart("verify_kzg_proof.prof");
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 5000; i++) {
         verify_kzg_proof(&out, &commitment, &z, &y, &proof, &s);
     }
     ProfilerStop();
@@ -634,8 +634,8 @@ static void profile_verify_kzg_proof(void) {
 
 static void profile_verify_aggregate_kzg_proof(void) {
     int n = 16;
-    Bytes48 commitments[n];
     Blob blobs[n];
+    Bytes48 commitments[n];
     Bytes48 proof;
     bool out;
 
@@ -648,6 +648,37 @@ static void profile_verify_aggregate_kzg_proof(void) {
     ProfilerStart("verify_aggregate_kzg_proof.prof");
     for (int i = 0; i < 1000; i++) {
         verify_aggregate_kzg_proof(&out, blobs, commitments, n, &proof, &s);
+    }
+    ProfilerStop();
+}
+
+static void profile_compute_kzg_proof(void) {
+    Blob blob;
+    Bytes32 z;
+    KZGProof out;
+
+    get_rand_blob(&blob);
+    get_rand_field_element(&z);
+
+    ProfilerStart("compute_kzg_proof.prof");
+    for (int i = 0; i < 100; i++) {
+        compute_kzg_proof(&out, &blob, &z, &s);
+    }
+    ProfilerStop();
+}
+
+static void profile_compute_aggregate_kzg_proof(void) {
+    int n = 16;
+    Blob blobs[n];
+    KZGProof out;
+
+    for (int i = 0; i < n; i++) {
+        get_rand_blob(&blobs[i]);
+    }
+
+    ProfilerStart("compute_aggregate_kzg_proof.prof");
+    for (int i = 0; i < 10; i++) {
+        compute_aggregate_kzg_proof(&out, blobs, n, &s);
     }
     ProfilerStop();
 }
@@ -701,10 +732,19 @@ int main(void) {
     RUN(test_log_2_byte__expected_values);
     RUN(test_compute_and_verify_kzg_proof__succeeds_round_trip);
     RUN(test_compute_and_verify_kzg_proof__succeeds_within_domain);
+
+    /*
+     * These functions are only executed if we're profiling. To me, it makes
+     * sense to put these in the testing file so we can re-use the helper
+     * functions. Additionally, it checks that whatever performance changes
+     * haven't broken the library.
+     */
 #ifdef PROFILE
     profile_blob_to_kzg_commitment();
     profile_verify_kzg_proof();
     profile_verify_aggregate_kzg_proof();
+    profile_compute_kzg_proof();
+    profile_compute_aggregate_kzg_proof();
 #endif
     teardown();
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef PROFILE
+#include <gperftools/profiler.h>
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // Globals
 ///////////////////////////////////////////////////////////////////////////////
@@ -591,6 +595,65 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Profiling Functions
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef PROFILE
+static void profile_blob_to_kzg_commitment(void) {
+    KZGCommitment c;
+    Blob blob;
+    Bytes32 field_element;
+
+    get_rand_field_element(&field_element);
+    memset(&blob, 0, sizeof(blob));
+    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+
+    ProfilerStart("blob_to_kzg_commitment.prof");
+    for (int i = 0; i < 1000; i++) {
+        blob_to_kzg_commitment(&c, &blob, &s);
+    }
+    ProfilerStop();
+}
+
+static void profile_verify_kzg_proof(void) {
+    Bytes48 commitment, proof;
+    Bytes32 z, y;
+    bool out;
+
+    get_rand_g1_bytes(&commitment);
+    get_rand_field_element(&z);
+    get_rand_field_element(&y);
+    get_rand_g1_bytes(&proof);
+
+    ProfilerStart("verify_kzg_proof.prof");
+    for (int i = 0; i < 1000; i++) {
+        verify_kzg_proof(&out, &commitment, &z, &y, &proof, &s);
+    }
+    ProfilerStop();
+}
+
+static void profile_verify_aggregate_kzg_proof(void) {
+    int n = 16;
+    Bytes48 commitments[n];
+    Blob blobs[n];
+    Bytes48 proof;
+    bool out;
+
+    for (int i = 0; i < n; i++) {
+        get_rand_g1_bytes(&commitments[i]);
+        get_rand_blob(&blobs[i]);
+    }
+    get_rand_g1_bytes(&proof);
+
+    ProfilerStart("verify_aggregate_kzg_proof.prof");
+    for (int i = 0; i < 1000; i++) {
+        verify_aggregate_kzg_proof(&out, blobs, commitments, n, &proof, &s);
+    }
+    ProfilerStop();
+}
+#endif /* PROFILE */
+
+///////////////////////////////////////////////////////////////////////////////
 // Main logic
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -638,6 +701,11 @@ int main(void) {
     RUN(test_log_2_byte__expected_values);
     RUN(test_compute_and_verify_kzg_proof__succeeds_round_trip);
     RUN(test_compute_and_verify_kzg_proof__succeeds_within_domain);
+#ifdef PROFILE
+    profile_blob_to_kzg_commitment();
+    profile_verify_kzg_proof();
+    profile_verify_aggregate_kzg_proof();
+#endif
     teardown();
 
     return TEST_REPORT();


### PR DESCRIPTION
This is a work in progress. This adds some C profiling. First, I experimented with [`llvm-xray`](https://llvm.org/docs/XRay.html) but found it very limiting & had subpar results. For example, it didn't seem to include all of the functions in the results and it doesn't work on ARM64 macOS, which required me to boot into Linux. Looking for alternatives I discovered [`gperftools`](https://github.com/gperftools/gperftools) by Google. This was a much better experience and there are fancy graphs that don't suck. Some results:

* [blob_to_kzg_commitment.pdf](https://github.com/ethereum/c-kzg-4844/files/10691199/blob_to_kzg_commitment.pdf)
* [verify_aggregate_kzg_proof.pdf](https://github.com/ethereum/c-kzg-4844/files/10691200/verify_aggregate_kzg_proof.pdf)
* [verify_kzg_proof.pdf](https://github.com/ethereum/c-kzg-4844/files/10691201/verify_kzg_proof.pdf)

Screenshots of those files, in their respective order:

<img width="1569" alt="image" src="https://user-images.githubusercontent.com/95511699/217682218-0fba1662-3996-4f94-8eaa-0bc925e2d192.png">

<img width="1569" alt="image" src="https://user-images.githubusercontent.com/95511699/217682276-5fc1bbf1-e98e-4a42-9db2-9f15848a9a18.png">

<img width="1569" alt="image" src="https://user-images.githubusercontent.com/95511699/217682348-1b1d52d2-ed33-4791-8259-681fb3d70a29.png">

### How to run

On Linux (Arch), you need to install:
```
sudo pacman -S gperftools graphviz
```

On macOS, you need to install:
```
brew install gperftools ghostscript graphviz
```

Then, to run the profiler, run:
```
make profile
```

On macOS, there are a whole bunch of "errors" but it appears to have still worked. Maybe this is the reason why there are some missing symbols in the graphs. This seems like a known issue with Apple's command line tools.

### Other notes

Here's the documentation for `gperftools` CPU profiling:
* https://gperftools.github.io/gperftools/cpuprofile.html