### PR TITLE
Check UInt8Array lengths in node.js bindings

### DIFF
--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -353,8 +353,11 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports["verifyAggregateKzgProof"] = Napi::Function::New(env, VerifyAggregateKzgProof);
 
   // Constants
-  exports["FIELD_ELEMENTS_PER_BLOB"] = Napi::Number::New(env, FIELD_ELEMENTS_PER_BLOB);
+  exports["BYTES_PER_BLOB"] = Napi::Number::New(env, BYTES_PER_BLOB);
+  exports["BYTES_PER_COMMITMENT"] = Napi::Number::New(env, BYTES_PER_COMMITMENT);
   exports["BYTES_PER_FIELD_ELEMENT"] = Napi::Number::New(env, BYTES_PER_FIELD_ELEMENT);
+  exports["BYTES_PER_PROOF"] = Napi::Number::New(env, BYTES_PER_PROOF);
+  exports["FIELD_ELEMENTS_PER_BLOB"] = Napi::Number::New(env, FIELD_ELEMENTS_PER_BLOB);
 
   return exports;
 }


### PR DESCRIPTION
For extra safety & better error reporting, I think we should check type lengths in the node.js bindings. For example, previously you could pass a blob of the wrong length (number of bytes) to `BlobToKzgCommitment` and it would accept it. If the blob length was less than it should be, it could either succeed or fail for the same input; depends on the (undefined) memory after it. When it failed, it would throw an ambiguous error: "Failed to convert blob to commitment".

This PR will:

* Export all of the `BYTES_PER_*` values.
* Add a check function for each type, which just checks byte length.
* Call the check function for each argument prior to passing to C funcs.
* Use `BYTES_PER_*` in the testing suite instead of numbers.
* Add an extra subtest for testing an invalid length blob.

@dgcoffman could you review this?

Fixes #93.