### PR TITLE
Use `-Ofast` compiler optimization

### DIFF
--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -1,5 +1,6 @@
 package cgokzg4844
 
+// #cgo CFLAGS: -Ofast
 // #cgo CFLAGS: -I${SRCDIR}/../../src
 // #cgo CFLAGS: -I${SRCDIR}/blst_headers
 // #cgo CFLAGS: -DFIELD_ELEMENTS_PER_BLOB=4096

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,36 +2,16 @@
 # Configuration Options
 ###############################################################################
 
-#
 # We use clang. Some versions of GCC report missing-braces warnings.
-#
 CC = clang
 
-#
 # By default, this is set to the mainnet value.
-#
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
-#
 # The base compiler flags. More can be added on command line.
-#
-CFLAGS += -I../inc
-CFLAGS += -Wall -Wextra -Werror -O2
-CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
+CFLAGS += -Ofast -fno-builtin -Wall -Wextra -Werror
 
-#
-# Compiler flags for including blst. Must be put after the module.
-#
-BLST = -L../lib -lblst
-
-#
-# Compiler flags for generating coverage data.
-#
-COVERAGE = -fprofile-instr-generate -fcoverage-mapping
-
-#
 # Platform specific options.
-#
 ifneq ($(OS),Windows_NT)
     CFLAGS += -fPIC
     UNAME_S := $(shell uname -s)
@@ -40,6 +20,17 @@ ifneq ($(OS),Windows_NT)
     endif
 endif
 
+# Compiler flags for c-kzg-4844.
+CKZG_CFLAGS += $(CFLAGS) -I../inc
+CKZG_CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
+
+# Compiler flags for blst. Must be put after the module.
+BLST_CFLAGS = $(CFLAGS)
+BLST = -L../lib -lblst
+
+# Compiler flags for generating coverage data.
+COVERAGE = -fprofile-instr-generate -fcoverage-mapping
+
 ###############################################################################
 # Makefile Rules
 ###############################################################################
@@ -47,18 +38,18 @@ endif
 all: c_kzg_4844.o
 
 %.o: %.c
-	@$(CC) $(CFLAGS) -c $<
+	@$(CC) $(CKZG_CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(BLST) 
+	@$(CC) $(CKZG_CFLAGS) -o $@ $< $(BLST)
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST) 
+	@$(CC) $(CKZG_CFLAGS) $(COVERAGE) -o $@ $< $(BLST)
 
 .PHONY: blst
 blst:
 	@cd ../blst && \
-	./build.sh && \
+	CFLAGS="$(BLST_CFLAGS)" ./build.sh && \
 	cp libblst.a ../lib && \
 	cp bindings/*.h ../inc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ CC = clang
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
 # The base compiler flags. More can be added on command line.
-CFLAGS += -Ofast -fno-builtin -Wall -Wextra -Werror
+CFLAGS += -Ofast -Wall -Wextra -Werror
 
 # Platform specific options.
 ifneq ($(OS),Windows_NT)
@@ -24,7 +24,7 @@ endif
 CKZG_CFLAGS += $(CFLAGS) -I../inc
 CKZG_CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 
-# Compiler flags for blst. Must be put after the module.
+# Compiler flags for blst.
 BLST_CFLAGS = $(CFLAGS)
 BLST = -L../lib -lblst
 


### PR DESCRIPTION
This PR enables the `-Ofast` compiler optimization for c-kzg-4844 and blst.

This is essentially `-O3` with these flags:

* `-fno-signed-zeros`
* `-freciprocal-math`
* `-ffp-contract=fast`
* `-menable-unsafe-fp-math` 
* `-menable-no-nans`
* `-menable-no-infs`
* `-mreassociate`
* `-fno-trapping-math`
* `-ffast-math`
* `-ffinite-math-only`

In my experience, this results in approximately 8-10% better performance for verifying proofs.

<details>
<summary>Go benchmarks</summary>

---------
Go benchmarks before:
```
$ go test -bench=Benchmark
goos: darwin
goarch: arm64
pkg: github.com/ethereum/c-kzg-4844/bindings/go
Benchmark/BlobToKZGCommitment-20         	      28	  40713198 ns/op
Benchmark/ComputeKZGProof-20             	      27	  42853014 ns/op
Benchmark/VerifyKZGProof-20              	    1251	    958151 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=1)-20         	      13	  83601353 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=2)-20         	       9	 124474472 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=4)-20         	       5	 206277958 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=8)-20         	       3	 369755305 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=16)-20        	       2	 697233188 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=32)-20        	       1	1353733542 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=64)-20        	       1	2661803083 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=1)-20          	     700	   1720993 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=2)-20          	     564	   2130258 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=4)-20          	     405	   2943427 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=8)-20          	     266	   4491497 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=16)-20         	     156	   7634009 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=32)-20         	      79	  13748203 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=64)-20         	      45	  25144311 ns/op
PASS
ok  	github.com/ethereum/c-kzg-4844/bindings/go	34.309s
```

Go benchmarks with `-Ofast`:
```
$ CGO_CFLAGS="-Ofast" go test -bench=Benchmark
goos: darwin
goarch: arm64
pkg: github.com/ethereum/c-kzg-4844/bindings/go
Benchmark/BlobToKZGCommitment-20         	      28	  40713030 ns/op
Benchmark/ComputeKZGProof-20             	      27	  42813551 ns/op
Benchmark/VerifyKZGProof-20              	    1249	    957952 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=1)-20         	      13	  83599987 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=2)-20         	       9	 124474903 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=4)-20         	       5	 206238075 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=8)-20         	       3	 369590958 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=16)-20        	       2	 697658667 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=32)-20        	       1	1351262792 ns/op
Benchmark/ComputeAggregateKZGProof(blobs=64)-20        	       1	2659932958 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=1)-20          	     698	   1660266 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=2)-20          	     585	   2084159 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=4)-20          	     433	   2806095 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=8)-20          	     286	   4177384 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=16)-20         	     169	   7026519 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=32)-20         	      91	  12571193 ns/op
Benchmark/VerifyAggregateKZGProof(blobs=64)-20         	      49	  22617714 ns/op
PASS
ok  	github.com/ethereum/c-kzg-4844/bindings/go	34.292s
```
</details>

<details>
<summary>Java benchmarks</summary>

---------
Java benchmarks before:
```
Benchmark                                      (count)  Mode  Cnt        Score       Error  Units
CKZG4844JNIBenchmark.blobToKzgCommitment           N/A  avgt    5       42.201 ±     0.113  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        1  avgt    5       85.147 ±     0.412  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        4  avgt    5      212.672 ±     0.195  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        8  avgt    5      382.823 ±     0.255  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof       16  avgt    5      722.955 ±     1.555  ms/op
CKZG4844JNIBenchmark.computeKzgProof               N/A  avgt    5       42.933 ±     0.260  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         1  avgt    5        1.712 ±     0.002  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         4  avgt    5        2.987 ±     0.047  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         8  avgt    5        4.647 ±     0.038  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof        16  avgt    5        7.876 ±     0.089  ms/op
CKZG4844JNIBenchmark.verifyKzgProof                N/A  avgt    5  1018912.019 ± 11401.918  ns/op
```

Java benchmarks with `-Ofast`:
```
Benchmark                                      (count)  Mode  Cnt        Score      Error  Units
CKZG4844JNIBenchmark.blobToKzgCommitment           N/A  avgt    5       42.347 ±    0.580  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        1  avgt    5       86.140 ±    1.701  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        4  avgt    5      213.486 ±    2.038  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof        8  avgt    5      383.909 ±    5.970  ms/op
CKZG4844JNIBenchmark.computeAggregateKzgProof       16  avgt    5      730.013 ±   20.750  ms/op
CKZG4844JNIBenchmark.computeKzgProof               N/A  avgt    5       43.287 ±    1.028  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         1  avgt    5        1.670 ±    0.021  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         4  avgt    5        2.804 ±    0.054  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof         8  avgt    5        4.280 ±    0.028  ms/op
CKZG4844JNIBenchmark.verifyAggregateKzgProof        16  avgt    5        7.111 ±    0.418  ms/op
CKZG4844JNIBenchmark.verifyKzgProof                N/A  avgt    5  1035464.910 ± 9830.902  ns/op
```
</details>