### PR TITLE
Add c_kzg_calloc function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 test_c_kzg_4844
 test_c_kzg_4844_*
 coverage.html
+analysis-report/
 *.profraw
 *.profdata
 *.prof

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1618,8 +1618,6 @@ C_KZG_RET load_trusted_setup(
     out->g1_values = NULL;
     out->g2_values = NULL;
 
-    CHECK(n1 > 0);
-    CHECK(n2 > 0);
     ret = new_g1_array(&out->g1_values, n1);
     if (ret != C_KZG_OK) goto out_error;
     ret = new_g2_array(&out->g2_values, n2);

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -151,6 +151,7 @@ static const fr_t FR_ONE = {
  * @param[in]  size The number of bytes to be allocated
  */
 static C_KZG_RET c_kzg_malloc(void **out, size_t size) {
+    *out = NULL;
     if (size == 0) return C_KZG_BADARGS;
     *out = malloc(size);
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;
@@ -166,6 +167,7 @@ static C_KZG_RET c_kzg_malloc(void **out, size_t size) {
  * @param[in]  size  The size of each element
  */
 static C_KZG_RET c_kzg_calloc(void **out, size_t count, size_t size) {
+    *out = NULL;
     if (count == 0 || size == 0) return C_KZG_BADARGS;
     *out = calloc(count, size);
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -83,6 +83,55 @@ static void get_rand_uint32(uint32_t *out) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Tests for memory allocation functions
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_c_kzg_malloc__succeeds_size_greater_than_zero(void) {
+    C_KZG_RET ret;
+    void *ptr = NULL;
+
+    ret = c_kzg_malloc(&ptr, 123);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+    ASSERT("valid pointer", ptr != NULL);
+}
+
+static void test_c_kzg_malloc__fails_size_equal_to_zero(void) {
+    C_KZG_RET ret;
+    void *ptr = (void *)0x123;
+
+    ret = c_kzg_malloc(&ptr, 0);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+    ASSERT_EQUALS(ptr, NULL);
+}
+
+static void test_c_kzg_calloc__succeeds_size_greater_than_zero(void) {
+    C_KZG_RET ret;
+    void *ptr = NULL;
+
+    ret = c_kzg_calloc(&ptr, 123, 456);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+    ASSERT("valid pointer", ptr != NULL);
+}
+
+static void test_c_kzg_calloc__fails_count_equal_to_zero(void) {
+    C_KZG_RET ret;
+    void *ptr = (void *)0x123;
+
+    ret = c_kzg_calloc(&ptr, 0, 456);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+    ASSERT_EQUALS(ptr, NULL);
+}
+
+static void test_c_kzg_calloc__fails_size_equal_to_zero(void) {
+    C_KZG_RET ret;
+    void *ptr = (void *)0x123;
+
+    ret = c_kzg_calloc(&ptr, 123, 0);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+    ASSERT_EQUALS(ptr, NULL);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Tests for blob_to_kzg_commitment
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -707,6 +756,11 @@ static void teardown(void) {
 
 int main(void) {
     setup();
+    RUN(test_c_kzg_malloc__succeeds_size_greater_than_zero);
+    RUN(test_c_kzg_malloc__fails_size_equal_to_zero);
+    RUN(test_c_kzg_calloc__succeeds_size_greater_than_zero);
+    RUN(test_c_kzg_calloc__fails_size_equal_to_zero);
+    RUN(test_c_kzg_calloc__fails_count_equal_to_zero);
     RUN(test_blob_to_kzg_commitment__succeeds_x_less_than_modulus);
     RUN(test_blob_to_kzg_commitment__fails_x_equal_to_modulus);
     RUN(test_blob_to_kzg_commitment__fails_x_greater_than_modulus);

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -93,6 +93,7 @@ static void test_c_kzg_malloc__succeeds_size_greater_than_zero(void) {
     ret = c_kzg_malloc(&ptr, 123);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ASSERT("valid pointer", ptr != NULL);
+    free(ptr);
 }
 
 static void test_c_kzg_malloc__fails_size_equal_to_zero(void) {
@@ -111,6 +112,7 @@ static void test_c_kzg_calloc__succeeds_size_greater_than_zero(void) {
     ret = c_kzg_calloc(&ptr, 123, 456);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ASSERT("valid pointer", ptr != NULL);
+    free(ptr);
 }
 
 static void test_c_kzg_calloc__fails_count_equal_to_zero(void) {


### PR DESCRIPTION
* Adds new `c_kzg_calloc` func that returns a `C_KZG_RET` value.
* Replace all instances of `malloc` and `calloc` with helper funcs.
* Rename parameters to match the func its wrapping.
* Use `c_kzg_calloc` in `new_*_array` funcs.