### PR TITLE
Fix rust bindings benchmarks

### DIFF
--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -40,10 +40,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b, blobs| b.iter(|| KZGProof::compute_aggregate_kzg_proof(blobs, &kzg_settings)),
         );
 
-        let kzg_commitments: Vec<KZGCommitment> = blobs
+        let kzg_commitments: Vec<Bytes48> = blobs
             .clone()
             .into_iter()
-            .map(|blob| KZGCommitment::blob_to_kzg_commitment(blob, &kzg_settings))
+            .map(|blob| KZGCommitment::blob_to_kzg_commitment(blob, &kzg_settings).to_bytes())
             .collect();
         let proof = KZGProof::compute_aggregate_kzg_proof(&blobs, &kzg_settings).unwrap();
 
@@ -53,7 +53,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b, blobs| {
                 b.iter(|| {
                     proof
-                        .verify_aggregate_kzg_proof(&blobs, &kzg_commitments, &kzg_settings)
+                        .verify_aggregate_kzg_proof(
+                            &blobs,
+                            kzg_commitments.as_slice(),
+                            &kzg_settings,
+                        )
                         .unwrap()
                 })
             },

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -434,10 +434,7 @@ mod tests {
 
             for (i, blob) in blobs.into_iter().enumerate() {
                 let commitment = KZGCommitment::blob_to_kzg_commitment(blob, &kzg_settings);
-                assert_eq!(
-                    commitment.as_hex_string().as_str(),
-                    expected_commitments[i]
-                );
+                assert_eq!(commitment.as_hex_string().as_str(), expected_commitments[i]);
             }
         }
     }
@@ -468,12 +465,7 @@ mod tests {
             let y_bytes = Bytes32::from_bytes(&hex::decode(y_hex).unwrap()).unwrap();
 
             assert!(kzg_proof
-                .verify_kzg_proof(
-                    commitment,
-                    z_bytes,
-                    y_bytes,
-                    &kzg_settings
-                )
+                .verify_kzg_proof(commitment, z_bytes, y_bytes, &kzg_settings)
                 .unwrap());
         }
     }


### PR DESCRIPTION
This wasn't updated when we switched to `Bytes32` and `Bytes48` types.

* Collect a vector of `Bytes48` instead of `KZGCommitment`.
* Call `.as_slice()` since the input is a slice now.
* Run `cargo fmt`.

Fixes #131.