### PR TITLE
Disable compiler optimizations for tests

### DIFF
--- a/.github/workflows/ckzg-test.yml
+++ b/.github/workflows/ckzg-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate coverage report
         run: |
           cd src
-          make test_cov
+          make coverage
       - name: Save coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,9 @@ CFLAGS += -I../inc
 CFLAGS += -Wall -Wextra -Werror -O2
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 
+# Disable optimizations. Put after $CFLAGS.
+NO_OPTIMIZE = -O0
+
 # Compiler flags for including blst. Put after source files.
 BLST = -L../lib -lblst
 
@@ -45,13 +48,13 @@ all: c_kzg_4844.o
 	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(BLST)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(BLST)
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(COVERAGE) -o $@ $< $(BLST)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(BLST)
 
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
 
 .PHONY: blst
 blst:
@@ -64,8 +67,8 @@ blst:
 test: test_c_kzg_4844
 	@./test_c_kzg_4844
 
-.PHONY: test_cov
-test_cov: test_c_kzg_4844_cov
+.PHONY: coverage
+coverage: test_c_kzg_4844_cov
 	@LLVM_PROFILE_FILE="ckzg.profraw" ./$<
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
 	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -105,6 +105,15 @@ static void test_c_kzg_malloc__fails_size_equal_to_zero(void) {
     ASSERT_EQUALS(ptr, NULL);
 }
 
+static void test_c_kzg_malloc__fails_too_big(void) {
+    C_KZG_RET ret;
+    void *ptr = NULL;
+
+    ret = c_kzg_malloc(&ptr, UINT64_MAX);
+    ASSERT_EQUALS(ret, C_KZG_MALLOC);
+    ASSERT_EQUALS(ptr, NULL);
+}
+
 static void test_c_kzg_calloc__succeeds_size_greater_than_zero(void) {
     C_KZG_RET ret;
     void *ptr = NULL;
@@ -130,6 +139,15 @@ static void test_c_kzg_calloc__fails_size_equal_to_zero(void) {
 
     ret = c_kzg_calloc(&ptr, 123, 0);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
+    ASSERT_EQUALS(ptr, NULL);
+}
+
+static void test_c_kzg_calloc__fails_too_big(void) {
+    C_KZG_RET ret;
+    void *ptr = NULL;
+
+    ret = c_kzg_calloc(&ptr, UINT64_MAX, UINT64_MAX);
+    ASSERT_EQUALS(ret, C_KZG_MALLOC);
     ASSERT_EQUALS(ptr, NULL);
 }
 
@@ -760,9 +778,11 @@ int main(void) {
     setup();
     RUN(test_c_kzg_malloc__succeeds_size_greater_than_zero);
     RUN(test_c_kzg_malloc__fails_size_equal_to_zero);
+    RUN(test_c_kzg_malloc__fails_too_big);
     RUN(test_c_kzg_calloc__succeeds_size_greater_than_zero);
     RUN(test_c_kzg_calloc__fails_size_equal_to_zero);
     RUN(test_c_kzg_calloc__fails_count_equal_to_zero);
+    RUN(test_c_kzg_calloc__fails_too_big);
     RUN(test_blob_to_kzg_commitment__succeeds_x_less_than_modulus);
     RUN(test_blob_to_kzg_commitment__fails_x_equal_to_modulus);
     RUN(test_blob_to_kzg_commitment__fails_x_greater_than_modulus);


### PR DESCRIPTION
* Disable optimizations for tests.
* Rename `test_cov` to `coverage`.
* Add two new tests.

Ran into an interesting problem with the tests. It appears that some of them were being optimized out. I added two new `c_kzg_*alloc` tests and they would fail unless I printed the results. Opened the test binary in Ghidra and found that it was just automatically failing without actually running the test. Also, it inlined all of the tests into main.

<img width="628" alt="Screenshot 2023-02-13 at 10 50 06 AM" src="https://user-images.githubusercontent.com/95511699/218524170-bb43429c-db36-4844-a431-35ca8f7c9d39.png">

Disabled optimizations and it looked like:

<img width="635" alt="Screenshot 2023-02-13 at 11 06 53 AM" src="https://user-images.githubusercontent.com/95511699/218524353-ee63275c-25d2-42ff-834f-1cc6290a81bd.png">

Doing a string search, I found that it was only executing 24/32 of the tests:

<img width="587" alt="Screenshot 2023-02-13 at 10 50 30 AM" src="https://user-images.githubusercontent.com/95511699/218524004-0acee5a4-d716-47ba-87bf-ee4fa74bb3cd.png">

Without optimizations, this properly showed 32 strings:

<img width="675" alt="Screenshot 2023-02-13 at 10 53 50 AM" src="https://user-images.githubusercontent.com/95511699/218523954-d77d194d-d34d-4154-b1ef-506af167edc3.png">






