### PR TITLE
[Java binding] Validation of loadTrustedSetup parameters

### DIFF
--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -42,7 +42,8 @@ void throw_invalid_size_exception(JNIEnv *env, const char *prefix, size_t size, 
   throw_c_kzg_exception(env, C_KZG_BADARGS, message);
 }
 
-KZGSettings *allocate_settings(JNIEnv *env) {
+KZGSettings *allocate_settings(JNIEnv *env)
+{
   KZGSettings *s = malloc(sizeof(KZGSettings));
   if (s == NULL)
   {
@@ -102,6 +103,24 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup___3BJ
   if (settings)
   {
     throw_exception(env, "Trusted Setup is already loaded. Free it before loading a new one.");
+    return;
+  }
+
+  size_t g1_bytes = (size_t)(*env)->GetArrayLength(env, g1);
+  size_t g1_expected_bytes = (size_t)g1Count * 48;
+
+  if (g1_bytes != g1_expected_bytes)
+  {
+    throw_invalid_size_exception(env, "Invalid g1 size.", g1_bytes, g1_expected_bytes);
+    return;
+  }
+
+  size_t g2_bytes = (size_t)(*env)->GetArrayLength(env, g2);
+  size_t g2_expected_bytes = (size_t)g2Count * 96;
+
+  if (g2_bytes != g2_expected_bytes)
+  {
+    throw_invalid_size_exception(env, "Invalid g2 size.", g2_bytes, g2_expected_bytes);
     return;
   }
 


### PR DESCRIPTION
Stumbled across a segfault error in mac-os error when running in our CI:

```
2023-02-22T10:55:12.455+0000 [DEBUG] [TestEventLogger] CKZG4844JNITest > shouldThrowExceptionOnIncorrectTrustedSetupParameters() STARTED
2023-02-22T10:55:12.968+0000 [QUIET] [system.out] #
2023-02-22T10:55:12.969+0000 [QUIET] [system.out] # A fatal error has been detected by the Java Runtime Environment:
2023-02-22T10:55:12.969+0000 [QUIET] [system.out] #
2023-02-22T10:55:12.969+0000 [QUIET] [system.out] #  SIGSEGV (0xb) at pc=0x0000000109e60012, pid=4005, tid=10243
2023-02-22T10:55:12.969+0000 [QUIET] [system.out] #
2023-02-22T10:55:12.969+0000 [QUIET] [system.out] # JRE version: OpenJDK Runtime Environment Temurin-17.0.5+8 (17.0.5+8) (build 17.0.5+8)
2023-02-22T10:55:12.970+0000 [QUIET] [system.out] # Java VM: OpenJDK 64-Bit Server VM Temurin-17.0.5+8 (17.0.5+8, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, bsd-amd64)
2023-02-22T10:55:12.970+0000 [QUIET] [system.out] # Problematic frame:
2023-02-22T10:55:12.970+0000 [QUIET] [system.out] # C  [libckzg4844jni.dylib+0x10012]  POINTonE1_Uncompress_Z+0x22
2023-02-22T10:55:12.970+0000 [QUIET] [system.out] #
2023-02-22T10:55:12.971+0000 [QUIET] [system.out] # No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
2023-02-22T10:55:12.971+0000 [QUIET] [system.out] #
2023-02-22T10:55:12.971+0000 [QUIET] [system.out] # An error report file with more information is saved as:
2023-02-22T10:55:12.971+0000 [QUIET] [system.out] # /Users/distiller/jc-kzg-4844/c-kzg-4844/bindings/java/hs_err_pid4005.log
```

After a brief discussion with Justin (thanks), we agreed it would make sense to add an additional validation in the java binding to ensure no segfault can occur by passing wrong parameters for the trusted setup.


