### PR TITLE
Fix g1_lincomb() to work with zero points as input

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -752,10 +752,10 @@ static void compute_challenge(
  * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n`
  * where `n` is `len - 1`.
  *
- * @param[out] out    The resulting sum-product
- * @param[in]  p      Array of G1 group elements, length @p len
- * @param[in]  coeffs Array of field elements, length @p len
- * @param[in]  len    The number of group/field elements
+ * @param[out] point_out    The resulting linear combination output
+ * @param[in]  p            Array of G1 group elements, length @p len
+ * @param[in]  coeffs       Array of field elements, length @p len
+ * @param[in]  len          The number of group/field elements
  *
  * For the benefit of future generations (since Blst has no documentation to
  * speak of), there are two ways to pass the arrays of scalars and points


### PR DESCRIPTION
Implements the weed out strategy from https://github.com/ethereum/c-kzg-4844/issues/138#issue-1588962093