### PR TITLE
Allow invalid length inputs in rust tests

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -634,7 +634,6 @@ mod tests {
             };
 
             let res = KZGProof::verify_blob_kzg_proof_batch(
-                //blobs.into_iter().map(|b| *b).collect::<Vec<Blob>>().as_slice(),
                 blobs.into_iter().map(|b| *b).collect::<Vec<Blob>>().as_slice(),
                 commitments.as_slice(),
                 proofs.as_slice(),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -461,11 +461,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(BLOB_TO_KZG_COMMITMENT_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(BLOB_TO_KZG_COMMITMENT_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: blob_to_kzg_commitment_test::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let Ok(blob) = test.input.get_blob() else {
                 assert!(test.get_output().is_none());
@@ -486,11 +483,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(COMPUTE_KZG_PROOF_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(COMPUTE_KZG_PROOF_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: compute_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(z)) = (test.input.get_blob(), test.input.get_z()) else {
                 assert!(test.get_output().is_none());
@@ -511,11 +505,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(COMPUTE_BLOB_KZG_PROOF_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(COMPUTE_BLOB_KZG_PROOF_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: compute_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let Ok(blob) = test.input.get_blob() else {
                 assert!(test.get_output().is_none());
@@ -536,11 +527,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(VERIFY_KZG_PROOF_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(VERIFY_KZG_PROOF_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: verify_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (
                 test.input.get_commitment(),
@@ -566,11 +554,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(VERIFY_BLOB_KZG_PROOF_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(VERIFY_BLOB_KZG_PROOF_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(commitment), Ok(proof)) = (
                 test.input.get_blob(),
@@ -595,11 +580,8 @@ mod tests {
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
-        let tests = glob::glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS)
-            .unwrap()
-            .map(|t| t.unwrap());
-        for test_file in tests {
-            let yaml_data = fs::read_to_string(test_file).unwrap();
+        for test_file in glob::glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS).unwrap() {
+            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
             let test: verify_blob_kzg_proof_batch::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blobs), Ok(commitments), Ok(proofs)) = (
                 test.input.get_blobs(),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -542,7 +542,12 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (test.input.get_commitment(), test.input.get_z(), test.input.get_y(), test.input.get_proof()) else {
+            let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (
+                test.input.get_commitment(),
+                test.input.get_z(),
+                test.input.get_y(),
+                test.input.get_proof()
+            ) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -567,7 +572,11 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(blob), Ok(commitment), Ok(proof)) = (test.input.get_blob(), test.input.get_commitment(), test.input.get_proof()) else {
+            let (Ok(blob), Ok(commitment), Ok(proof)) = (
+                test.input.get_blob(),
+                test.input.get_commitment(),
+                test.input.get_proof()
+            ) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -592,8 +601,11 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof_batch::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
-            let (Ok(blobs), Ok(commitments), Ok(proofs)) = (test.input.get_blobs(), test.input.get_commitments(), test.input.get_proofs()) else {
+            let (Ok(blobs), Ok(commitments), Ok(proofs)) = (
+                test.input.get_blobs(),
+                test.input.get_commitments(),
+                test.input.get_proofs()
+            ) else {
                 assert!(test.get_output().is_none());
                 continue;
             };

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -112,20 +112,7 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != BYTES_PER_BLOB {
-            return Err(Error::InvalidBytesLength(format!(
-                "Invalid byte length. Expected {} got {}",
-                BYTES_PER_BLOB,
-                bytes.len(),
-            )));
-        }
-        let mut new_bytes = [0; BYTES_PER_BLOB];
-        new_bytes.copy_from_slice(bytes);
-        Ok(Self { bytes: new_bytes })
-    }
-
-    pub fn from_bytes_boxed(bytes: &[u8]) -> Result<Box<Self>, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Box<Self>, Error> {
         if bytes.len() != BYTES_PER_BLOB {
             return Err(Error::InvalidBytesLength(format!(
                 "Invalid byte length. Expected {} got {}",
@@ -469,7 +456,7 @@ mod tests {
     const VERIFY_BLOB_KZG_PROOF_TESTS: &str = "../../tests/verify_blob_kzg_proof/*/*/*";
     const VERIFY_BLOB_KZG_PROOF_BATCH_TESTS: &str = "../../tests/verify_blob_kzg_proof_batch/*/*/*";
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_blob_to_kzg_commitment() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -488,7 +475,7 @@ mod tests {
                 continue;
             };
 
-            let res = KZGCommitment::blob_to_kzg_commitment(blob, &kzg_settings);
+            let res = KZGCommitment::blob_to_kzg_commitment(*blob, &kzg_settings);
 
             if res.is_ok() {
                 assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
@@ -498,7 +485,7 @@ mod tests {
         }
     }
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_compute_kzg_proof() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -517,7 +504,7 @@ mod tests {
                 continue;
             };
 
-            let res = KZGProof::compute_kzg_proof(blob, z, &kzg_settings);
+            let res = KZGProof::compute_kzg_proof(*blob, z, &kzg_settings);
 
             if res.is_ok() {
                 assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
@@ -527,7 +514,7 @@ mod tests {
         }
     }
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_compute_blob_kzg_proof() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -546,7 +533,7 @@ mod tests {
                 continue;
             };
 
-            let res = KZGProof::compute_blob_kzg_proof(blob, &kzg_settings);
+            let res = KZGProof::compute_blob_kzg_proof(*blob, &kzg_settings);
 
             if res.is_ok() {
                 assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
@@ -556,7 +543,7 @@ mod tests {
         }
     }
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_verify_kzg_proof() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -585,7 +572,7 @@ mod tests {
         }
     }
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_verify_blob_kzg_proof() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -604,7 +591,7 @@ mod tests {
                 continue;
             };
 
-            let res = KZGProof::verify_blob_kzg_proof(blob, commitment, proof, &kzg_settings);
+            let res = KZGProof::verify_blob_kzg_proof(*blob, commitment, proof, &kzg_settings);
 
             if res.is_ok() {
                 assert_eq!(res.unwrap(), test.get_output().unwrap())
@@ -614,7 +601,7 @@ mod tests {
         }
     }
 
-    //#[cfg(not(feature = "minimal-spec"))]
+    #[cfg(not(feature = "minimal-spec"))]
     #[test]
     fn test_verify_blob_kzg_proof_batch() {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
@@ -634,7 +621,11 @@ mod tests {
             };
 
             let res = KZGProof::verify_blob_kzg_proof_batch(
-                blobs.into_iter().map(|b| *b).collect::<Vec<Blob>>().as_slice(),
+                blobs
+                    .into_iter()
+                    .map(|b| *b)
+                    .collect::<Vec<Blob>>()
+                    .as_slice(),
                 commitments.as_slice(),
                 proofs.as_slice(),
                 &kzg_settings,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-extern crate core;
-
 mod test_formats;
 
 include!("bindings.rs");
@@ -469,18 +467,14 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: blob_to_kzg_commitment_test::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
             let Ok(blob) = test.input.get_blob() else {
                 assert!(test.get_output().is_none());
                 continue;
             };
 
-            let res = KZGCommitment::blob_to_kzg_commitment(*blob, &kzg_settings);
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
-            } else {
-                assert!(test.get_output().is_none())
+            match KZGCommitment::blob_to_kzg_commitment(*blob, &kzg_settings) {
+                Ok(res) => assert_eq!(res.bytes, test.get_output().unwrap().bytes),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }
@@ -498,18 +492,14 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
             let (Ok(blob), Ok(z)) = (test.input.get_blob(), test.input.get_z()) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
 
-            let res = KZGProof::compute_kzg_proof(*blob, z, &kzg_settings);
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
-            } else {
-                assert!(test.get_output().is_none())
+            match KZGProof::compute_kzg_proof(*blob, z, &kzg_settings) {
+                Ok(res) => assert_eq!(res.bytes, test.get_output().unwrap().bytes),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }
@@ -527,18 +517,14 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
             let Ok(blob) = test.input.get_blob() else {
                 assert!(test.get_output().is_none());
                 continue;
             };
 
-            let res = KZGProof::compute_blob_kzg_proof(*blob, &kzg_settings);
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap().bytes, test.get_output().unwrap().bytes)
-            } else {
-                assert!(test.get_output().is_none())
+            match KZGProof::compute_blob_kzg_proof(*blob, &kzg_settings) {
+                Ok(res) => assert_eq!(res.bytes, test.get_output().unwrap().bytes),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }
@@ -556,18 +542,14 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
             let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (test.input.get_commitment(), test.input.get_z(), test.input.get_y(), test.input.get_proof()) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
 
-            let res = KZGProof::verify_kzg_proof(commitment, z, y, proof, &kzg_settings);
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap(), test.get_output().unwrap())
-            } else {
-                assert!(test.get_output().is_none())
+            match KZGProof::verify_kzg_proof(commitment, z, y, proof, &kzg_settings) {
+                Ok(res) => assert_eq!(res, test.get_output().unwrap()),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }
@@ -585,18 +567,14 @@ mod tests {
         for test_file in tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-
             let (Ok(blob), Ok(commitment), Ok(proof)) = (test.input.get_blob(), test.input.get_commitment(), test.input.get_proof()) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
 
-            let res = KZGProof::verify_blob_kzg_proof(*blob, commitment, proof, &kzg_settings);
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap(), test.get_output().unwrap())
-            } else {
-                assert!(test.get_output().is_none())
+            match KZGProof::verify_blob_kzg_proof(*blob, commitment, proof, &kzg_settings) {
+                Ok(res) => assert_eq!(res, test.get_output().unwrap()),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }
@@ -620,7 +598,7 @@ mod tests {
                 continue;
             };
 
-            let res = KZGProof::verify_blob_kzg_proof_batch(
+            match KZGProof::verify_blob_kzg_proof_batch(
                 blobs
                     .into_iter()
                     .map(|b| *b)
@@ -629,12 +607,9 @@ mod tests {
                 commitments.as_slice(),
                 proofs.as_slice(),
                 &kzg_settings,
-            );
-
-            if res.is_ok() {
-                assert_eq!(res.unwrap(), test.get_output().unwrap())
-            } else {
-                assert!(test.get_output().is_none())
+            ) {
+                Ok(res) => assert_eq!(res, test.get_output().unwrap()),
+                _ => assert!(test.get_output().is_none()),
             }
         }
     }

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes48;
-use crate::{Blob, Error};
+use crate::{Blob, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use crate::Blob;
 use crate::Bytes48;
+use crate::{Blob, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +10,10 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Blob {
-        Blob::from_bytes(&hex::decode(self.blob.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        let hex_str = self.blob.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Blob::from_bytes(&bytes)
     }
 }
 
@@ -26,10 +28,9 @@ pub struct Test<'a> {
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
         if self.output.is_some() {
-            Some(
-                Bytes48::from_bytes(&hex::decode(self.output.unwrap().replace("0x", "")).unwrap())
-                    .unwrap(),
-            )
+            let hex_str = self.output.unwrap().replace("0x", "");
+            let bytes = hex::decode(hex_str).unwrap();
+            Some(Bytes48::from_bytes(&bytes).unwrap())
         } else {
             None
         }

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -26,12 +26,9 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
-        if self.output.is_some() {
-            let hex_str = self.output.unwrap().replace("0x", "");
-            let bytes = hex::decode(hex_str).unwrap();
-            Some(Bytes48::from_bytes(&bytes).unwrap())
-        } else {
-            None
-        }
+        self.output
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
     }
 }

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes48;
-use crate::{Blob, Error};
+use crate::{Blob, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use crate::Blob;
 use crate::Bytes48;
+use crate::{Blob, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +10,10 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Blob {
-        Blob::from_bytes(&hex::decode(self.blob.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        let hex_str = self.blob.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Blob::from_bytes(&bytes)
     }
 }
 
@@ -26,10 +28,9 @@ pub struct Test<'a> {
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
         if self.output.is_some() {
-            Some(
-                Bytes48::from_bytes(&hex::decode(self.output.unwrap().replace("0x", "")).unwrap())
-                    .unwrap(),
-            )
+            let hex_str = self.output.unwrap().replace("0x", "");
+            let bytes = hex::decode(hex_str).unwrap();
+            Some(Bytes48::from_bytes(&bytes).unwrap())
         } else {
             None
         }

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -26,12 +26,9 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
-        if self.output.is_some() {
-            let hex_str = self.output.unwrap().replace("0x", "");
-            let bytes = hex::decode(hex_str).unwrap();
-            Some(Bytes48::from_bytes(&bytes).unwrap())
-        } else {
-            None
-        }
+        self.output
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
     }
 }

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes32;
-use crate::Bytes48;
-use crate::{Blob, Error};
+use crate::{Blob, Bytes32, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use crate::Blob;
 use crate::Bytes32;
 use crate::Bytes48;
+use crate::{Blob, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -12,12 +12,16 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Blob {
-        Blob::from_bytes(&hex::decode(self.blob.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        let hex_str = self.blob.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Blob::from_bytes(&bytes)
     }
 
-    pub fn get_z(&self) -> Bytes32 {
-        Bytes32::from_bytes(&hex::decode(self.z.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_z(&self) -> Result<Bytes32, Error> {
+        let hex_str = self.z.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes32::from_bytes(&bytes)
     }
 }
 
@@ -32,10 +36,9 @@ pub struct Test<'a> {
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
         if self.output.is_some() {
-            Some(
-                Bytes48::from_bytes(&hex::decode(self.output.unwrap().replace("0x", "")).unwrap())
-                    .unwrap(),
-            )
+            let hex_str = self.output.unwrap().replace("0x", "");
+            let bytes = hex::decode(hex_str).unwrap();
+            Some(Bytes48::from_bytes(&bytes).unwrap())
         } else {
             None
         }

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -12,7 +12,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -33,12 +33,9 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
-        if self.output.is_some() {
-            let hex_str = self.output.unwrap().replace("0x", "");
-            let bytes = hex::decode(hex_str).unwrap();
-            Some(Bytes48::from_bytes(&bytes).unwrap())
-        } else {
-            None
-        }
+        self.output
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
     }
 }

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes48;
-use crate::{Blob, Error};
+use crate::{Blob, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
@@ -12,7 +12,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use crate::Blob;
 use crate::Bytes48;
+use crate::{Blob, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -12,16 +12,22 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Blob {
-        Blob::from_bytes(&hex::decode(self.blob.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        let hex_str = self.blob.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Blob::from_bytes(&bytes)
     }
 
-    pub fn get_commitment(&self) -> Bytes48 {
-        Bytes48::from_bytes(&hex::decode(self.commitment.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_commitment(&self) -> Result<Bytes48, Error> {
+        let hex_str = self.commitment.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes48::from_bytes(&bytes)
     }
 
-    pub fn get_proof(&self) -> Bytes48 {
-        Bytes48::from_bytes(&hex::decode(self.proof.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_proof(&self) -> Result<Bytes48, Error> {
+        let hex_str = self.proof.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes48::from_bytes(&bytes)
     }
 }
 

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use crate::Blob;
 use crate::Bytes48;
+use crate::{Blob, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -12,28 +12,35 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self) -> Vec<Blob> {
-        self.blobs
-            .iter()
-            .map(|f| hex::decode(f.replace("0x", "")).unwrap())
-            .map(|bytes| Blob::from_bytes(bytes.as_slice()).unwrap())
-            .collect::<Vec<Blob>>()
+    pub fn get_blobs(&self) -> Result<Vec<Box<Blob>>, Error> {
+        let mut ret: Vec<Result<Box<Blob>, Error>>  = Vec::new();
+        for blob in &self.blobs {
+            let hex_str = &blob.replace("0x", "");
+            let bytes = &hex::decode(hex_str).unwrap();
+            ret.push(Blob::from_bytes_boxed(&bytes));
+        }
+
+        //let new: Result<Vec<T>, E> = v.into_iter().collect()
+        ret.into_iter().collect::<Result<Vec<Box<Blob>>, Error>>()
+        //ret.iter().transpose()
     }
 
-    pub fn get_commitments(&self) -> Vec<Bytes48> {
+    pub fn get_commitments(&self) -> Result<Vec<Bytes48>, Error> {
         self.commitments
             .iter()
-            .map(|f| hex::decode(f.replace("0x", "")).unwrap())
-            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()).unwrap())
-            .collect::<Vec<Bytes48>>()
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()))
+            .collect::<Result<Vec<Bytes48>, Error>>()
     }
 
-    pub fn get_proofs(&self) -> Vec<Bytes48> {
+    pub fn get_proofs(&self) -> Result<Vec<Bytes48>, Error> {
         self.proofs
             .iter()
-            .map(|f| hex::decode(f.replace("0x", "")).unwrap())
-            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()).unwrap())
-            .collect::<Vec<Bytes48>>()
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()))
+            .collect::<Result<Vec<Bytes48>, Error>>()
     }
 }
 

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -17,7 +17,7 @@ impl Input {
             .iter()
             .map(|s| s.replace("0x", ""))
             .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Blob::from_bytes_boxed(bytes.as_slice()))
+            .map(|bytes| Blob::from_bytes(bytes.as_slice()))
             .collect::<Result<Vec<Box<Blob>>, Error>>()
     }
 

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -13,16 +13,12 @@ pub struct Input {
 
 impl Input {
     pub fn get_blobs(&self) -> Result<Vec<Box<Blob>>, Error> {
-        let mut ret: Vec<Result<Box<Blob>, Error>>  = Vec::new();
-        for blob in &self.blobs {
-            let hex_str = &blob.replace("0x", "");
-            let bytes = &hex::decode(hex_str).unwrap();
-            ret.push(Blob::from_bytes_boxed(&bytes));
-        }
-
-        //let new: Result<Vec<T>, E> = v.into_iter().collect()
-        ret.into_iter().collect::<Result<Vec<Box<Blob>>, Error>>()
-        //ret.iter().transpose()
+        self.blobs
+            .iter()
+            .map(|s| s.replace("0x", ""))
+            .map(|hex_str| hex::decode(hex_str).unwrap())
+            .map(|bytes| Blob::from_bytes_boxed(bytes.as_slice()))
+            .collect::<Result<Vec<Box<Blob>>, Error>>()
     }
 
     pub fn get_commitments(&self) -> Result<Vec<Bytes48>, Error> {

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes48;
-use crate::{Blob, Error};
+use crate::{Blob, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/verify_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_kzg_proof.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::Bytes48;
-use crate::{Bytes32, Error};
+use crate::{Bytes32, Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/bindings/rust/src/test_formats/verify_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_kzg_proof.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use crate::Bytes32;
 use crate::Bytes48;
+use crate::{Bytes32, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -13,20 +13,28 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_commitment(&self) -> Bytes48 {
-        Bytes48::from_bytes(&hex::decode(self.commitment.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_commitment(&self) -> Result<Bytes48, Error> {
+        let hex_str = self.commitment.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes48::from_bytes(&bytes)
     }
 
-    pub fn get_z(&self) -> Bytes32 {
-        Bytes32::from_bytes(&hex::decode(self.z.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_z(&self) -> Result<Bytes32, Error> {
+        let hex_str = self.z.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes32::from_bytes(&bytes)
     }
 
-    pub fn get_y(&self) -> Bytes32 {
-        Bytes32::from_bytes(&hex::decode(self.y.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_y(&self) -> Result<Bytes32, Error> {
+        let hex_str = self.y.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes32::from_bytes(&bytes)
     }
 
-    pub fn get_proof(&self) -> Bytes48 {
-        Bytes48::from_bytes(&hex::decode(self.proof.replace("0x", "")).unwrap()).unwrap()
+    pub fn get_proof(&self) -> Result<Bytes48, Error> {
+        let hex_str = self.proof.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes48::from_bytes(&bytes)
     }
 }
 


### PR DESCRIPTION
This PR will check that each input value is ok, if not it will assert that the output is null.

* I ran into issues with overflowing the stack, so `Blob::from_bytes` returns a boxed value now.
  * `thread 'tests::test_verify_blob_kzg_proof_batch' has overflowed its stack`
  * If there's a better way of handling this, please let me know.
* The `test.input.get_*` functions return a result now, instead of always unwrapping.