### PR TITLE
Update Compute*KZGProof in java bindings

### DIFF
--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -185,7 +185,7 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitm
   return commitment;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray z_bytes)
+JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray z_bytes)
 {
   if (settings == NULL)
   {
@@ -211,12 +211,16 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(
   Bytes32 *z_native = (Bytes32 *)(*env)->GetByteArrayElements(env, z_bytes, NULL);
 
   jbyteArray proof = (*env)->NewByteArray(env, BYTES_PER_PROOF);
-  KZGProof *proof_native = (KZGProof *)(uint8_t *)(*env)->GetByteArrayElements(env, proof, NULL);
+  jbyteArray y = (*env)->NewByteArray(env, BYTES_PER_FIELD_ELEMENT);
 
-  C_KZG_RET ret = compute_kzg_proof(proof_native, blob_native, z_native, settings);
+  KZGProof *proof_native = (KZGProof *)(uint8_t *)(*env)->GetByteArrayElements(env, proof, NULL);
+  Bytes32 *y_native = (Bytes32 *)(uint8_t *)(*env)->GetByteArrayElements(env, y, NULL);
+
+  C_KZG_RET ret = compute_kzg_proof(proof_native, y_native, blob_native, z_native, settings);
 
   (*env)->ReleaseByteArrayElements(env, blob, (jbyte *)blob_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, proof, (jbyte *)proof_native, 0);
+  (*env)->ReleaseByteArrayElements(env, y, (jbyte *)y_native, 0);
 
   if (ret != C_KZG_OK)
   {
@@ -224,10 +228,39 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(
     return NULL;
   }
 
-  return proof;
+  jclass tupleClass = (*env)->FindClass(env, "ethereum/ckzg4844/Tuple");
+  if (tupleClass == NULL)
+  {
+    throw_c_kzg_exception(env, ret, "Failed to find Tuple class.");
+    return NULL;
+  }
+
+  jmethodID tupleConstructor = (*env)->GetMethodID(env, tupleClass, "<init>", "([B[B)V");
+  if (tupleConstructor == NULL)
+  {
+    throw_c_kzg_exception(env, ret, "Failed to find Tuple constructor.");
+    return NULL;
+  }
+
+  jobject tuple = (*env)->NewObject(env, tupleClass, tupleConstructor, proof, y);
+  if (tuple == NULL)
+  {
+    throw_c_kzg_exception(env, ret, "Failed to instantiate new Tuple.");
+    return NULL;
+  }
+
+  /*
+  jobject tuple = env->AllocObject(tupleClass);
+  jfieldID nameField = env->GetFieldID(tuple, "name", "[B");
+  jfieldID balanceField = env->GetFieldID(userDataClass, "balance", "[B");
+  env->SetObjectField(newUserData, nameField, name);
+  env->SetDoubleField(newUserData, balanceField, balance);
+  */
+
+  return tuple;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blob)
+JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgProof(JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray commitment_bytes)
 {
   if (settings == NULL)
   {
@@ -242,14 +275,23 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgPr
     return NULL;
   }
 
+  size_t commitment_bytes_size = (size_t)(*env)->GetArrayLength(env, commitment_bytes);
+  if (commitment_bytes_size != BYTES_PER_COMMITMENT)
+  {
+    throw_invalid_size_exception(env, "Invalid commitment size.", commitment_bytes_size, BYTES_PER_COMMITMENT);
+    return NULL;
+  }
+
   Blob *blob_native = (Blob *)(*env)->GetByteArrayElements(env, blob, NULL);
+  Bytes48 *commitment_native = (Bytes48 *)(*env)->GetByteArrayElements(env, commitment_bytes, NULL);
 
   jbyteArray proof = (*env)->NewByteArray(env, BYTES_PER_PROOF);
   KZGProof *proof_native = (KZGProof *)(uint8_t *)(*env)->GetByteArrayElements(env, proof, NULL);
 
-  C_KZG_RET ret = compute_blob_kzg_proof(proof_native, blob_native, settings);
+  C_KZG_RET ret = compute_blob_kzg_proof(proof_native, blob_native, commitment_native, settings);
 
   (*env)->ReleaseByteArrayElements(env, blob, (jbyte *)blob_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, commitment_bytes, (jbyte *)commitment_native, JNI_ABORT);
   (*env)->ReleaseByteArrayElements(env, proof, (jbyte *)proof_native, 0);
 
   if (ret != C_KZG_OK)

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -233,21 +233,21 @@ JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(JNI
   jclass tupleClass = (*env)->FindClass(env, "ethereum/ckzg4844/Tuple");
   if (tupleClass == NULL)
   {
-    throw_c_kzg_exception(env, C_KZG_ERROR, "Failed to find Tuple class.");
+    throw_exception(env, "Failed to find Tuple class.");
     return NULL;
   }
 
   jmethodID tupleConstructor = (*env)->GetMethodID(env, tupleClass, "<init>", "([B[B)V");
   if (tupleConstructor == NULL)
   {
-    throw_c_kzg_exception(env, C_KZG_ERROR, "Failed to find Tuple constructor.");
+    throw_exception(env, "Failed to find Tuple constructor.");
     return NULL;
   }
 
   jobject tuple = (*env)->NewObject(env, tupleClass, tupleConstructor, proof, y);
   if (tuple == NULL)
   {
-    throw_c_kzg_exception(env, C_KZG_ERROR, "Failed to instantiate new Tuple.");
+    throw_exception(env, "Failed to instantiate new Tuple.");
     return NULL;
   }
 

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -249,14 +249,6 @@ JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(JNI
     return NULL;
   }
 
-  /*
-  jobject tuple = env->AllocObject(tupleClass);
-  jfieldID nameField = env->GetFieldID(tuple, "name", "[B");
-  jfieldID balanceField = env->GetFieldID(userDataClass, "balance", "[B");
-  env->SetObjectField(newUserData, nameField, name);
-  env->SetDoubleField(newUserData, balanceField, balance);
-  */
-
   return tuple;
 }
 

--- a/bindings/java/src/jmh/java/ethereum/ckzg4844/CKZG4844JNIBenchmark.java
+++ b/bindings/java/src/jmh/java/ethereum/ckzg4844/CKZG4844JNIBenchmark.java
@@ -53,10 +53,12 @@ public class CKZG4844JNIBenchmark {
   @State(Scope.Benchmark)
   public static class ComputeBlobKzgProofState {
     private byte[] blob;
+    private byte[] commitment;
 
     @Setup(Level.Iteration)
     public void setUp() {
       blob = TestUtils.createRandomBlob();
+      commitment = TestUtils.createRandomCommitment();
     }
   }
 
@@ -123,13 +125,13 @@ public class CKZG4844JNIBenchmark {
   }
 
   @Benchmark
-  public byte[] computeKzgProof(final ComputeKzgProofState state) {
+  public Tuple computeKzgProof(final ComputeKzgProofState state) {
     return CKZG4844JNI.computeKzgProof(state.blob, state.z);
   }
 
   @Benchmark
   public byte[] computeBlobKzgProof(final ComputeBlobKzgProofState state) {
-    return CKZG4844JNI.computeBlobKzgProof(state.blob);
+    return CKZG4844JNI.computeBlobKzgProof(state.blob, state.commitment);
   }
 
   @Benchmark

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -156,7 +156,7 @@ public class CKZG4844JNI {
    *
    * @param blob blob bytes
    * @param z_bytes a point
-   * @return A tuple of proof and y
+   * @return a tuple of the proof and the value y = f(z)
    * @throws CKZGException if there is a crypto error
    */
   public static native Tuple computeKzgProof(byte[] blob, byte[] z_bytes);
@@ -166,7 +166,7 @@ public class CKZG4844JNI {
    *
    * @param blob blob bytes
    * @param commitment_bytes commitment bytes
-   * @return the aggregated proof
+   * @return the proof
    * @throws CKZGException if there is a crypto error
    */
   public static native byte[] computeBlobKzgProof(byte[] blob, byte[] commitment_bytes);

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -156,19 +156,20 @@ public class CKZG4844JNI {
    *
    * @param blob blob bytes
    * @param z_bytes a point
-   * @return the proof
+   * @return A tuple of proof and y
    * @throws CKZGException if there is a crypto error
    */
-  public static native byte[] computeKzgProof(byte[] blob, byte[] z_bytes);
+  public static native Tuple computeKzgProof(byte[] blob, byte[] z_bytes);
 
   /**
    * Given a blob, return the KZG proof that is used to verify it against the commitment
    *
    * @param blob blob bytes
+   * @param commitment_bytes commitment bytes
    * @return the aggregated proof
    * @throws CKZGException if there is a crypto error
    */
-  public static native byte[] computeBlobKzgProof(byte[] blob);
+  public static native byte[] computeBlobKzgProof(byte[] blob, byte[] commitment_bytes);
 
   /**
    * Verify the proof by point evaluation for the given commitment

--- a/bindings/java/src/main/java/ethereum/ckzg4844/Tuple.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/Tuple.java
@@ -1,0 +1,23 @@
+package ethereum.ckzg4844;
+
+public class Tuple {
+  private byte[] first;
+  private byte[] second;
+
+  public Tuple(byte[] first, byte[] second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  public byte[] getFirst() {
+    return first;
+  }
+
+  public byte[] getSecond() {
+    return second;
+  }
+
+  public static Tuple of(byte[] first, byte[] second) {
+    return new Tuple(first, second);
+  }
+}

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -70,9 +70,11 @@ public class CKZG4844JNITest {
     if (PRESET != Preset.MAINNET) return;
 
     try {
-      byte[] proof = CKZG4844JNI.computeKzgProof(test.getInput().getBlob(), test.getInput().getZ());
-      assertArrayEquals(test.getOutput(), proof);
+      Tuple tuple = CKZG4844JNI.computeKzgProof(test.getInput().getBlob(), test.getInput().getZ());
+      assertArrayEquals(test.getOutput().getFirst(), tuple.getFirst());
+      assertArrayEquals(test.getOutput().getSecond(), tuple.getSecond());
     } catch (CKZGException ex) {
+      System.out.println(ex);
       assertNull(test.getOutput());
     }
   }
@@ -83,7 +85,9 @@ public class CKZG4844JNITest {
     if (PRESET != Preset.MAINNET) return;
 
     try {
-      byte[] proof = CKZG4844JNI.computeBlobKzgProof(test.getInput().getBlob());
+      byte[] proof =
+          CKZG4844JNI.computeBlobKzgProof(
+              test.getInput().getBlob(), test.getInput().getCommitment());
       assertArrayEquals(test.getOutput(), proof);
     } catch (CKZGException ex) {
       assertNull(test.getOutput());
@@ -165,7 +169,7 @@ public class CKZG4844JNITest {
             i -> {
               blobsArray[i] = TestUtils.createRandomBlob();
               commitmentsArray[i] = CKZG4844JNI.blobToKzgCommitment(blobsArray[i]);
-              proofsArray[i] = CKZG4844JNI.computeBlobKzgProof(blobsArray[i]);
+              proofsArray[i] = CKZG4844JNI.computeBlobKzgProof(blobsArray[i], commitmentsArray[i]);
             });
     final byte[] blobs = TestUtils.flatten(blobsArray);
     final byte[] commitments = TestUtils.flatten(commitmentsArray);
@@ -188,8 +192,9 @@ public class CKZG4844JNITest {
     loadTrustedSetup();
     final byte[] blob = TestUtils.createRandomBlob();
     final byte[] z_bytes = TestUtils.randomBLSFieldElementBytes();
-    final byte[] proof = CKZG4844JNI.computeKzgProof(blob, z_bytes);
-    assertEquals(CKZG4844JNI.BYTES_PER_PROOF, proof.length);
+    final Tuple tuple = CKZG4844JNI.computeKzgProof(blob, z_bytes);
+    assertEquals(CKZG4844JNI.BYTES_PER_PROOF, tuple.getFirst().length);
+    assertEquals(CKZG4844JNI.BYTES_PER_FIELD_ELEMENT, tuple.getSecond().length);
     CKZG4844JNI.freeTrustedSetup();
   }
 
@@ -197,7 +202,8 @@ public class CKZG4844JNITest {
   public void checkComputeBlobKzgProof() {
     loadTrustedSetup();
     final byte[] blob = TestUtils.createRandomBlob();
-    final byte[] proof = CKZG4844JNI.computeBlobKzgProof(blob);
+    final byte[] commitment = TestUtils.createRandomCommitment();
+    final byte[] proof = CKZG4844JNI.computeBlobKzgProof(blob, commitment);
     assertEquals(CKZG4844JNI.BYTES_PER_PROOF, proof.length);
     CKZG4844JNI.freeTrustedSetup();
   }
@@ -254,7 +260,9 @@ public class CKZG4844JNITest {
         exception.getErrorMessage());
 
     exception =
-        assertThrows(CKZGException.class, () -> CKZG4844JNI.computeBlobKzgProof(new byte[123]));
+        assertThrows(
+            CKZGException.class,
+            () -> CKZG4844JNI.computeBlobKzgProof(new byte[123], new byte[32]));
 
     assertEquals(C_KZG_BADARGS, exception.getError());
     assertEquals(

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -273,6 +273,18 @@ public class CKZG4844JNITest {
         assertThrows(
             CKZGException.class,
             () ->
+                CKZG4844JNI.computeBlobKzgProof(
+                    new byte[CKZG4844JNI.getBytesPerBlob()], new byte[49]));
+
+    assertEquals(C_KZG_BADARGS, exception.getError());
+    assertEquals(
+        String.format("Invalid commitment size. Expected 48 bytes but got 49."),
+        exception.getErrorMessage());
+
+    exception =
+        assertThrows(
+            CKZGException.class,
+            () ->
                 CKZG4844JNI.verifyBlobKzgProofBatch(
                     new byte[42],
                     TestUtils.createRandomCommitments(2),

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -74,7 +74,6 @@ public class CKZG4844JNITest {
       assertArrayEquals(test.getOutput().getFirst(), tuple.getFirst());
       assertArrayEquals(test.getOutput().getSecond(), tuple.getSecond());
     } catch (CKZGException ex) {
-      System.out.println(ex);
       assertNull(test.getOutput());
     }
   }

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
@@ -61,7 +61,7 @@ public class TestUtils {
   }
 
   public static byte[] createRandomProof() {
-    return CKZG4844JNI.computeBlobKzgProof(createRandomBlob());
+    return CKZG4844JNI.computeBlobKzgProof(createRandomBlob(), createRandomCommitment());
   }
 
   public static byte[] createRandomProofs(final int count) {

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKzgProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKzgProofTest.java
@@ -5,9 +5,14 @@ import org.apache.tuweni.bytes.Bytes;
 public class ComputeBlobKzgProofTest {
   public static class Input {
     private String blob;
+    private String commitment;
 
     public byte[] getBlob() {
       return Bytes.fromHexString(blob).toArray();
+    }
+
+    public byte[] getCommitment() {
+      return Bytes.fromHexString(commitment).toArray();
     }
   }
 

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKzgProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKzgProofTest.java
@@ -1,5 +1,7 @@
 package ethereum.ckzg4844.test_formats;
 
+import ethereum.ckzg4844.Tuple;
+import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 
 public class ComputeKzgProofTest {
@@ -17,16 +19,18 @@ public class ComputeKzgProofTest {
   }
 
   private Input input;
-  private String output;
+  private List<String> output;
 
   public Input getInput() {
     return input;
   }
 
-  public byte[] getOutput() {
+  public Tuple getOutput() {
     if (output == null) {
       return null;
     }
-    return Bytes.fromHexString(output).toArray();
+    byte[] proof = Bytes.fromHexString(output.get(0)).toArray();
+    byte[] y = Bytes.fromHexString(output.get(1)).toArray();
+    return Tuple.of(proof, y);
   }
 }


### PR DESCRIPTION
This PR updates the Java bindings to be in accordance with:

* https://github.com/ethereum/c-kzg-4844/pull/174