### PR TITLE
Update Compute*KZGProof in rust bindings

### DIFF
--- a/bindings/rust/src/bindings.rs
+++ b/bindings/rust/src/bindings.rs
@@ -220,7 +220,8 @@ extern "C" {
     ) -> C_KZG_RET;
 
     pub fn compute_kzg_proof(
-        out: *mut KZGProof,
+        proof_out: *mut KZGProof,
+        y_out: *mut Bytes32,
         blob: *const Blob,
         z_bytes: *const Bytes32,
         s: *const KZGSettings,
@@ -229,6 +230,7 @@ extern "C" {
     pub fn compute_blob_kzg_proof(
         out: *mut KZGProof,
         blob: *const Blob,
+        commitment_bytes: *const Bytes48,
         s: *const KZGSettings,
     ) -> C_KZG_RET;
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -614,7 +614,6 @@ mod tests {
                 assert!(test.get_output().is_none());
                 continue;
             };
-            println!("new");
 
             match KZGProof::verify_blob_kzg_proof_batch(
                 &blobs,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -186,7 +186,13 @@ impl KZGProof {
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         let mut y_out = MaybeUninit::<Bytes32>::uninit();
         unsafe {
-            let res = compute_kzg_proof(kzg_proof.as_mut_ptr(), y_out.as_mut_ptr(), &blob, &z_bytes, kzg_settings);
+            let res = compute_kzg_proof(
+                kzg_proof.as_mut_ptr(),
+                y_out.as_mut_ptr(),
+                &blob,
+                &z_bytes,
+                kzg_settings,
+            );
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok((kzg_proof.assume_init(), y_out.assume_init()))
             } else {
@@ -195,10 +201,19 @@ impl KZGProof {
         }
     }
 
-    pub fn compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48, kzg_settings: &KZGSettings) -> Result<Self, Error> {
+    pub fn compute_blob_kzg_proof(
+        blob: Blob,
+        commitment_bytes: Bytes48,
+        kzg_settings: &KZGSettings,
+    ) -> Result<Self, Error> {
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         unsafe {
-            let res = compute_blob_kzg_proof(kzg_proof.as_mut_ptr(), &blob, &commitment_bytes, kzg_settings);
+            let res = compute_blob_kzg_proof(
+                kzg_proof.as_mut_ptr(),
+                &blob,
+                &commitment_bytes,
+                kzg_settings,
+            );
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(kzg_proof.assume_init())
             } else {
@@ -406,7 +421,9 @@ mod tests {
         let proofs: Vec<Bytes48> = blobs
             .iter()
             .zip(commitments.clone())
-            .map(|(blob, commitment)| KZGProof::compute_blob_kzg_proof(*blob, commitment, &kzg_settings).unwrap())
+            .map(|(blob, commitment)| {
+                KZGProof::compute_blob_kzg_proof(*blob, commitment, &kzg_settings).unwrap()
+            })
             .map(|proof| proof.to_bytes())
             .collect();
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -492,9 +492,9 @@ mod tests {
             };
 
             match KZGProof::compute_kzg_proof(blob, z, &kzg_settings) {
-                Ok(res) => {
-                    assert_eq!(res.0.bytes, test.get_output().unwrap().0.bytes);
-                    assert_eq!(res.1.bytes, test.get_output().unwrap().1.bytes);
+                Ok((proof, y)) => {
+                    assert_eq!(proof.bytes, test.get_output().unwrap().0.bytes);
+                    assert_eq!(y.bytes, test.get_output().unwrap().1.bytes);
                 }
                 _ => assert!(test.get_output().is_none()),
             }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -110,7 +110,7 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Box<Self>, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != BYTES_PER_BLOB {
             return Err(Error::InvalidBytesLength(format!(
                 "Invalid byte length. Expected {} got {}",
@@ -120,7 +120,7 @@ impl Blob {
         }
         let mut new_bytes = [0; BYTES_PER_BLOB];
         new_bytes.copy_from_slice(bytes);
-        Ok(Box::new(Self { bytes: new_bytes }))
+        Ok(Self { bytes: new_bytes })
     }
 }
 
@@ -469,7 +469,7 @@ mod tests {
                 continue;
             };
 
-            match KZGCommitment::blob_to_kzg_commitment(*blob, &kzg_settings) {
+            match KZGCommitment::blob_to_kzg_commitment(blob, &kzg_settings) {
                 Ok(res) => assert_eq!(res.bytes, test.get_output().unwrap().bytes),
                 _ => assert!(test.get_output().is_none()),
             }
@@ -491,7 +491,7 @@ mod tests {
                 continue;
             };
 
-            match KZGProof::compute_kzg_proof(*blob, z, &kzg_settings) {
+            match KZGProof::compute_kzg_proof(blob, z, &kzg_settings) {
                 Ok(res) => {
                     assert_eq!(res.0.bytes, test.get_output().unwrap().0.bytes);
                     assert_eq!(res.1.bytes, test.get_output().unwrap().1.bytes);
@@ -519,7 +519,7 @@ mod tests {
                 continue;
             };
 
-            match KZGProof::compute_blob_kzg_proof(*blob, commitment, &kzg_settings) {
+            match KZGProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings) {
                 Ok(res) => assert_eq!(res.bytes, test.get_output().unwrap().bytes),
                 _ => assert!(test.get_output().is_none()),
             }
@@ -572,7 +572,7 @@ mod tests {
                 continue;
             };
 
-            match KZGProof::verify_blob_kzg_proof(*blob, commitment, proof, &kzg_settings) {
+            match KZGProof::verify_blob_kzg_proof(blob, commitment, proof, &kzg_settings) {
                 Ok(res) => assert_eq!(res, test.get_output().unwrap()),
                 _ => assert!(test.get_output().is_none()),
             }
@@ -597,15 +597,12 @@ mod tests {
                 assert!(test.get_output().is_none());
                 continue;
             };
+            println!("new");
 
             match KZGProof::verify_blob_kzg_proof_batch(
-                blobs
-                    .into_iter()
-                    .map(|b| *b)
-                    .collect::<Vec<Blob>>()
-                    .as_slice(),
-                commitments.as_slice(),
-                proofs.as_slice(),
+                &blobs,
+                &commitments,
+                &proofs,
                 &kzg_settings,
             ) {
                 Ok(res) => assert_eq!(res, test.get_output().unwrap()),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -420,9 +420,9 @@ mod tests {
 
         let proofs: Vec<Bytes48> = blobs
             .iter()
-            .zip(commitments.clone())
+            .zip(commitments.iter())
             .map(|(blob, commitment)| {
-                KZGProof::compute_blob_kzg_proof(*blob, commitment, &kzg_settings).unwrap()
+                KZGProof::compute_blob_kzg_proof(*blob, *commitment, &kzg_settings).unwrap()
             })
             .map(|proof| proof.to_bytes())
             .collect();

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -9,7 +9,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
+    pub fn get_blob(&self) -> Result<Blob, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct Input<'a> {
     blob: &'a str,
+    commitment: &'a str,
 }
 
 impl Input<'_> {
@@ -13,6 +14,12 @@ impl Input<'_> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)
+    }
+
+    pub fn get_commitment(&self) -> Result<Bytes48, Error> {
+        let hex_str = self.commitment.replace("0x", "");
+        let bytes = hex::decode(hex_str).unwrap();
+        Bytes48::from_bytes(&bytes)
     }
 }
 

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
+    pub fn get_blob(&self) -> Result<Blob, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -37,13 +37,11 @@ impl Test<'_> {
             return None;
         }
 
-        let proof_hex = self.output.as_ref().unwrap().0
-            .replace("0x", "");
+        let proof_hex = self.output.as_ref().unwrap().0.replace("0x", "");
         let proof_bytes = hex::decode(proof_hex).unwrap();
         let proof = Bytes48::from_bytes(&proof_bytes).unwrap();
 
-        let z_hex = self.output.as_ref().unwrap().1
-            .replace("0x", "");
+        let z_hex = self.output.as_ref().unwrap().1.replace("0x", "");
         let z_bytes = hex::decode(z_hex).unwrap();
         let z = Bytes32::from_bytes(&z_bytes).unwrap();
 

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -28,14 +28,25 @@ pub struct Test<'a> {
     #[serde(borrow)]
     pub input: Input<'a>,
     #[serde(borrow)]
-    output: Option<&'a str>,
+    output: Option<(&'a str, &'a str)>,
 }
 
 impl Test<'_> {
-    pub fn get_output(&self) -> Option<Bytes48> {
-        self.output
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
+    pub fn get_output(&self) -> Option<(Bytes48, Bytes32)> {
+        if self.output.is_none() {
+            return None;
+        }
+
+        let proof_hex = self.output.as_ref().unwrap().0
+            .replace("0x", "");
+        let proof_bytes = hex::decode(proof_hex).unwrap();
+        let proof = Bytes48::from_bytes(&proof_bytes).unwrap();
+
+        let z_hex = self.output.as_ref().unwrap().1
+            .replace("0x", "");
+        let z_bytes = hex::decode(z_hex).unwrap();
+        let z = Bytes32::from_bytes(&z_bytes).unwrap();
+
+        Some((proof, z))
     }
 }

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
+    pub fn get_blob(&self) -> Result<Blob, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
@@ -11,7 +11,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
+    pub fn get_blob(&self) -> Result<Blob, Error> {
         let hex_str = self.blob.replace("0x", "");
         let bytes = hex::decode(hex_str).unwrap();
         Blob::from_bytes(&bytes)

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -11,13 +11,17 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self) -> Result<Vec<Box<Blob>>, Error> {
-        self.blobs
-            .iter()
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Blob::from_bytes(bytes.as_slice()))
-            .collect::<Result<Vec<Box<Blob>>, Error>>()
+    pub fn get_blobs(&self) -> Result<Vec<Blob>, Error> {
+        let mut v: Vec<Blob> = Vec::new();
+
+        for blob in &self.blobs {
+            let blob_hex = blob.replace("0x", "");
+            let blob_bytes = hex::decode(blob_hex).unwrap();
+            let b = Blob::from_bytes(blob_bytes.as_slice())?;
+            v.push(b);
+        }
+
+        return Ok(v);
     }
 
     pub fn get_commitments(&self) -> Result<Vec<Bytes48>, Error> {


### PR DESCRIPTION
This is still WIP because even though everything works with `cargo test --release`, there is a stack overflow in the end-to-end test when run with `cargo test`.

I might need to box something like @jtraglia did for variable length tests.