### PR TITLE
Update Compute*KZGProof in c# bindings

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
@@ -31,10 +31,10 @@ public static partial class Ckzg
     private static extern unsafe KzgResult BlobToKzgCommitment(byte* commitment, byte* blob, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeKzgProof(byte* proof, byte* blob, byte* z, IntPtr ts);
+    private static extern unsafe KzgResult ComputeKzgProof(byte* proof_out, byte*y_out, byte* blob, byte* z, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeBlobKzgProof(byte* proof, byte* blob, IntPtr ts);
+    private static extern unsafe KzgResult ComputeBlobKzgProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
     private static extern unsafe KzgResult VerifyKzgProof(out bool result, byte* commitment, byte* z,

--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -117,7 +117,7 @@ public class ReferenceTests
     private class ComputeKzgProofTest
     {
         public ComputeKzgProofInput Input { get; set; } = null!;
-        public string? Output { get; set; } = null!;
+        public List<string>? Output { get; set; } = null!;
     }
 
     [TestCase]
@@ -133,16 +133,24 @@ public class ReferenceTests
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] proof = new byte[48];
+            byte[] y = new byte[32];
             byte[] blob = GetBytes(test.Input.Blob);
             byte[] z = GetBytes(test.Input.Z);
 
             try
             {
-                Ckzg.ComputeKzgProof(proof, blob, z, _ts);
-                string? proofStr = test.Output;
+                Ckzg.ComputeKzgProof(proof, y, blob, z, _ts);
+                Assert.That(test.Output, Is.Not.EqualTo(null));
+
+                string? proofStr = test.Output.ElementAt(0);
                 Assert.That(proofStr, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(proofStr);
                 Assert.That(proof, Is.EqualTo(expectedProof));
+
+                string? yStr = test.Output.ElementAt(1);
+                Assert.That(yStr, Is.Not.EqualTo(null));
+                byte[] expectedY = GetBytes(yStr);
+                Assert.That(y, Is.EqualTo(expectedY));
             }
             catch
             {
@@ -158,6 +166,7 @@ public class ReferenceTests
     private class ComputeBlobKzgProofInput
     {
         public string Blob { get; set; } = null!;
+        public string Commitment { get; set; } = null!;
     }
 
     private class ComputeBlobKzgProofTest
@@ -180,10 +189,11 @@ public class ReferenceTests
 
             byte[] proof = new byte[48];
             byte[] blob = GetBytes(test.Input.Blob);
+            byte[] commitment = GetBytes(test.Input.Commitment);
 
             try
             {
-                Ckzg.ComputeBlobKzgProof(proof, blob, _ts);
+                Ckzg.ComputeBlobKzgProof(proof, blob, commitment, _ts);
                 string? proofStr = test.Output;
                 Assert.That(proofStr, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(proofStr);

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -15,9 +15,9 @@ DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
 
 DLLEXPORT C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZGSettings *s);
 
-DLLEXPORT C_KZG_RET compute_kzg_proof(KZGProof *out, const Blob *blob, const Bytes32 *z_bytes, const KZGSettings *s);
+DLLEXPORT C_KZG_RET compute_kzg_proof(KZGProof *proof_out, Bytes32 *y_out, const Blob *blob, const Bytes32 *z_bytes, const KZGSettings *s);
 
-DLLEXPORT C_KZG_RET compute_blob_kzg_proof(KZGProof *out, const Blob *blob, const KZGSettings *s);
+DLLEXPORT C_KZG_RET compute_blob_kzg_proof(KZGProof *out, const Blob *blob, const Bytes48 *commitment, const KZGSettings *s);
 
 DLLEXPORT C_KZG_RET verify_kzg_proof(bool *result, const Bytes48 *commitments_bytes, const Bytes32 *z_bytes, const Bytes32 *y_bytes, const Bytes48 *proof_bytes, const KZGSettings *s);
 


### PR DESCRIPTION
This PR updates the C# bindings to the new ComputeKzgProof & ComputeBlobKzgProof interface.