### PR TITLE
Make verify_blob_kzg_proof_batch() work with multithreading

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -13,6 +13,7 @@ minimal-spec = []
 [dependencies]
 hex = "0.4.2"
 libc = "0.2"
+rayon = "1.7.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR is a PoC replacing `verify_blob_kzg_proof_batch()` with multithreaded calls to `verify_blob_kzg_proof()`. This is made really easy by Rust's rayon crate which is why I only did it for Rust.

The code is quite messy; I just made it as a PoC and I can improve it if we want to go with it.

Two big benefits here:
- This is significantly faster than the status quo (see below)
- We don't touch the more complicated batch verification logic of c-kzg

Two drawbacks:
- This is not gonna work in single threaded machines (but even rpi4s have multiple cores these days iirc)
- An extra dependency for the rust bindings

---

Here are some benchmarks:

* Parallel batch (this PR):
```
verify_blob_kzg_proof_batch/1      time:   [4.6296 ms 4.6458 ms 4.6643 ms]
verify_blob_kzg_proof_batch/2      time:   [5.0340 ms 5.1749 ms 5.3304 ms]
verify_blob_kzg_proof_batch/4      time:   [8.2233 ms 8.2545 ms 8.2890 ms]
verify_blob_kzg_proof_batch/8      time:   [13.109 ms 13.194 ms 13.279 ms]
verify_blob_kzg_proof_batch/16     time:   [19.952 ms 20.080 ms 20.225 ms]
verify_blob_kzg_proof_batch/32     time:   [36.771 ms 36.972 ms 37.187 ms]
verify_blob_kzg_proof_batch/64     time:   [67.669 ms 68.022 ms 68.448 ms]
```

* Regular `verify_blob_kzg_proof_batch()`
```
verify_blob_kzg_proof_batch/1      time:   [4.7198 ms 4.7386 ms 4.7630 ms]
verify_blob_kzg_proof_batch/2      time:   [7.2811 ms 7.3248 ms 7.3990 ms]
verify_blob_kzg_proof_batch/4      time:   [12.417 ms 12.436 ms 12.459 ms]
verify_blob_kzg_proof_batch/8      time:   [22.761 ms 22.772 ms 22.785 ms]
verify_blob_kzg_proof_batch/16     time:   [43.231 ms 43.302 ms 43.398 ms]
verify_blob_kzg_proof_batch/32     time:   [84.329 ms 84.544 ms 84.800 ms]
verify_blob_kzg_proof_batch/64     time:   [170.50 ms 170.72 ms 170.98 ms]
```

(My laptop is slow, so just pay attention to the relative changes between the two approaches)