### PR TITLE
Documentation fix for roots of unity

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -75,6 +75,7 @@ static const g2_t G2_GENERATOR = {
 
 /**
  * The first 32 roots of unity in the finite field F_r.
+ * SCALE2_ROOT_OF_UNITY[i] is a 2^i'th root of unity.
  *
  * For element `{A, B, C, D}`, the field element value is
  * `A + B * 2^64 + C * 2^128 + D * 2^192`. This format may be converted to
@@ -91,9 +92,10 @@ static const g2_t G2_GENERATOR = {
  * `k < q-1` where q is the modulus. So powers of r generate the field. This is
  * also known as being a "primitive element".
  *
- * This is easy to check for: we just require that r^((q-1)/2) != 1. Instead of
- * 5, we could use 7, 10, 13, 14, 15, 20... to create the roots of unity below.
- * There are a lot of primitive roots:
+ * In the formula above, the restriction can be slightly relaxed to `r` being a non-square.
+ * This is easy to check: We just require that r^((q-1)/2) == -1. Instead of
+ * 5, we could use 7, 10, 13, 14, 15, 20... to create the 2^i'th roots of unity below.
+ * Generally, there are a lot of primitive roots:
  * https://crypto.stanford.edu/pbc/notes/numbertheory/gen.html
  */
 static const uint64_t SCALE2_ROOT_OF_UNITY[][4] = {


### PR DESCRIPTION
The previous statement was slightly wrong. Being a primite root does not mean r^( (q-1)/2) != 1. If q=1 == 2^s * t, the latter is satisfied by e.g. t'th roots of unity, but those are not primitive roots by the usual definition. Fortunately, the actual computation of 2^i'th roots of unity does not require a primitve root to start with, only a non-square.