### PR TITLE
Cleanup rust tests format functions

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -122,6 +122,10 @@ impl Blob {
         new_bytes.copy_from_slice(bytes);
         Ok(Self { bytes: new_bytes })
     }
+
+    pub fn from_hex(hex_str: &str) -> Result<Self, Error> {
+        Self::from_bytes(&hex::decode(&hex_str[2..]).unwrap())
+    }
 }
 
 impl Bytes32 {
@@ -137,6 +141,10 @@ impl Bytes32 {
         new_bytes.copy_from_slice(bytes);
         Ok(Self { bytes: new_bytes })
     }
+
+    pub fn from_hex(hex_str: &str) -> Result<Self, Error> {
+        Self::from_bytes(&hex::decode(&hex_str[2..]).unwrap())
+    }
 }
 
 impl Bytes48 {
@@ -151,6 +159,10 @@ impl Bytes48 {
         let mut new_bytes = [0; 48];
         new_bytes.copy_from_slice(bytes);
         Ok(Self { bytes: new_bytes })
+    }
+
+    pub fn from_hex(hex_str: &str) -> Result<Self, Error> {
+        Self::from_bytes(&hex::decode(&hex_str[2..]).unwrap())
     }
 }
 

--- a/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/test_formats/blob_to_kzg_commitment_test.rs
@@ -10,9 +10,7 @@ pub struct Input<'a> {
 
 impl Input<'_> {
     pub fn get_blob(&self) -> Result<Blob, Error> {
-        let hex_str = self.blob.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Blob::from_bytes(&bytes)
+        Blob::from_hex(self.blob)
     }
 }
 
@@ -26,9 +24,6 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
-        self.output
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
+        self.output.map(|s| Bytes48::from_hex(s).unwrap())
     }
 }

--- a/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_blob_kzg_proof.rs
@@ -11,15 +11,11 @@ pub struct Input<'a> {
 
 impl Input<'_> {
     pub fn get_blob(&self) -> Result<Blob, Error> {
-        let hex_str = self.blob.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Blob::from_bytes(&bytes)
+        Blob::from_hex(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {
-        let hex_str = self.commitment.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes48::from_bytes(&bytes)
+        Bytes48::from_hex(self.commitment)
     }
 }
 
@@ -33,9 +29,6 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<Bytes48> {
-        self.output
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Bytes48::from_bytes(&bytes).unwrap())
+        self.output.map(|s| Bytes48::from_hex(s).unwrap())
     }
 }

--- a/bindings/rust/src/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/compute_kzg_proof.rs
@@ -11,15 +11,11 @@ pub struct Input<'a> {
 
 impl Input<'_> {
     pub fn get_blob(&self) -> Result<Blob, Error> {
-        let hex_str = self.blob.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Blob::from_bytes(&bytes)
+        Blob::from_hex(self.blob)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {
-        let hex_str = self.z.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes32::from_bytes(&bytes)
+        Bytes32::from_hex(self.z)
     }
 }
 
@@ -33,18 +29,11 @@ pub struct Test<'a> {
 
 impl Test<'_> {
     pub fn get_output(&self) -> Option<(Bytes48, Bytes32)> {
-        if self.output.is_none() {
-            return None;
-        }
-
-        let proof_hex = self.output.as_ref().unwrap().0.replace("0x", "");
-        let proof_bytes = hex::decode(proof_hex).unwrap();
-        let proof = Bytes48::from_bytes(&proof_bytes).unwrap();
-
-        let z_hex = self.output.as_ref().unwrap().1.replace("0x", "");
-        let z_bytes = hex::decode(z_hex).unwrap();
-        let z = Bytes32::from_bytes(&z_bytes).unwrap();
-
-        Some((proof, z))
+        self.output.map(|(proof, y)| {
+            (
+                Bytes48::from_hex(proof).unwrap(),
+                Bytes32::from_hex(y).unwrap(),
+            )
+        })
     }
 }

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof.rs
@@ -12,21 +12,15 @@ pub struct Input<'a> {
 
 impl Input<'_> {
     pub fn get_blob(&self) -> Result<Blob, Error> {
-        let hex_str = self.blob.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Blob::from_bytes(&bytes)
+        Blob::from_hex(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {
-        let hex_str = self.commitment.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes48::from_bytes(&bytes)
+        Bytes48::from_hex(self.commitment)
     }
 
     pub fn get_proof(&self) -> Result<Bytes48, Error> {
-        let hex_str = self.proof.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes48::from_bytes(&bytes)
+        Bytes48::from_hex(self.proof)
     }
 }
 

--- a/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/test_formats/verify_blob_kzg_proof_batch.rs
@@ -13,32 +13,23 @@ pub struct Input {
 impl Input {
     pub fn get_blobs(&self) -> Result<Vec<Blob>, Error> {
         let mut v: Vec<Blob> = Vec::new();
-
         for blob in &self.blobs {
-            let blob_hex = blob.replace("0x", "");
-            let blob_bytes = hex::decode(blob_hex).unwrap();
-            let b = Blob::from_bytes(blob_bytes.as_slice())?;
-            v.push(b);
+            v.push(Blob::from_hex(blob)?);
         }
-
         return Ok(v);
     }
 
     pub fn get_commitments(&self) -> Result<Vec<Bytes48>, Error> {
         self.commitments
             .iter()
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()))
+            .map(|s| Bytes48::from_hex(s))
             .collect::<Result<Vec<Bytes48>, Error>>()
     }
 
     pub fn get_proofs(&self) -> Result<Vec<Bytes48>, Error> {
         self.proofs
             .iter()
-            .map(|s| s.replace("0x", ""))
-            .map(|hex_str| hex::decode(hex_str).unwrap())
-            .map(|bytes| Bytes48::from_bytes(bytes.as_slice()))
+            .map(|s| Bytes48::from_hex(s))
             .collect::<Result<Vec<Bytes48>, Error>>()
     }
 }

--- a/bindings/rust/src/test_formats/verify_kzg_proof.rs
+++ b/bindings/rust/src/test_formats/verify_kzg_proof.rs
@@ -13,27 +13,19 @@ pub struct Input<'a> {
 
 impl Input<'_> {
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {
-        let hex_str = self.commitment.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes48::from_bytes(&bytes)
+        Bytes48::from_hex(self.commitment)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {
-        let hex_str = self.z.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes32::from_bytes(&bytes)
+        Bytes32::from_hex(self.z)
     }
 
     pub fn get_y(&self) -> Result<Bytes32, Error> {
-        let hex_str = self.y.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes32::from_bytes(&bytes)
+        Bytes32::from_hex(self.y)
     }
 
     pub fn get_proof(&self) -> Result<Bytes48, Error> {
-        let hex_str = self.proof.replace("0x", "");
-        let bytes = hex::decode(hex_str).unwrap();
-        Bytes48::from_bytes(&bytes)
+        Bytes48::from_hex(self.proof)
     }
 }
 


### PR DESCRIPTION
This PR will:

* Replace the boilerplate hex decoding with `::from_hex`.
* Fix a minor typo in the `compute_kzg_proof` output function.
  * The name `z` was used when it should have been `y`.