### PR TITLE
Automate publishing for C#

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -102,4 +102,4 @@ jobs:
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
     - name: Publish package
       if: github.ref == 'refs/heads/main'
-      run: dotnet nuget push bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg --api-key {{secrets.CSHARP_NUGET_APIKEY}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg --api-key ${{ secrets.CSHARP_NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -101,4 +101,5 @@ jobs:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
     - name: Publish package
+      if: github.ref == 'refs/heads/main'
       run: dotnet nuget push bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg --api-key {{secrets.CSHARP_NUGET_APIKEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -100,3 +100,5 @@ jobs:
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
+    - name: Publish package
+      run: dotnet nuget push bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg --api-key {{secrets.CSHARP_NUGET_APIKEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 env:
-  binding_build_number_based_version: 0.1.1.${{ github.run_number }}
+  binding_build_number_based_version: 0.1.2.${{ github.run_number }}
 
 jobs:
   build-ckzg:
@@ -94,9 +94,9 @@ jobs:
     - name: Test
       run: cd bindings/csharp && dotnet test --configuration Release --no-restore
     - name: Build
-      run: cd bindings/csharp && dotnet build -p:Version=${{ inputs.version || env.binding_build_number_based_version }} --configuration Release --no-restore
+      run: cd bindings/csharp && dotnet pack -p:Version=${{ inputs.version || env.binding_build_number_based_version }} --configuration Release --no-restore --output nupkgs
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
-        path: bindings/csharp/build/Ckzg.Bindings.*.nupkg
+        path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg


### PR DESCRIPTION
The C# package is available at https://www.nuget.org/packages/Ckzg.Bindings/
Previously, it was placed manually there, by uploading the build artifact.
It can be done automatically now.