### PR TITLE
Null out pointers when failing to construct FFT or KZG Settings

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1672,6 +1672,9 @@ out_error:
     free(fs->expanded_roots_of_unity);
     free(fs->reverse_roots_of_unity);
     free(fs->roots_of_unity);
+    fs->expanded_roots_of_unity = NULL;
+    fs->reverse_roots_of_unity = NULL;
+    fs->roots_of_unity = NULL;
 out_success:
     return ret;
 }
@@ -1762,6 +1765,9 @@ out_error:
     free((void *)out->fs);
     free(out->g1_values);
     free(out->g2_values);
+    out->fs = NULL;
+    out->g1_values = NULL;
+    out->g2 = NULL;
 out_success:
     free(g1_projective);
     return ret;
@@ -1814,6 +1820,8 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
  * @param[in] s The trusted setup to free
  */
 void free_trusted_setup(KZGSettings *s) {
-    free_fft_settings((FFTSettings *)s->fs);
+    if (s->fs != NULL){
+        free_fft_settings((FFTSettings *)s->fs);
+    }
     free_kzg_settings(s);
 }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1767,7 +1767,7 @@ out_error:
     free(out->g2_values);
     out->fs = NULL;
     out->g1_values = NULL;
-    out->g2 = NULL;
+    out->g2_values = NULL;
 out_success:
     free(g1_projective);
     return ret;


### PR DESCRIPTION
This aims to prevent a double-free footgun if a user (wrongly) calls the free_* function after construction of the setup fails.

Notably, if there is a (say) out-of-memory error at the second malloc call when creating a KZG / FFT setup and the user (wrongly) then frees the setup, we get a double-free. This PR aims to make that bogus free call a no-op.
Of course, the user is not actually expected to free the setup, but it's a likely error.