### PR TITLE
Add c_kzg_free() helper free-and-null macro

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -33,6 +33,14 @@
 #define CHECK(cond) \
     if (!(cond)) return C_KZG_BADARGS
 
+/** Helper macro to release memory allocated on the heap.  Unlike free(),
+ * c_kzg_free() macro sets the pointer value to NULL after freeing it. */
+#define c_kzg_free(p) \
+    (void)({ \
+        free(p); \
+        (p) = NULL; \
+    })
+
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
@@ -180,7 +188,7 @@ static C_KZG_RET c_kzg_calloc(void **out, size_t count, size_t size) {
 /**
  * Allocate memory for an array of G1 group elements.
  *
- * @remark Free the space later using `free()`.
+ * @remark Free the space later using `c_kzg_free()`.
  *
  * @param[out] x Pointer to the allocated space
  * @param[in]  n The number of G1 elements to be allocated
@@ -192,7 +200,7 @@ static C_KZG_RET new_g1_array(g1_t **x, size_t n) {
 /**
  * Allocate memory for an array of G2 group elements.
  *
- * @remark Free the space later using `free()`.
+ * @remark Free the space later using `c_kzg_free()`.
  *
  * @param[out] x Pointer to the allocated space
  * @param[in]  n The number of G2 elements to be allocated
@@ -204,7 +212,7 @@ static C_KZG_RET new_g2_array(g2_t **x, size_t n) {
 /**
  * Allocate memory for an array of field elements.
  *
- * @remark Free the space later using `free()`.
+ * @remark Free the space later using `c_kzg_free()`.
  *
  * @param[out] x Pointer to the allocated space
  * @param[in]  n The number of field elements to be allocated
@@ -343,7 +351,7 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, size_t len) {
     out[0] = inv;
 
 out:
-    free(prod);
+    c_kzg_free(prod);
     return ret;
 }
 
@@ -818,9 +826,9 @@ static C_KZG_RET g1_lincomb_fast(
     ret = C_KZG_OK;
 
 out:
-    free(scratch);
-    free(p_affine);
-    free(scalars);
+    c_kzg_free(scratch);
+    c_kzg_free(p_affine);
+    c_kzg_free(scalars);
     return ret;
 }
 
@@ -897,8 +905,8 @@ static C_KZG_RET evaluate_polynomial_in_evaluation_form(
     blst_fr_mul(out, out, &tmp);
 
 out:
-    free(inverses_in);
-    free(inverses);
+    c_kzg_free(inverses_in);
+    c_kzg_free(inverses);
     return ret;
 }
 
@@ -1165,8 +1173,8 @@ static C_KZG_RET compute_kzg_proof_impl(
     bytes_from_g1(proof_out, &out_g1);
 
 out:
-    free(inverses_in);
-    free(inverses);
+    c_kzg_free(inverses_in);
+    c_kzg_free(inverses);
     return ret;
 }
 
@@ -1320,7 +1328,7 @@ static C_KZG_RET compute_r_powers(
     ret = C_KZG_OK;
 
 out:
-    free(bytes);
+    c_kzg_free(bytes);
     return ret;
 }
 
@@ -1412,9 +1420,9 @@ static C_KZG_RET verify_kzg_proof_batch(
     ret = C_KZG_OK;
 
 out:
-    free(r_powers);
-    free(C_minus_y);
-    free(r_times_z);
+    c_kzg_free(r_powers);
+    c_kzg_free(C_minus_y);
+    c_kzg_free(r_times_z);
 
     return ret;
 }
@@ -1498,11 +1506,11 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     );
 
 out:
-    free(commitments_g1);
-    free(proofs_g1);
-    free(evaluation_challenges_fr);
-    free(ys_fr);
-    free(polynomials);
+    c_kzg_free(commitments_g1);
+    c_kzg_free(proofs_g1);
+    c_kzg_free(evaluation_challenges_fr);
+    c_kzg_free(ys_fr);
+    c_kzg_free(polynomials);
 
     return ret;
 }
@@ -1690,9 +1698,9 @@ static C_KZG_RET new_fft_settings(FFTSettings *fs, unsigned int max_scale) {
     goto out_success;
 
 out_error:
-    free(fs->expanded_roots_of_unity);
-    free(fs->reverse_roots_of_unity);
-    free(fs->roots_of_unity);
+    c_kzg_free(fs->expanded_roots_of_unity);
+    c_kzg_free(fs->reverse_roots_of_unity);
+    c_kzg_free(fs->roots_of_unity);
 out_success:
     return ret;
 }
@@ -1703,9 +1711,9 @@ out_success:
  * @param[in] fs The settings to be freed
  */
 static void free_fft_settings(FFTSettings *fs) {
-    free(fs->expanded_roots_of_unity);
-    free(fs->reverse_roots_of_unity);
-    free(fs->roots_of_unity);
+    c_kzg_free(fs->expanded_roots_of_unity);
+    c_kzg_free(fs->reverse_roots_of_unity);
+    c_kzg_free(fs->roots_of_unity);
     fs->max_width = 0;
 }
 
@@ -1715,9 +1723,9 @@ static void free_fft_settings(FFTSettings *fs) {
  * @param[in] ks The settings to be freed
  */
 static void free_kzg_settings(KZGSettings *ks) {
-    free(ks->fs);
-    free(ks->g1_values);
-    free(ks->g2_values);
+    c_kzg_free(ks->fs);
+    c_kzg_free(ks->g1_values);
+    c_kzg_free(ks->g2_values);
 }
 
 /**
@@ -1780,11 +1788,11 @@ C_KZG_RET load_trusted_setup(
     goto out_success;
 
 out_error:
-    free(out->fs);
-    free(out->g1_values);
-    free(out->g2_values);
+    c_kzg_free(out->fs);
+    c_kzg_free(out->g1_values);
+    c_kzg_free(out->g2_values);
 out_success:
-    free(g1_projective);
+    c_kzg_free(g1_projective);
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -33,8 +33,10 @@
 #define CHECK(cond) \
     if (!(cond)) return C_KZG_BADARGS
 
-/** Helper macro to release memory allocated on the heap.  Unlike free(),
- * c_kzg_free() macro sets the pointer value to NULL after freeing it. */
+/**
+ * Helper macro to release memory allocated on the heap. Unlike free(),
+ * c_kzg_free() macro sets the pointer value to NULL after freeing it.
+ */
 #define c_kzg_free(p) \
     (void)({ \
         free(p); \

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1715,7 +1715,7 @@ static void free_fft_settings(FFTSettings *fs) {
  * @param[in] ks The settings to be freed
  */
 static void free_kzg_settings(KZGSettings *ks) {
-    free((FFTSettings *)ks->fs);
+    free(ks->fs);
     free(ks->g1_values);
     free(ks->g2_values);
 }
@@ -1780,7 +1780,7 @@ C_KZG_RET load_trusted_setup(
     goto out_success;
 
 out_error:
-    free((void *)out->fs);
+    free(out->fs);
     free(out->g1_values);
     free(out->g2_values);
 out_success:

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1708,9 +1708,15 @@ out_success:
 /**
  * Free the memory that was previously allocated by #new_fft_settings.
  *
+ * @remark It's a NOP if `fs` is NULL.
+ *
  * @param[in] fs The settings to be freed
  */
 static void free_fft_settings(FFTSettings *fs) {
+    if (!fs) {
+        return;
+    }
+
     c_kzg_free(fs->expanded_roots_of_unity);
     c_kzg_free(fs->reverse_roots_of_unity);
     c_kzg_free(fs->roots_of_unity);
@@ -1720,9 +1726,15 @@ static void free_fft_settings(FFTSettings *fs) {
 /**
  * Free the memory that was previously allocated by #new_kzg_settings.
  *
+ * @remark It's a NOP if `ks` is NULL.
+ *
  * @param[in] ks The settings to be freed
  */
 static void free_kzg_settings(KZGSettings *ks) {
+    if (!ks) {
+        return;
+    }
+
     c_kzg_free(ks->fs);
     c_kzg_free(ks->g1_values);
     c_kzg_free(ks->g2_values);
@@ -1840,9 +1852,15 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
 /**
  * Free a trusted setup (KZGSettings).
  *
+ * @remark It's a NOP if `s` is NULL.
+ *
  * @param[in] s The trusted setup to free
  */
 void free_trusted_setup(KZGSettings *s) {
+    if (!s) {
+        return;
+    }
+
     free_fft_settings((FFTSettings *)s->fs);
     free_kzg_settings(s);
 }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1715,9 +1715,7 @@ out_success:
  * @param[in] fs The settings to be freed
  */
 static void free_fft_settings(FFTSettings *fs) {
-    if (!fs) {
-        return;
-    }
+    if (fs == NULL) return;
 
     c_kzg_free(fs->expanded_roots_of_unity);
     c_kzg_free(fs->reverse_roots_of_unity);
@@ -1733,9 +1731,7 @@ static void free_fft_settings(FFTSettings *fs) {
  * @param[in] ks The settings to be freed
  */
 static void free_kzg_settings(KZGSettings *ks) {
-    if (!ks) {
-        return;
-    }
+    if (ks == NULL) return;
 
     c_kzg_free(ks->fs);
     c_kzg_free(ks->g1_values);
@@ -1859,9 +1855,7 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
  * @param[in] s The trusted setup to free
  */
 void free_trusted_setup(KZGSettings *s) {
-    if (!s) {
-        return;
-    }
+    if (s == NULL) return;
 
     free_fft_settings((FFTSettings *)s->fs);
     free_kzg_settings(s);

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -119,7 +119,7 @@ typedef struct {
  */
 typedef struct {
     /** The corresponding settings for performing FFTs. */
-    const FFTSettings *fs;
+    FFTSettings *fs;
     /** G1 group elements from the trusted setup,
      * in Lagrange form bit-reversal permutation. */
     g1_t *g1_values;


### PR DESCRIPTION
Add a helper macro to release memory allocated on the heap.  Unlike free(), c_kzg_free() macro sets the pointer value to NULL after freeing it.

This is inspired by https://github.com/ethereum/c-kzg-4844/pull/209 .
