### PR TITLE
Add ref test count checks for all bindings

### DIFF
--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -80,7 +80,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_blobToKzgCommitmentTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_blobToKzgCommitmentTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             BlobToKzgCommitmentTest test = _deserializer.Deserialize<BlobToKzgCommitmentTest>(yaml);
@@ -125,7 +128,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_computeKzgProofTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeKzgProofTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             ComputeKzgProofTest test = _deserializer.Deserialize<ComputeKzgProofTest>(yaml);
@@ -174,7 +180,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_computeBlobKzgProofTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeBlobKzgProofTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             ComputeBlobKzgProofTest test = _deserializer.Deserialize<ComputeBlobKzgProofTest>(yaml);
@@ -222,7 +231,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_verifyKzgProofTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyKzgProofTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             VerifyKzgProofTest test = _deserializer.Deserialize<VerifyKzgProofTest>(yaml);
@@ -268,7 +280,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_verifyBlobKzgProofTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKzgProofTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             VerifyBlobKzgProofTest test = _deserializer.Deserialize<VerifyBlobKzgProofTest>(yaml);
@@ -312,7 +327,10 @@ public class ReferenceTests
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        foreach (string testFile in matcher.GetResultsInFullPath(_verifyBlobKzgProofBatchTests))
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKzgProofBatchTests);
+        Assert.That(testFiles.Count(), Is.GreaterThan(0));
+
+        foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
             VerifyBlobKzgProofBatchTest test = _deserializer.Deserialize<VerifyBlobKzgProofBatchTest>(yaml);

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -128,6 +128,8 @@ func TestBlobToKZGCommitment(t *testing.T) {
 
 	tests, err := filepath.Glob(blobToKZGCommitmentTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)
@@ -166,6 +168,8 @@ func TestComputeKZGProof(t *testing.T) {
 
 	tests, err := filepath.Glob(computeKZGProofTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)
@@ -218,6 +222,8 @@ func TestComputeBlobKZGProof(t *testing.T) {
 
 	tests, err := filepath.Glob(computeBlobKZGProofTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)
@@ -265,6 +271,8 @@ func TestVerifyKZGProof(t *testing.T) {
 
 	tests, err := filepath.Glob(verifyKZGProofTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)
@@ -325,6 +333,8 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 
 	tests, err := filepath.Glob(verifyBlobKZGProofTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)
@@ -378,6 +388,8 @@ func TestVerifyBlobKZGProofBatch(t *testing.T) {
 
 	tests, err := filepath.Glob(verifyBlobKZGProofBatchTests)
 	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
 	for _, testPath := range tests {
 		t.Run(testPath, func(t *testing.T) {
 			testFile, err := os.Open(testPath)

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
@@ -91,9 +91,11 @@ public class TestUtils {
 
   public static List<BlobToKzgCommitmentTest> getBlobToKzgCommitmentTests() {
     final Stream.Builder<BlobToKzgCommitmentTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(BLOB_TO_KZG_COMMITMENT_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(BLOB_TO_KZG_COMMITMENT_TESTS)) {
+      for (String testFile : testFiles) {
         String data = Files.readString(Path.of(testFile));
         BlobToKzgCommitmentTest test = OBJECT_MAPPER.readValue(data, BlobToKzgCommitmentTest.class);
         tests.add(test);
@@ -107,9 +109,11 @@ public class TestUtils {
 
   public static List<ComputeKzgProofTest> getComputeKzgProofTests() {
     final Stream.Builder<ComputeKzgProofTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(COMPUTE_KZG_PROOF_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(COMPUTE_KZG_PROOF_TESTS)) {
+      for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
         ComputeKzgProofTest test = OBJECT_MAPPER.readValue(jsonData, ComputeKzgProofTest.class);
         tests.add(test);
@@ -123,9 +127,11 @@ public class TestUtils {
 
   public static List<ComputeBlobKzgProofTest> getComputeBlobKzgProofTests() {
     final Stream.Builder<ComputeBlobKzgProofTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(COMPUTE_BLOB_KZG_PROOF_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(COMPUTE_BLOB_KZG_PROOF_TESTS)) {
+      for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
         ComputeBlobKzgProofTest test =
             OBJECT_MAPPER.readValue(jsonData, ComputeBlobKzgProofTest.class);
@@ -140,9 +146,11 @@ public class TestUtils {
 
   public static List<VerifyKzgProofTest> getVerifyKzgProofTests() {
     final Stream.Builder<VerifyKzgProofTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(VERIFY_KZG_PROOF_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(VERIFY_KZG_PROOF_TESTS)) {
+      for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
         VerifyKzgProofTest test = OBJECT_MAPPER.readValue(jsonData, VerifyKzgProofTest.class);
         tests.add(test);
@@ -156,9 +164,11 @@ public class TestUtils {
 
   public static List<VerifyBlobKzgProofTest> getVerifyBlobKzgProofTests() {
     final Stream.Builder<VerifyBlobKzgProofTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(VERIFY_BLOB_KZG_PROOF_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(VERIFY_BLOB_KZG_PROOF_TESTS)) {
+      for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
         VerifyBlobKzgProofTest test =
             OBJECT_MAPPER.readValue(jsonData, VerifyBlobKzgProofTest.class);
@@ -173,9 +183,11 @@ public class TestUtils {
 
   public static List<VerifyBlobKzgProofBatchTest> getVerifyBlobKzgProofBatchTests() {
     final Stream.Builder<VerifyBlobKzgProofBatchTest> tests = Stream.builder();
+    List<String> testFiles = getTestFiles(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
+    assert !testFiles.isEmpty();
 
     try {
-      for (String testFile : getTestFiles(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS)) {
+      for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
         VerifyBlobKzgProofBatchTest test =
             OBJECT_MAPPER.readValue(jsonData, VerifyBlobKzgProofBatchTest.class);

--- a/bindings/nim/tests/test_yaml.nim
+++ b/bindings/nim/tests/test_yaml.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[os, strutils, streams],
+  std/[os, sequtils, strutils, streams],
   unittest2, yaml,
   ../kzg,
   ./types
@@ -41,11 +41,13 @@ proc fromHexList(T: type, xList: YamlNode): seq[T] =
     result.add(T.fromHex(x.content))
 
 template runTests(folder: string, body: untyped) =
-  for filename in walkDirRec(folder):
-    test toTestName(filename):
+  let test_files = walkDirRec(folder).toSeq()
+  check test_files.len > 0
+  for test_file in test_files:
+    test toTestName(test_file):
       # nim template is hygienic, {.inject.} will allow body to
       # access injected symbol in current scope
-      let n {.inject.} = loadYaml(filename)
+      let n {.inject.} = loadYaml(test_file)
       try:
         body
       except ValueError:

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -36,7 +36,7 @@ const SETUP_FILE_PATH = resolve(
 
 const MAX_TOP_BYTE = 114;
 
-const TEST_DIR = "../../../tests";
+const TEST_DIR = "../../tests";
 type BlobToKzgCommitmentTest = TestMeta<{ blob: string }, string>;
 const BLOB_TO_KZG_COMMITMENT_TESTS = join(
   TEST_DIR,
@@ -110,6 +110,8 @@ describe("C-KZG", () => {
   describe("reference tests should pass", () => {
     it("reference tests for blobToKzgCommitment should pass", () => {
       let tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: BlobToKzgCommitmentTest = yaml.load(
           readFileSync(testFile, "ascii"),
@@ -133,6 +135,8 @@ describe("C-KZG", () => {
 
     it("reference tests for computeKzgProof should pass", () => {
       let tests = globSync(COMPUTE_KZG_PROOF_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: ComputeKzgProofTest = yaml.load(
           readFileSync(testFile, "ascii"),
@@ -156,6 +160,8 @@ describe("C-KZG", () => {
 
     it("reference tests for computeBlobKzgProof should pass", () => {
       let tests = globSync(COMPUTE_BLOB_KZG_PROOF_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: ComputeBlobKzgProofTest = yaml.load(
           readFileSync(testFile, "ascii"),
@@ -180,6 +186,8 @@ describe("C-KZG", () => {
 
     it("reference tests for verifyKzgProof should pass", () => {
       let tests = globSync(VERIFY_KZG_PROOF_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: VerifyKzgProofTest = yaml.load(
           readFileSync(testFile, "ascii"),
@@ -204,6 +212,8 @@ describe("C-KZG", () => {
 
     it("reference tests for verifyBlobKzgProof should pass", () => {
       let tests = globSync(VERIFY_BLOB_KZG_PROOF_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: VerifyBlobKzgProofTest = yaml.load(
           readFileSync(testFile, "ascii"),
@@ -227,6 +237,8 @@ describe("C-KZG", () => {
 
     it("reference tests for verifyBlobKzgProofBatch should pass", () => {
       let tests = globSync(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
       tests.forEach((testFile: string) => {
         const test: VerifyBatchKzgProofTest = yaml.load(
           readFileSync(testFile, "ascii"),

--- a/bindings/python/tests.py
+++ b/bindings/python/tests.py
@@ -14,6 +14,7 @@ VERIFY_KZG_PROOF_TESTS = "../../tests/verify_kzg_proof/*/*/data.yaml"
 VERIFY_BLOB_KZG_PROOF_TESTS = "../../tests/verify_blob_kzg_proof/*/*/data.yaml"
 VERIFY_BLOB_KZG_PROOF_BATCH_TESTS = "../../tests/verify_blob_kzg_proof_batch/*/*/data.yaml"
 
+
 ###############################################################################
 # Helper Functions
 ###############################################################################
@@ -21,12 +22,16 @@ VERIFY_BLOB_KZG_PROOF_BATCH_TESTS = "../../tests/verify_blob_kzg_proof_batch/*/*
 def bytes_from_hex(hexstring):
     return bytes.fromhex(hexstring.replace("0x", ""))
 
+
 ###############################################################################
 # Tests
 ###############################################################################
 
 def test_blob_to_kzg_commitment(ts):
-    for test_file in glob.glob(BLOB_TO_KZG_COMMITMENT_TESTS):
+    test_files = glob.glob(BLOB_TO_KZG_COMMITMENT_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 
@@ -43,7 +48,10 @@ def test_blob_to_kzg_commitment(ts):
 
 
 def test_compute_kzg_proof(ts):
-    for test_file in glob.glob(COMPUTE_KZG_PROOF_TESTS):
+    test_files = glob.glob(COMPUTE_KZG_PROOF_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 
@@ -64,7 +72,10 @@ def test_compute_kzg_proof(ts):
 
 
 def test_compute_blob_kzg_proof(ts):
-    for test_file in glob.glob(COMPUTE_BLOB_KZG_PROOF_TESTS):
+    test_files = glob.glob(COMPUTE_BLOB_KZG_PROOF_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 
@@ -82,7 +93,10 @@ def test_compute_blob_kzg_proof(ts):
 
 
 def test_verify_kzg_proof(ts):
-    for test_file in glob.glob(VERIFY_KZG_PROOF_TESTS):
+    test_files = glob.glob(VERIFY_KZG_PROOF_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 
@@ -102,7 +116,10 @@ def test_verify_kzg_proof(ts):
 
 
 def test_verify_blob_kzg_proof(ts):
-    for test_file in glob.glob(VERIFY_BLOB_KZG_PROOF_TESTS):
+    test_files = glob.glob(VERIFY_BLOB_KZG_PROOF_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 
@@ -121,7 +138,10 @@ def test_verify_blob_kzg_proof(ts):
 
 
 def test_verify_blob_kzg_proof_batch(ts):
-    for test_file in glob.glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS):
+    test_files = glob.glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
         with open(test_file, "r") as f:
             test = yaml.safe_load(f)
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -493,9 +493,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(BLOB_TO_KZG_COMMITMENT_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(BLOB_TO_KZG_COMMITMENT_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: blob_to_kzg_commitment_test::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let Ok(blob) = test.input.get_blob() else {
                 assert!(test.get_output().is_none());
@@ -515,9 +520,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(COMPUTE_KZG_PROOF_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(COMPUTE_KZG_PROOF_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(z)) = (test.input.get_blob(), test.input.get_z()) else {
                 assert!(test.get_output().is_none());
@@ -540,9 +550,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(COMPUTE_BLOB_KZG_PROOF_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(COMPUTE_BLOB_KZG_PROOF_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(commitment)) = (
                 test.input.get_blob(),
@@ -565,9 +580,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(VERIFY_KZG_PROOF_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(VERIFY_KZG_PROOF_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(commitment), Ok(z), Ok(y), Ok(proof)) = (
                 test.input.get_commitment(),
@@ -592,9 +612,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(VERIFY_BLOB_KZG_PROOF_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(VERIFY_BLOB_KZG_PROOF_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(commitment), Ok(proof)) = (
                 test.input.get_blob(),
@@ -618,9 +643,14 @@ mod tests {
         let trusted_setup_file = PathBuf::from("../../src/trusted_setup.txt");
         assert!(trusted_setup_file.exists());
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
 
-        for test_file in glob::glob(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS).unwrap() {
-            let yaml_data = fs::read_to_string(test_file.unwrap()).unwrap();
+        for test_file in test_files {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof_batch::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blobs), Ok(commitments), Ok(proofs)) = (
                 test.input.get_blobs(),


### PR DESCRIPTION
We discovered that the testdir path for one of the bindings was configured incorrectly and the reference tests were not being executed. This was a risk of globing files. Thanks to @asanso for pointing this out.

* Collect test files into a list & ensure there are a non-zero number of them.