### PR TITLE
Simplify and cleanup C code

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1268,13 +1268,13 @@ C_KZG_RET verify_blob_kzg_proof(
 }
 
 /**
+ * Compute random linear combination challenge scalars for batch verification.
  *
- *
- * @param[out]  r_powers_out
- * @param[in]   commitments_g1
- * @param[in]   zs_fr
- * @param[in]   ys_fr
- * @param[in]   proofs_g1
+ * @param[out]  r_powers_out   The output challenges
+ * @param[in]   commitments_g1 The input commitments
+ * @param[in]   zs_fr          The input evaluation points
+ * @param[in]   ys_fr          The input evaluation results
+ * @param[in]   proofs_g1      The input proofs
  */
 static C_KZG_RET compute_r_powers(
     fr_t *r_powers_out,

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -55,11 +55,6 @@ static const char *RANDOM_CHALLENGE_KZG_BATCH_DOMAIN = "RCKZGBATCH___V1_";
 /** Length of the domain strings above. */
 static const size_t DOMAIN_STR_LENGTH = 16;
 
-/** Length of the "metadata" before the data */
-static const size_t DOMAIN_SEPARATOR_LENGTH = DOMAIN_STR_LENGTH +
-                                              sizeof(uint64_t) +
-                                              sizeof(uint64_t);
-
 /** The number of bytes in a g1 point. */
 static const size_t BYTES_PER_G1 = 48;
 
@@ -702,7 +697,8 @@ static C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
 }
 
 /* Input size to the Fiat-Shamir challenge computation. */
-static const size_t CHALLENGE_INPUT_SIZE = DOMAIN_SEPARATOR_LENGTH +
+static const size_t CHALLENGE_INPUT_SIZE = DOMAIN_STR_LENGTH +
+                                           sizeof(uint64_t) + sizeof(uint64_t) +
                                            BYTES_PER_BLOB +
                                            BYTES_PER_COMMITMENT;
 
@@ -1291,7 +1287,8 @@ static C_KZG_RET compute_r_powers(
     Bytes32 r_bytes;
     fr_t r;
 
-    size_t input_size = DOMAIN_SEPARATOR_LENGTH +
+    size_t input_size = DOMAIN_STR_LENGTH + sizeof(uint64_t) +
+                        sizeof(uint64_t) +
                         (n * (BYTES_PER_COMMITMENT +
                               2 * BYTES_PER_FIELD_ELEMENT + BYTES_PER_PROOF));
     ret = c_kzg_malloc((void **)&bytes, input_size);

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -60,11 +60,6 @@ static const size_t DOMAIN_SEPARATOR_LENGTH = DOMAIN_STR_LENGTH +
                                               sizeof(uint64_t) +
                                               sizeof(uint64_t);
 
-/* Input size to the Fiat-Shamir challenge computation. */
-static const size_t CHALLENGE_INPUT_SIZE = DOMAIN_SEPARATOR_LENGTH +
-                                           BYTES_PER_BLOB +
-                                           BYTES_PER_COMMITMENT;
-
 /** The number of bytes in a g1 point. */
 static const size_t BYTES_PER_G1 = 48;
 
@@ -705,6 +700,11 @@ static C_KZG_RET blob_to_polynomial(Polynomial *p, const Blob *blob) {
     }
     return C_KZG_OK;
 }
+
+/* Input size to the Fiat-Shamir challenge computation. */
+static const size_t CHALLENGE_INPUT_SIZE = DOMAIN_SEPARATOR_LENGTH +
+                                           BYTES_PER_BLOB +
+                                           BYTES_PER_COMMITMENT;
 
 /**
  * Return the Fiat-Shamir challenge required to verify `blob` and `commitment`.

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1354,7 +1354,7 @@ out:
  *
  * @param[out] ok             True if the proofs are valid, otherwise false
  * @param[in]  commitments_g1 Array of commitments to verify
- * @param[in]  zs_fr          Array of evaluation of points for the KZG proofs
+ * @param[in]  zs_fr          Array of evaluation points for the KZG proofs
  * @param[in]  ys_fr          Array of evaluation results for the KZG proofs
  * @param[in]  proofs_g1      Array of proofs used for verification
  * @param[in]  n              The number of blobs/commitments/proofs

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -390,6 +390,7 @@ out:
 static void g1_mul(g1_t *out, const g1_t *a, const fr_t *b) {
     blst_scalar s;
     blst_scalar_from_fr(&s, b);
+    /* The last argument is the number of bits in the scalar */
     blst_p1_mult(out, a, s.b, 8 * sizeof(blst_scalar));
 }
 
@@ -403,6 +404,7 @@ static void g1_mul(g1_t *out, const g1_t *a, const fr_t *b) {
 static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
     blst_scalar s;
     blst_scalar_from_fr(&s, b);
+    /* The last argument is the number of bits in the scalar */
     blst_p2_mult(out, a, s.b, 8 * sizeof(blst_scalar));
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -859,7 +859,7 @@ static void compute_powers(fr_t *out, fr_t *x, uint64_t n) {
  * @param[out] out The result of the evaluation
  * @param[in]  p   The polynomial in evaluation form
  * @param[in]  x   The point to evaluate the polynomial at
- * @param[in]  s   The settings struct containing the roots of unity
+ * @param[in]  s   The trusted setup
  */
 static C_KZG_RET evaluate_polynomial_in_evaluation_form(
     fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s
@@ -921,8 +921,7 @@ out:
  *
  * @param[out] out The resulting commitment
  * @param[in]  p   The polynomial to commit to
- * @param[in]  s   The settings struct containing the commitment key
- *                 (i.e. the trusted setup)
+ * @param[in]  s   The trusted setup
  */
 static C_KZG_RET poly_to_kzg_commitment(
     g1_t *out, const Polynomial *p, const KZGSettings *s
@@ -937,8 +936,7 @@ static C_KZG_RET poly_to_kzg_commitment(
  *
  * @param[out] out  The resulting commitment
  * @param[in]  blob The blob representing the polynomial to be committed to
- * @param[in]  s    The settings struct containing the commitment key (i.e.
- *                  the trusted setup)
+ * @param[in]  s    The trusted setup
  */
 C_KZG_RET blob_to_kzg_commitment(
     KZGCommitment *out, const Blob *blob, const KZGSettings *s
@@ -1510,15 +1508,6 @@ out:
 ///////////////////////////////////////////////////////////////////////////////
 // Trusted Setup Functions
 ///////////////////////////////////////////////////////////////////////////////
-
-/**
- * Discrete fourier transforms over arrays of G1 group elements.
- *
- * Also known as [number theoretic
- * transforms](https://en.wikipedia.org/wiki/Discrete_Fourier_transform_(general)#Number-theoretic_transform).
- *
- * @remark Functions here work only for lengths that are a power of two.
- */
 
 /**
  * Fast Fourier Transform.

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -33,13 +33,13 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// Macros
+// Constants
 ///////////////////////////////////////////////////////////////////////////////
 
-#define BYTES_PER_COMMITMENT 48
-#define BYTES_PER_PROOF 48
-#define BYTES_PER_FIELD_ELEMENT 32
-#define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
+const size_t BYTES_PER_COMMITMENT = 48;
+const size_t BYTES_PER_PROOF = 48;
+const size_t BYTES_PER_FIELD_ELEMENT = 32;
+const size_t BYTES_PER_BLOB = FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Types

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -33,13 +33,13 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// Constants
+// Macros
 ///////////////////////////////////////////////////////////////////////////////
 
-const size_t BYTES_PER_COMMITMENT = 48;
-const size_t BYTES_PER_PROOF = 48;
-const size_t BYTES_PER_FIELD_ELEMENT = 32;
-const size_t BYTES_PER_BLOB = FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT;
+#define BYTES_PER_COMMITMENT 48
+#define BYTES_PER_PROOF 48
+#define BYTES_PER_FIELD_ELEMENT 32
+#define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Types


### PR DESCRIPTION
This is a work in progress. This simplifies & cleans up the C library.

* Define static constants for sizes.
* ~Convert macros to consts where possible.~
* Remove backticks from functions in documentation.
* Group g1/g2 multiplications and g1/g2 subtraction funcs together.
* Replace `reverse_bits` with simpler version without macros.
  * Benchmarks show no difference in performance.
* Convert `//` style comments to `/* */` style comments everywhere.
* Replace integers with constants where possible.
* For `verify_kzg_proof_impl` use variable names from spec.
* Remove unnecessary casts now that `FFTSettings` isn't const.