### PR TITLE
Simplify `fr_batch_inv` and reject zero inputs

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -365,7 +365,7 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
 
     fr_t accumulator = FR_ONE;
 
-    for (i = 0; i < (int)len; i++) {
+    for (i = 0; i < len; i++) {
         out[i] = accumulator;
         blst_fr_mul(&accumulator, &accumulator, &a[i]);
     }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -287,6 +287,7 @@ static void test_fr_batch_inv__test_consistent(void) {
     }
 }
 
+/** Make sure that batch inverse doesn't support zeroes */
 static void test_fr_batch_inv__test_zero(void) {
     C_KZG_RET ret;
     fr_t a[32], batch_inverses[32];
@@ -298,12 +299,7 @@ static void test_fr_batch_inv__test_zero(void) {
     a[5] = FR_ZERO;
 
     ret = fr_batch_inv(batch_inverses, a, 32);
-    ASSERT_EQUALS(ret, C_KZG_OK);
-
-    for (size_t i = 0; i < 32; i++) {
-        bool ok = fr_equal(&batch_inverses[i], &FR_ZERO);
-        ASSERT_EQUALS(ok, true);
-    }
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This implements the first approach from https://github.com/ethereum/c-kzg-4844/issues/205 