### PR TITLE
Fix a mistake in python bindings makefile

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,11 +1,11 @@
 .PHONY: all
 all: install test ecc_test
 
-../../src/c-kzg-4844.o:
-	cd ../../src/ && make blst && make
+../../src/c_kzg_4844.o:
+	make -C../../src c_kzg_4844.o
 
 .PHONY: install
-install: setup.py ckzg.c ../../src/c-kzg-4844.o
+install: setup.py ckzg.c ../../src/c_kzg_4844.o
 	python3 setup.py install
 
 .PHONY: test


### PR DESCRIPTION
The expected file is `c_kzg_4844.o` (with underscores) not `c-kzg-4844.o` (with dashes).

This was causing the build/test to always happen. No biggie but should fix.