### PR TITLE
Speed up rust build just a little

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -48,7 +48,7 @@ fn main() {
     // Ensure libckzg exists in `OUT_DIR`
     Command::new("make")
         .current_dir(root_dir.join("src"))
-        .arg("all")
+        .arg("c_kzg_4844.o")
         .arg(format!(
             "FIELD_ELEMENTS_PER_BLOB={}",
             field_elements_per_blob


### PR DESCRIPTION
In the rust bindings build, it will `make all` which builds `c_kzg_4844.o` and runs all of the C tests.

This PR will call `make c_kzg_4844.o` instead, which should speed things up just a little.