### PR TITLE
Revise NuGet packaging

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -87,14 +87,14 @@ jobs:
         name: ckzg-library-wrapper-linux-arm64
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
 
-    - name: Setup .NET Core SDK
+    - name: Set up .NET
       uses: actions/setup-dotnet@v3
     - name: Install dependencies
       run: cd bindings/csharp && dotnet restore
     - name: Test
-      run: cd bindings/csharp && dotnet test --configuration Release --no-restore
+      run: cd bindings/csharp && dotnet test -c release --no-restore
     - name: Build
-      run: cd bindings/csharp && dotnet pack -p:Version=${{ inputs.version || env.binding_build_number_based_version }} --configuration Release --no-restore --output nupkgs
+      run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
@@ -102,4 +102,4 @@ jobs:
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
     - name: Publish package
       if: github.ref == 'refs/heads/main'
-      run: dotnet nuget push bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg --api-key ${{ secrets.CSHARP_NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg -k ${{ secrets.CSHARP_NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<LangVersion>preview</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
 		<RootNamespace>Ckzg</RootNamespace>
@@ -11,11 +11,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<Authors>Ethereum Foundation</Authors>
+		<Copyright>Ethereum Foundation</Copyright>
+		<Description>The C# bindings for the Polynomial Commitments API library for EIP-4844</Description>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
 		<PackageId>Ckzg.Bindings</PackageId>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageProjectUrl>https://github.com/ethereum/c-kzg-4844/tree/main/bindings/csharp</PackageProjectUrl>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>c-kzg eip-4844</PackageTags>
 		<RepositoryType>git</RepositoryType>
@@ -26,7 +28,6 @@
 
 	<ItemGroup>
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
-		<None Include="..\..\..\LICENSE" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -1,35 +1,47 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>preview</LangVersion>
-        <Nullable>enable</Nullable>
-        <OutputType>Library</OutputType>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <PackageProjectUrl>https://github.com/ethereum/c-kzg-4844/tree/main/bindings/csharp</PackageProjectUrl>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageTags>c-kzg eip-4844</PackageTags>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
-        <RootNamespace>Ckzg</RootNamespace>
-        <TargetFramework>net6.0</TargetFramework>
-        <Title>Ckzg.Bindings</Title>
-        <Version>0.1.0.0</Version>
-    </PropertyGroup>
+	<PropertyGroup>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<LangVersion>preview</LangVersion>
+		<Nullable>enable</Nullable>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Ckzg</RootNamespace>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <None Include="..\..\..\LICENSE" Pack="true" PackagePath="\"/>
-    </ItemGroup>
+	<PropertyGroup>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<PackageId>Ckzg.Bindings</PackageId>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageProjectUrl>https://github.com/ethereum/c-kzg-4844/tree/main/bindings/csharp</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageTags>c-kzg eip-4844</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<Version>0.1.0.0</Version>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll"/>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so"/>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so"/>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.so')" Include="runtimes/osx-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.so"/>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.so')" Include="runtimes/osx-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.so"/>
-    </ItemGroup>
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\..\LICENSE" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.so')" Include="runtimes/osx-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.so" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.so')" Include="runtimes/osx-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.so" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates NuGet packaging in the following way:

- Adds `Microsoft.SourceLink.GitHub` package for symbols and makes the build deterministic that will change [reds](https://nuget.info/packages/Ckzg.Bindings/0.1.2.51) to greens:

  | ![red](https://user-images.githubusercontent.com/337518/225761096-1f7adb67-5fae-401d-a426-539b3e82483b.png) | ![green](https://user-images.githubusercontent.com/337518/225761117-29a216d8-ac11-4da4-9a91-1d849990a437.png) |
  |---|---|
- Moves the package-specific items to a separate `PropertyGroup` element for better maintainability and visibility.

#### Recommended additions

I'd recommend to add the following to the package:

- `<Author>`: I presume it's Ethereum Foundation
- `<Copyright>`: I presume it's the author
- `<Description>`: A brief description

#### Nice-to-have changes

- Replace the license file with SPDX indentifier, i.e. insetad of `<PackageLicenseFile>` use `<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>`. It's easier for users to know the license just by its id without having to open and check it. Is there a reason not to do so?
- Change the `TargetFramework` from `net6.0` to `net7.0`
- Change the `LangVersion` from `preview` to `latest`

CC @flcl42 @jtraglia 