### PR TITLE
Document that bit_reversal_permutation does not work for n==1.

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -590,12 +590,13 @@ static uint32_t reverse_bits(uint32_t n) {
  * @param[in,out] values The array, which is re-ordered in-place
  * @param[in]     size   The size in bytes of an element of the array
  * @param[in]     n      The length of the array, must be a power of two
- *                       less that 2^32
+ *                       less that 2^32 and unequal to 1.
  */
 static C_KZG_RET bit_reversal_permutation(
     void *values, size_t size, uint64_t n
 ) {
     CHECK(n >> 32 == 0);
+    CHECK(n != 0);
     CHECK(is_power_of_two(n));
     CHECK(log2_pow2(n) != 0);
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -595,8 +595,8 @@ static uint32_t reverse_bits(uint32_t n) {
 static C_KZG_RET bit_reversal_permutation(
     void *values, size_t size, uint64_t n
 ) {
-    CHECK(n >> 32 == 0);
     CHECK(n != 0);
+    CHECK(n >> 32 == 0);
     CHECK(is_power_of_two(n));
     CHECK(log2_pow2(n) != 0);
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -590,7 +590,7 @@ static uint32_t reverse_bits(uint32_t n) {
  * @param[in,out] values The array, which is re-ordered in-place
  * @param[in]     size   The size in bytes of an element of the array
  * @param[in]     n      The length of the array, must be a power of two
- *                       greater than 1 and less than 2^32.
+ *                       strictly greater than 1 and less than 2^32.
  */
 static C_KZG_RET bit_reversal_permutation(
     void *values, size_t size, uint64_t n

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -590,7 +590,7 @@ static uint32_t reverse_bits(uint32_t n) {
  * @param[in,out] values The array, which is re-ordered in-place
  * @param[in]     size   The size in bytes of an element of the array
  * @param[in]     n      The length of the array, must be a power of two
- *                       less that 2^32 and unequal to 1.
+ *                       greater than 1 and less than 2^32.
  */
 static C_KZG_RET bit_reversal_permutation(
     void *values, size_t size, uint64_t n


### PR DESCRIPTION
Document that bit_reversal_permutation does not work with length 1. There is even a test to check this behaviour. Note that the length-1 case actually would work the given implementation; I do not know why this case is (intentionally) excluded.

Also, explicitly check that n != 0. This does not change anything, really, but previously, it was caught as a side-effect of implementation quirks of log2_pow2 and is_power_of_two, which is not good style.