### PR TITLE
Check that FIELD_ELEMENTS_PER_BLOB is defined.

### DIFF
--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -45,7 +45,7 @@ extern "C" {
  * current implementation limitation. Notably, the size of the FFT setup would
  * overflow uint32_t, which would casues issues.
  */
-#if (FIELD_ELEMENTS_PER_BLOB <= 0) || ((FIELD_ELEMENTS_PER_BLOB) > (1 << 31))
+#if ((FIELD_ELEMENTS_PER_BLOB) <= 0) || ((FIELD_ELEMENTS_PER_BLOB) > (1 << 31))
 #error Invalid value of FIELD_ELEMENTS_PER_BLOB
 #endif // FIELD_ELEMENTS_PER_BLOB
 

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -36,6 +36,19 @@ extern "C" {
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
 
+#ifndef FIELD_ELEMENTS_PER_BLOB
+#error FIELD_ELEMENTS_PER_BLOB is undefined. This value must be externally supplied.
+#endif // FIELD_ELEMENTS_PER_BLOB
+/**
+ * There are only 1<<32 2-adic roots of unity in the field, limiting the
+ * possible values of FIELD_ELEMENTS_PER_BLOB. The restriction to 1<<31 is a
+ * current implementation limitation. Notably, the size of the FFT setup would
+ * overflow uint32_t, which would casues issues
+ */
+#if (FIELD_ELEMENTS_PER_BLOB <= 0) || ((FIELD_ELEMENTS_PER_BLOB) > (1 << 31))
+#error Invalid value of FIELD_ELEMENTS_PER_BLOB
+#endif // FIELD_ELEMENTS_PER_BLOB
+
 #define BYTES_PER_COMMITMENT 48
 #define BYTES_PER_PROOF 48
 #define BYTES_PER_FIELD_ELEMENT 32

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -43,7 +43,7 @@ extern "C" {
  * There are only 1<<32 2-adic roots of unity in the field, limiting the
  * possible values of FIELD_ELEMENTS_PER_BLOB. The restriction to 1<<31 is a
  * current implementation limitation. Notably, the size of the FFT setup would
- * overflow uint32_t, which would casues issues
+ * overflow uint32_t, which would casues issues.
  */
 #if (FIELD_ELEMENTS_PER_BLOB <= 0) || ((FIELD_ELEMENTS_PER_BLOB) > (1 << 31))
 #error Invalid value of FIELD_ELEMENTS_PER_BLOB


### PR DESCRIPTION
This adds a check that FIELD_ELEMENTS_PER_BLOB is defined and outputs an error if not.
This also serves to document inside the .h file that FIELD_ELEMENTS_PER_BLOB is supposed to be externally set.

The restriction to FIELD_ELEMENTS_PER_BLOB <= (1 << 31) is essentially due to log2_pow2 only working on 32-bit integers at the moment; With FIELD_ELEMENTS_PER_BLOB > (1<<31), the FFT setup size overflows uint32_t and things go wrong. This limitation will likely be lifted in a separate PR and the check removed. Of course, we don't expect users to set FIELD_ELEMENTS_PER_BLOB that large, anyway.