### PR TITLE
nim bindings: add support for nimble package

### DIFF
--- a/bindings/nim/README.md
+++ b/bindings/nim/README.md
@@ -14,7 +14,8 @@ nimble install stew
 
 ## Tests
 
-Currently tests only support Nim compiler version 1.4, and 1.6 because of yaml library limitations.
+Currently reference tests only support Nim compiler version 1.4, and 1.6 because of yaml library limitations.
+But other tests that is not using yaml can be run by Nim 1.2 - devel.
 
 Dependencies:
 
@@ -29,13 +30,18 @@ Run the tests from folder `bindings\nim`:
 nim test
 ```
 
+Or from c-kzg-4844 root folder:
+
+```
+nimble test
+```
+
 ## How to use this bindings in your project
 
-Because the structure of folders is not a normal Nim library, we suggest you to
-clone this repository in your project sub folder or submodule it.
+Install via nimble:
 
-Then you can import one of the binding file into your project.
+```
+nimble install https://github.com/ethereum/c-kzg-4844
+```
 
-## Library
-
-The library which uses this binding is [nim-kzg4844](https://github.com/status-im/nim-kzg4844).
+Then import one of `kzg4844/kzg`, `kzg4844/kzg_abi`, or `kzg4844/kzg_ex` into your project.

--- a/bindings/nim/config.nims
+++ b/bindings/nim/config.nims
@@ -1,3 +1,9 @@
+import strutils
+from os import DirSep
+
+const
+  testPath = currentSourcePath.rsplit(DirSep, 1)[0] & "/tests"
+
 # Helper functions
 proc test(args, path: string) =
   if not dirExists "build":
@@ -5,10 +11,13 @@ proc test(args, path: string) =
   exec "nim " & getEnv("TEST_LANG", "c") & " " & getEnv("NIMFLAGS") & " " & args &
     " --outdir:build -r -f --hints:off --warnings:off --skipParentCfg " & path
 
-task test, "Run all tests":
+proc runAllTest*() =
   echo ">>>>>>>>>>>>>>>> Run tests in DEBUG mode <<<<<<<<<<<<<<<<"
-  test "-d:debug", "tests/test_all"
+  test "-d:debug", testPath & "/test_all"
   echo ">>>>>>>>>>>>>>>> Run tests in RELEASE mode <<<<<<<<<<<<<<<<"
-  test "-d:release", "tests/test_all"
+  test "-d:release", testPath & "/test_all"
   echo ">>>>>>>>>>>>>>>> Run tests in RELEASE and THREADS ON mode <<<<<<<<<<<<<<<<"
-  test "--threads:on -d:release", "tests/test_all"
+  test "--threads:on -d:release", testPath & "/test_all"
+
+task test, "Run all tests":
+  runAllTest()

--- a/bindings/nim/nimble/README.md
+++ b/bindings/nim/nimble/README.md
@@ -1,0 +1,4 @@
+# Nim bindings
+
+This directory contains nimble stuff. Sigh, nimble is rather picky about folder structure and file naming.
+

--- a/bindings/nim/nimble/kzg4844.nim
+++ b/bindings/nim/nimble/kzg4844.nim
@@ -1,0 +1,7 @@
+import
+  kzg4844/kzg,
+  kzg4844/kzg_ex
+
+export
+  kzg,
+  kzg_ex

--- a/bindings/nim/nimble/kzg4844/kzg.nim
+++ b/bindings/nim/nimble/kzg4844/kzg.nim
@@ -1,0 +1,5 @@
+import
+  ../bindings/nim/kzg
+
+export
+  kzg

--- a/bindings/nim/nimble/kzg4844/kzg_abi.nim
+++ b/bindings/nim/nimble/kzg4844/kzg_abi.nim
@@ -1,0 +1,5 @@
+import
+  ../bindings/nim/kzg_abi
+
+export
+  kzg_abi

--- a/bindings/nim/nimble/kzg4844/kzg_ex.nim
+++ b/bindings/nim/nimble/kzg4844/kzg_ex.nim
@@ -1,0 +1,5 @@
+import
+  ../bindings/nim/kzg_ex
+
+export
+  kzg_ex

--- a/kzg4844.nimble
+++ b/kzg4844.nimble
@@ -1,0 +1,45 @@
+mode = ScriptMode.Verbose
+
+##################################################
+# Package definition
+##################################################
+
+packageName   = "kzg4844"
+version       = "0.1.0"
+author        = "Andri Lim"
+description   = "Nim wrapper of c-kzg-4844"
+license       = "Apache License 2.0"
+skipDirs      = @[
+  "tests", "lib", "inc", "fuzz",
+  "bindings/csharp",
+  "bindings/go",
+  "bindings/java",
+  "bindings/node.js",
+  "bindings/python",
+  "bindings/rust"
+  ]
+installDirs   = @[
+  "blst",
+  "src",
+  "bindings/nim"
+  ]
+
+requires "nim >= 1.2.0",
+         "stew"
+
+##################################################
+# Test code
+##################################################
+
+import "bindings/nim/config.nims"
+
+task test, "Run all tests":
+  runAllTest()
+
+##################################################
+# Package installation code
+##################################################
+
+after install:
+  mvDir("bindings/nim/nimble", ".")
+  rmDir("bindings/nim/tests")


### PR DESCRIPTION
Nimble is Nim standard package manager, this PR aims to let user using Nimble to manage this package installation.
Only `kzg4844.nimble` file is added to root directory. The rest is contained in `bindings/nim` and the installation script in `kzg4844.nimble` will handle the rest to meet Nimble requirements.
