### PR TITLE
Short circuit batch verification if n==1

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1494,6 +1494,13 @@ C_KZG_RET verify_blob_kzg_proof_batch(
         return C_KZG_OK;
     }
 
+    /* For a single blob, just do a regular single verification */
+    if (n == 1) {
+        return verify_blob_kzg_proof(
+            ok, &blobs[0], &commitments_bytes[0], &proofs_bytes[0], s
+        );
+    }
+
     /* We will need a bunch of arrays to store our objects... */
     ret = new_g1_array(&commitments_g1, n);
     if (ret != C_KZG_OK) goto out;


### PR DESCRIPTION
Stole this idea from @kevaundray's golang codebase: https://github.com/crate-crypto/go-proto-danksharding-crypto/blob/15ed9c4701955ea47ad787fdccb9baba4ffc1687/internal/kzg/kzg_verify.go#L125

No strong opinion about whether want to do this. It gives an 8% or so speedup when batch is called with a single blob (because we don't do any mem allocation, or the compute powers fiat shamir stuff), which is something that might happen a lot if clients decide to just use batch for everything (better UX).

(/cc @jtraglia @ppopth @GottfriedHerold )