### PR TITLE
Consolidate allocs and conversions

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1486,7 +1486,7 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     g1_t *proofs_g1 = NULL;
     fr_t *evaluation_challenges_fr = NULL;
     fr_t *ys_fr = NULL;
-    Polynomial *polynomials = NULL;
+
 
     /* Exit early if we are given zero blobs */
     if (n == 0) {
@@ -1503,8 +1503,6 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&ys_fr, n);
     if (ret != C_KZG_OK) goto out;
-    ret = c_kzg_calloc((void **)&polynomials, n, sizeof(Polynomial));
-    if (ret != C_KZG_OK) goto out;
 
     for (size_t i = 0; i < n; i++) {
         /* Convert each commitment to a g1 point */
@@ -1513,8 +1511,10 @@ C_KZG_RET verify_blob_kzg_proof_batch(
         );
         if (ret != C_KZG_OK) goto out;
 
+        Polynomial polynomial;
+
         /* Convert each blob from bytes to a poly */
-        ret = blob_to_polynomial(&polynomials[i], &blobs[i]);
+        ret = blob_to_polynomial(&polynomial, &blobs[i]);
         if (ret != C_KZG_OK) goto out;
 
         compute_challenge(
@@ -1522,7 +1522,7 @@ C_KZG_RET verify_blob_kzg_proof_batch(
         );
 
         ret = evaluate_polynomial_in_evaluation_form(
-            &ys_fr[i], &polynomials[i], &evaluation_challenges_fr[i], s
+            &ys_fr[i], &polynomial, &evaluation_challenges_fr[i], s
         );
         if (ret != C_KZG_OK) goto out;
 
@@ -1539,7 +1539,6 @@ out:
     c_kzg_free(proofs_g1);
     c_kzg_free(evaluation_challenges_fr);
     c_kzg_free(ys_fr);
-    c_kzg_free(polynomials);
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1487,7 +1487,6 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     fr_t *evaluation_challenges_fr = NULL;
     fr_t *ys_fr = NULL;
 
-
     /* Exit early if we are given zero blobs */
     if (n == 0) {
         *ok = true;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -996,7 +996,7 @@ C_KZG_RET blob_to_kzg_commitment(
  *
  * An instance of this struct models a claim (to be verified) that:
  * proof_g1 is a proof for p(evaluation_point) == y_fr,
- * where g1_t is a commitment to the polynomial p.
+ * where commitment_g1 is a commitment to the polynomial p.
  */
 typedef struct {
     g1_t commitment_g1;    /** Commitment to polynomial p*/
@@ -1272,7 +1272,7 @@ out:
  * @param[in]  s                The trusted setup
  */
 C_KZG_RET make_claim_from_blob_kzg_proof(
-    kzg_evaluation_claim *claim,
+    kzg_evaluation_claim *claim_out,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
     const Bytes48 *proof_bytes,
@@ -1281,20 +1281,22 @@ C_KZG_RET make_claim_from_blob_kzg_proof(
     C_KZG_RET ret;
     Polynomial polynomial;
 
-    ret = bytes_to_kzg_commitment(&claim->commitment_g1, commitment_bytes);
+    ret = bytes_to_kzg_commitment(&claim_out->commitment_g1, commitment_bytes);
     if (ret != C_KZG_OK) return ret;
 
     ret = blob_to_polynomial(&polynomial, blob);
     if (ret != C_KZG_OK) return ret;
 
-    compute_challenge(&claim->evaluation_point, blob, &claim->commitment_g1);
+    compute_challenge(
+        &claim_out->evaluation_point, blob, &claim_out->commitment_g1
+    );
 
     ret = evaluate_polynomial_in_evaluation_form(
-        &claim->y_fr, &polynomial, &claim->evaluation_point, s
+        &claim_out->y_fr, &polynomial, &claim_out->evaluation_point, s
     );
     if (ret != C_KZG_OK) return ret;
 
-    return bytes_to_kzg_proof(&claim->proof_g1, proof_bytes);
+    return bytes_to_kzg_proof(&claim_out->proof_g1, proof_bytes);
 }
 
 /**
@@ -1407,8 +1409,8 @@ out:
  * @remark This function only works for `n > 0`.
  *
  * @param[out] ok             True if the proofs are valid, otherwise false
- * @param[in]  claims         Array of claims, each consisting a a commitment, a
- * KZG proof, and a evaluation point and result.
+ * @param[in]  claims         Array of claims, each consisting of a commitment,
+ * a KZG proof, an evaluation point and a result.
  * @param[in]  n              The number of blobs/commitments/proofs
  * @param[in]  s              The trusted setup
  */

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1516,7 +1516,7 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     /* We will make a claim about a polynomial evaluation for each element of
      * the batch */
     ret = c_kzg_calloc((void **)&claims, n, sizeof(kzg_evaluation_claim));
-    if (ret != C_KZG_OUT) return ret;
+    if (ret != C_KZG_OK) return ret;
 
     for (size_t i = 0; i < n; i++) {
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1516,6 +1516,7 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     /* We will make a claim about a polynomial evaluation for each element of
      * the batch */
     ret = c_kzg_calloc((void **)&claims, n, sizeof(kzg_evaluation_claim));
+    if (ret != C_KZG_OUT) return ret;
 
     for (size_t i = 0; i < n; i++) {
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1504,13 +1504,13 @@ C_KZG_RET verify_blob_kzg_proof_batch(
     if (ret != C_KZG_OK) goto out;
 
     for (size_t i = 0; i < n; i++) {
+        Polynomial polynomial;
+
         /* Convert each commitment to a g1 point */
         ret = bytes_to_kzg_commitment(
             &commitments_g1[i], &commitments_bytes[i]
         );
         if (ret != C_KZG_OK) goto out;
-
-        Polynomial polynomial;
 
         /* Convert each blob from bytes to a poly */
         ret = blob_to_polynomial(&polynomial, &blobs[i]);


### PR DESCRIPTION
This PR draft is a reply to 

@asn-d6 "That said, I would be curious to see how a PR for this one would look like." from the discussion in #234.

Note that this PR-draft is based on #235 just to avoid conflicts, it completely removes the variable from the code anyway.
It may be helpful for review to look at the 2 commits 3ba09df and 9e5de9a separately.

Personally, I find the code actually cleaner that way (less duplication, clearer semantics), but I have no strong feelings about this PR draft.