### PR TITLE
Use portable blst in CI go tests

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Test
         run: |
           cd bindings/go
-          go test
+          CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test
       - name: Benchmark
         run: |
           cd bindings/go
-          go test -bench=Benchmark
+          CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test -bench=Benchmark
       - name: Check headers
         run: |
           cmp blst/bindings/blst.h bindings/go/blst_headers/blst.h

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/stretchr/testify v1.8.1
 	github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
In the CI checks, there is [an intermittent failure with the Go bindings](https://github.com/ethereum/c-kzg-4844/actions/runs/4451351762/jobs/7817901579):

```
go: downloading github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2
go: downloading github.com/stretchr/testify v1.8.1
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
Caught SIGILL in blst_cgo_init, consult <blst>/bindings/go/README.md.
exit status 132
FAIL	github.com/ethereum/c-kzg-4844/bindings/go	0.001s
```

The README says:

> If the test or target application crashes with an "illegal instruction" exception [after copying to an older system], rebuild with `CGO_CFLAGS` environment variable set to `-O -D__BLST_PORTABLE__`. Don't forget -O!

I suspect this happens when build doesn't match up with the system being executed on, because of some GitHub actions optimization or something. I really don't know, but it does keep happening.

Also, this happens here in blst:

https://github.com/supranational/blst/blob/a7fd1f584d26b0ae6cdc427976ea1d8980f7e15d/bindings/go/blst.go#L18-L26

Also also, I ran `go mod tidy` and it changed a little.