### PR TITLE
Add example for go bindings

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,7 +6,7 @@ exported functions in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).
 ## Installation
 
 ```
-go get github.com/ethereum/c-kzg-4844/bindings/go
+go get github.com/ethereum/c-kzg-4844
 ```
 
 ## Go version
@@ -17,38 +17,15 @@ functions.
 
 ## Example
 
-For example, a module with this source file:
-```go
-package main
+For reference, see the `example` module in this directory. You can test it out with `go run`:
 
-import "fmt"
-import "encoding/hex"
-import ckzg "github.com/ethereum/c-kzg-4844/bindings/go"
-
-func main() {
-	ret := ckzg.LoadTrustedSetupFile("trusted_setup.txt")
-	if ret != ckzg.C_KZG_OK {
-		panic("failed to load trusted setup")
-	}
-	defer ckzg.FreeTrustedSetup()
-
-	blob := ckzg.Blob{1, 2, 3}
-	commitment, ret := ckzg.BlobToKZGCommitment(blob)
-	if ret != ckzg.C_KZG_OK {
-		panic("failed to get commitment for blob")
-	}
-	fmt.Println(hex.EncodeToString(commitment[:]))
-}
 ```
-
-Will produce this output:
-```
-$ go run .
+user@system ~/c-kzg-4844/bindings/go/example $ go clean -modcache
+user@system ~/c-kzg-4844/bindings/go/example $ go run .
+go: downloading github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a
+go: downloading github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2
 88f1aea383b825371cb98acfbae6c81cce601a2e3129461c3c2b816409af8f3e5080db165fd327db687b3ed632153a62
 ```
-
-The trusted setup file in the example can be downloaded here:
-* https://github.com/ethereum/c-kzg-4844/raw/main/src/trusted_setup.txt
 
 ## Tests
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -20,7 +20,6 @@ functions.
 For reference, see the `example` module in this directory. You can test it out with `go run`:
 
 ```
-user@system ~/c-kzg-4844/bindings/go/example $ go clean -modcache
 user@system ~/c-kzg-4844/bindings/go/example $ go run .
 go: downloading github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a
 go: downloading github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2

--- a/bindings/go/example/go.mod
+++ b/bindings/go/example/go.mod
@@ -1,0 +1,8 @@
+module example
+
+go 1.20
+
+require (
+	github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a // indirect
+	github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 // indirect
+)

--- a/bindings/go/example/go.mod
+++ b/bindings/go/example/go.mod
@@ -1,8 +1,7 @@
 module example
 
-go 1.20
+go 1.19
 
-require (
-	github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a // indirect
-	github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 // indirect
-)
+require github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a
+
+require github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 // indirect

--- a/bindings/go/example/go.sum
+++ b/bindings/go/example/go.sum
@@ -1,4 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a h1:9JrfUHZY75ml0uPjFYVt+vRr/XHrNMvIpXnRDbVNyVE=
 github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a/go.mod h1:ECrzdyCNp8d5bLD8Id8Y0mZ8+HDZ0LIdshCrDDTO944=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 h1:wh1wzwAhZBNiZO37uWS/nDaKiIwHz4mDo4pnA+fqTO0=
 github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/bindings/go/example/go.sum
+++ b/bindings/go/example/go.sum
@@ -1,0 +1,4 @@
+github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a h1:9JrfUHZY75ml0uPjFYVt+vRr/XHrNMvIpXnRDbVNyVE=
+github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a/go.mod h1:ECrzdyCNp8d5bLD8Id8Y0mZ8+HDZ0LIdshCrDDTO944=
+github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 h1:wh1wzwAhZBNiZO37uWS/nDaKiIwHz4mDo4pnA+fqTO0=
+github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=

--- a/bindings/go/example/main.go
+++ b/bindings/go/example/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	ckzg "github.com/ethereum/c-kzg-4844/bindings/go"
+)
+
+var TrustedSetupPath = "../../../src/trusted_setup.txt"
+
+func main() {
+	ret := ckzg.LoadTrustedSetupFile(TrustedSetupPath)
+	if ret != ckzg.C_KZG_OK {
+		panic("failed to load trusted setup")
+	}
+	defer ckzg.FreeTrustedSetup()
+
+	blob := ckzg.Blob{1, 2, 3}
+	commitment, ret := ckzg.BlobToKZGCommitment(blob)
+	if ret != ckzg.C_KZG_OK {
+		panic("failed to get commitment for blob")
+	}
+	fmt.Println(hex.EncodeToString(commitment[:]))
+}


### PR DESCRIPTION
This PR adds an example of how to use the Go binding, just to clear any possible confusion. There's a minor complication, but I'm not terribly worried about this because it's not going to be used by any client. The old version of this package that doesn't work is cached and there isn't an easy way to remove it. This is a problem because this is the package that Go recommends. We moved `go.mod` to the project root; Go is referencing the old location.

### Example of problem

Delete the module files:
```
$ cd bindings/go/example
$ rm go.mod go.sum 
```

Create a new module:
```
$ go mod init example
go: creating new go.mod: module example
go: to add module requirements and sums:
        go mod tidy
```

Follow Go's instructions and run `go mod tidy`:
```
$ go mod tidy
go: finding module for package github.com/ethereum/c-kzg-4844/bindings/go
go: downloading github.com/ethereum/c-kzg-4844/bindings/go v0.0.0-20230126171313-363c7d7593b4
go: found github.com/ethereum/c-kzg-4844/bindings/go in github.com/ethereum/c-kzg-4844/bindings/go v0.0.0-20230126171313-363c7d7593b4
go: downloading github.com/stretchr/testify v1.8.1
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/pmezard/go-difflib v1.0.0
```

As you can see, it downloads the old one, from January 26th:
* `github.com/ethereum/c-kzg-4844/bindings/go v0.0.0-20230126171313`

Try running it:
```
$ go run .
# github.com/ethereum/c-kzg-4844/bindings/go
/Users/jtraglia/go/pkg/mod/github.com/ethereum/c-kzg-4844/bindings/go@v0.0.0-20230126171313-363c7d7593b4/main.go:6:11: fatal error: 'c_kzg_4844.c' file not found
 #include "c_kzg_4844.c"
          ^~~~~~~~~~~~~~
1 error generated.
```