### PR TITLE
Fix minor memleak in Go bindings

### DIFF
--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -99,8 +99,8 @@ func LoadTrustedSetupFile(trustedSetupFile string) CKZGRet {
 	if fp == nil {
 		panic("error reading trusted setup")
 	}
-	C.fclose(fp)
 	ret := C.load_trusted_setup_file(&settings, fp)
+	C.fclose(fp)
 	if CKZGRet(ret) == C_KZG_OK {
 		loaded = true
 	}

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -96,10 +96,10 @@ func LoadTrustedSetupFile(trustedSetupFile string) CKZGRet {
 	cMode := C.CString("r")
 	defer C.free(unsafe.Pointer(cMode))
 	fp := C.fopen(cTrustedSetupFile, cMode)
-	defer C.fclose(fp)
 	if fp == nil {
 		panic("error reading trusted setup")
 	}
+	C.fclose(fp)
 	ret := C.load_trusted_setup_file(&settings, fp)
 	if CKZGRet(ret) == C_KZG_OK {
 		loaded = true

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -91,12 +91,16 @@ func LoadTrustedSetupFile(trustedSetupFile string) CKZGRet {
 	if loaded {
 		panic("trusted setup is already loaded")
 	}
-	fp := C.fopen(C.CString(trustedSetupFile), C.CString("rb"))
+	cTrustedSetupFile := C.CString(trustedSetupFile)
+	defer C.free(unsafe.Pointer(cTrustedSetupFile))
+	cMode := C.CString("r")
+	defer C.free(unsafe.Pointer(cMode))
+	fp := C.fopen(cTrustedSetupFile, cMode)
+	defer C.fclose(fp)
 	if fp == nil {
 		panic("error reading trusted setup")
 	}
 	ret := C.load_trusted_setup_file(&settings, fp)
-	C.fclose(fp)
 	if CKZGRet(ret) == C_KZG_OK {
 		loaded = true
 	}


### PR DESCRIPTION
The allocated C strings that were being passed to `fopen` were never being freed. I thought these were casts.

* Call `defer free` for the two strings right after allocating them.
* Change mode from "rb" to "r" because the trusted setup shouldn't be binary.