### PR TITLE
Use do {} while(0) for c_kzg_free macro

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -39,10 +39,10 @@
  * c_kzg_free() macro sets the pointer value to NULL after freeing it.
  */
 #define c_kzg_free(p) \
-    (void)({ \
+    do { \
         free(p); \
         (p) = NULL; \
-    })
+    } while (0)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Constants


### PR DESCRIPTION
This is what I'm used to in macros. I don't believe it makes a difference in practice.

I was motivated to make this change because vim complains about it:

<img src="https://user-images.githubusercontent.com/95511699/227526571-e6e5e76f-f89f-42dd-a114-c9873b8a2c51.png" width="500">