### PR TITLE
[Java binding] Avoid unnecessary array copying in tests

### DIFF
--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
@@ -6,7 +6,6 @@ import ethereum.ckzg4844.test_formats.*;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -232,10 +231,6 @@ public class TestUtils {
 
   public static byte[] randomBLSFieldElementBytes() {
     return randomBLSFieldElement().toArray(ByteOrder.LITTLE_ENDIAN);
-  }
-
-  private static InputStream readResource(final String resource) {
-    return Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
   }
 
   public static List<String> getFiles(String path) {

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/BlobToKzgCommitmentTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/BlobToKzgCommitmentTest.java
@@ -7,7 +7,7 @@ public class BlobToKzgCommitmentTest {
     private String blob;
 
     public byte[] getBlob() {
-      return Bytes.fromHexString(blob).toArray();
+      return Bytes.fromHexString(blob).toArrayUnsafe();
     }
   }
 

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKzgProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKzgProofTest.java
@@ -8,7 +8,7 @@ public class ComputeBlobKzgProofTest {
     private String commitment;
 
     public byte[] getBlob() {
-      return Bytes.fromHexString(blob).toArray();
+      return Bytes.fromHexString(blob).toArrayUnsafe();
     }
 
     public byte[] getCommitment() {

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKzgProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKzgProofTest.java
@@ -10,7 +10,7 @@ public class ComputeKzgProofTest {
     private String z;
 
     public byte[] getBlob() {
-      return Bytes.fromHexString(blob).toArray();
+      return Bytes.fromHexString(blob).toArrayUnsafe();
     }
 
     public byte[] getZ() {

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKzgProofBatchTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKzgProofBatchTest.java
@@ -15,7 +15,7 @@ public class VerifyBlobKzgProofBatchTest {
       return TestUtils.flatten(
           blobs.stream()
               .map(Bytes::fromHexString)
-              .map(Bytes::toArray)
+              .map(Bytes::toArrayUnsafe)
               .collect(Collectors.toList())
               .toArray(byte[][]::new));
     }

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKzgProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKzgProofTest.java
@@ -9,7 +9,7 @@ public class VerifyBlobKzgProofTest {
     private String proof;
 
     public byte[] getBlob() {
-      return Bytes.fromHexString(blob).toArray();
+      return Bytes.fromHexString(blob).toArrayUnsafe();
     }
 
     public byte[] getCommitment() {


### PR DESCRIPTION
A bit of a nit really...

Basically `toArray()` copies the whole underlying array to a new one. `toArrayUnsafe()` just uses the underlying array. Given we don't modify the inputs in the binding, It is ok to use `toArrayUnsafe()` and is a test code as well. Only did it for blobs since they could be heavy in relation to other inputs.