### PR TITLE
`make` inits submodule & builds blst

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -15,33 +15,24 @@ jobs:
         with:
           submodules: recursive
       - name: Check formatting
+        working-directory: src
         run: |
-          cd src
           make format
           git diff --exit-code
-      - name: Build
-        run: |
-          cd src
-          make blst
-          make
-      - name: Test
-        run: |
-          cd src
-          make test
+      - name: Build/Test
+        working-directory: src
+        run: make
       - name: Clang Sanitizers
-        run: |
-          cd src
-          make sanitize
+        working-directory: src
+        run: make sanitize
       - name: Clang Static Analyzer
-        run: |
-          cd src
-          make analyze
+        working-directory: src
+        run: make analyze
       - name: Install LLVM
         uses: egor-tensin/setup-clang@v1
       - name: Generate coverage report
-        run: |
-          cd src
-          make coverage
+        working-directory: src
+        run: make coverage
       - name: Save coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -39,22 +39,21 @@ There are bindings for the following languages:
 
 ## Installation
 
-Initialize the blst submodule:
+### Prerequisites
+
+The following must be installed:
+
+* `git`
+* `make`
+* `clang`
+
+### Build & test
+
+To build `c_kzg_4844.o`, the object file that the bindings use, run `make` in
+the `src` directory. This will ensure the `blst` submodule has been initialized,
+build `blst`, build `c_kzg_4844`, and run the tests. From the project root, run
+this:
 
 ```
-git submodule update --init
-```
-
-Build the blst library:
-
-```
-cd src
-make blst
-```
-
-Build/test the C-KZG-4844 library:
-
-```
-cd src
-make
+cd src && make
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,9 @@ CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 # Disable optimizations. Put after $CFLAGS.
 NO_OPTIMIZE = -O0
 
-# Compiler flags for including blst. Put after source files.
+# Settings for blst.
+BLST_LIBRARY = ../lib/libblst.a
+BLST_BUILDSCRIPT = ../blst/build.sh
 BLST = -L../lib -lblst
 
 # Compiler flags for generating coverage data.
@@ -44,7 +46,19 @@ endif
 
 all: c_kzg_4844.o test
 
-%.o: %.c
+$(BLST_BUILDSCRIPT):
+	@git submodule update --init
+
+$(BLST_LIBRARY): $(BLST_BUILDSCRIPT)
+	@cd $(dir $(BLST_BUILDSCRIPT)) && \
+	./$(notdir $(BLST_BUILDSCRIPT)) && \
+	cp $(notdir $(BLST_LIBRARY)) ../lib && \
+	cp bindings/*.h ../inc
+
+.PHONY: blst
+blst: $(BLST_LIBRARY)
+
+c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
@@ -55,13 +69,6 @@ test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
 
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
-
-.PHONY: blst
-blst:
-	@cd ../blst && \
-	./build.sh && \
-	cp libblst.a ../lib && \
-	cp bindings/*.h ../inc
 
 .PHONY: test
 test: test_c_kzg_4844


### PR DESCRIPTION
A minor annoyance of mine has been that `make` doesn't automatically initialize the submodule & build the blst library if it hasn't already been done. This PR updates the Makefile to do this, and updates the README to reflect those changes.