### PR TITLE
Check the return value of fclose in go bindings

### DIFF
--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -100,12 +100,12 @@ func LoadTrustedSetupFile(trustedSetupFile string) CKZGRet {
 		panic("error reading trusted setup")
 	}
 	ret := C.load_trusted_setup_file(&settings, fp)
+	if C.fclose(fp) != 0 {
+		C.free_trusted_setup(&settings)
+		return C_KZG_ERROR
+	}
 	if CKZGRet(ret) == C_KZG_OK {
 		loaded = true
-	}
-	if C.fclose(fp) != 0 {
-		FreeTrustedSetup()
-		return C_KZG_ERROR
 	}
 	return CKZGRet(ret)
 }

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -100,9 +100,12 @@ func LoadTrustedSetupFile(trustedSetupFile string) CKZGRet {
 		panic("error reading trusted setup")
 	}
 	ret := C.load_trusted_setup_file(&settings, fp)
-	C.fclose(fp)
 	if CKZGRet(ret) == C_KZG_OK {
 		loaded = true
+	}
+	if C.fclose(fp) != 0 {
+		FreeTrustedSetup()
+		return C_KZG_ERROR
 	}
 	return CKZGRet(ret)
 }


### PR DESCRIPTION
Based on recent discussions, it's a good idea to check this return value.