### PR TITLE
Ignore generated snapshots in rust bindings

### DIFF
--- a/bindings/rust/.gitignore
+++ b/bindings/rust/.gitignore
@@ -1,2 +1,3 @@
 src/bindings/generated.rs
+snapshots/
 target/


### PR DESCRIPTION
After building/testing the rust bindings on my system, there was a new untracked file in `git status`.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        snapshots/bindings_aarch64-apple-darwin_4096.rs
```

I'm pretty sure we should be ignoring these generated files.