### PR TITLE
Add bundle to publish command

### DIFF
--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -64,7 +64,7 @@ format: install
 
 # Publish package to npm (requires an auth token)
 .PHONY: publish
-publish: build
+publish: build bundle
 	@cd dist
 	@npm publish
 


### PR DESCRIPTION
@g11tech published the new bindings and noticed a bug running `publish`.  The command work when all run but `publish` fails when run independently.

## Inclusions
- Add bundle to publish command dependencies