### PR TITLE
.gitignore node deps

### DIFF
--- a/bindings/node.js/.gitignore
+++ b/bindings/node.js/.gitignore
@@ -1,4 +1,5 @@
 build
+deps
 dist
 *.node
 node_modules


### PR DESCRIPTION
If `make` fails git shows a big diff with the deps.

## Inclusions
- Add deps folder to gitignore.