### PR TITLE
Clean-up node error messages

### DIFF
--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -7,8 +7,8 @@
 #include "blst.h"
 
 /**
- * Convert C_KZG_RET to a string representation for error messages 
-*/
+ * Convert C_KZG_RET to a string representation for error messages.
+ */
 std::string from_c_kzg_ret(C_KZG_RET ret) {
     switch (ret) {
       case C_KZG_RET::C_KZG_OK:

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -7,6 +7,22 @@
 #include "blst.h"
 
 /**
+ * Convert C_KZG_RET to a string representation for error messages 
+*/
+std::string from_c_kzg_ret(C_KZG_RET ret) {
+    switch (ret) {
+      case C_KZG_RET::C_KZG_OK:
+        return "C_KZG_OK";
+      case C_KZG_RET::C_KZG_BADARGS:
+        return "C_KZG_BADARGS";
+      case C_KZG_RET::C_KZG_ERROR:
+        return "C_KZG_ERROR";
+      case C_KZG_RET::C_KZG_MALLOC:
+        return "C_KZG_MALLOC";
+    }
+}
+
+/**
  * Structure containing information needed for the lifetime of the bindings
  * instance. It is not safe to use global static data with worker instances.
  * Native node addons are loaded as a dll's once no matter how many node
@@ -152,7 +168,9 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo& info) {
 
   // Check that loading the trusted setup was successful
   if (ret != C_KZG_OK) {
-    Napi::Error::New(env, "Error loading trusted setup file: " + file_path).ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error loading trusted setup file: " << file_path;
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Undefined();
   }
 
@@ -183,8 +201,9 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   KZGCommitment commitment;
   C_KZG_RET ret = blob_to_kzg_commitment(&commitment, blob, kzg_settings);
   if (ret != C_KZG_OK) {
-     Napi::Error::New(env, "Failed to convert blob to commitment")
-      .ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to convert blob to commitment";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 
@@ -228,8 +247,9 @@ Napi::Value ComputeKzgProof(const Napi::CallbackInfo& info) {
   );
 
   if (ret != C_KZG_OK) {
-     Napi::Error::New(env, "Failed to compute proof")
-      .ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to compute proof";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 
@@ -275,8 +295,9 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo& info) {
   );
 
   if (ret != C_KZG_OK) {
-     Napi::Error::New(env, "Error in computeBlobKzgProof")
-      .ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in computeBlobKzgProof";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 
@@ -329,7 +350,9 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   );
 
   if (ret != C_KZG_OK) {
-    Napi::TypeError::New(env, "Failed to verify KZG proof").ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to verify KZG proof";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 
@@ -376,7 +399,9 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo& info) {
     kzg_settings);
 
   if (ret != C_KZG_OK) {
-    Napi::TypeError::New(env, "Error in verifyBlobKzgProof").ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in verifyBlobKzgProof";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
 
@@ -468,7 +493,9 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo& info) {
   );
 
   if (ret != C_KZG_OK) {
-    Napi::TypeError::New(env, "Error in verifyBlobKzgProofBatch").ThrowAsJavaScriptException();
+    std::ostringstream msg;
+    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in verifyBlobKzgProofBatch";
+    Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     goto out;
   }
 

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -15,10 +15,12 @@ std::string from_c_kzg_ret(C_KZG_RET ret) {
         return "C_KZG_OK";
       case C_KZG_RET::C_KZG_BADARGS:
         return "C_KZG_BADARGS";
-      case C_KZG_RET::C_KZG_ERROR:
-        return "C_KZG_ERROR";
       case C_KZG_RET::C_KZG_MALLOC:
         return "C_KZG_MALLOC";
+      default:
+      case C_KZG_RET::C_KZG_ERROR:
+        return "C_KZG_ERROR";
+        
     }
 }
 
@@ -169,7 +171,7 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo& info) {
   // Check that loading the trusted setup was successful
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error loading trusted setup file: " << file_path;
+    msg << "Error loading trusted setup file: " << from_c_kzg_ret(ret);
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Undefined();
   }
@@ -202,7 +204,7 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   C_KZG_RET ret = blob_to_kzg_commitment(&commitment, blob, kzg_settings);
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to convert blob to commitment";
+    msg << "Failed to convert blob to commitment: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -248,7 +250,7 @@ Napi::Value ComputeKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to compute proof";
+    msg << "Failed to compute proof: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -296,7 +298,7 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in computeBlobKzgProof";
+    msg << "Error in computeBlobKzgProof: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -351,7 +353,7 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Failed to verify KZG proof";
+    msg << "Failed to verify KZG proof: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -400,7 +402,7 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in verifyBlobKzgProof";
+    msg << "Error in verifyBlobKzgProof: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -494,7 +496,7 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     std::ostringstream msg;
-    msg << "[C_KZG_RET::" << from_c_kzg_ret(ret) << "] Error in verifyBlobKzgProofBatch";
+    msg << "Error in verifyBlobKzgProofBatch: " << from_c_kzg_ret(ret) ;
     Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
     goto out;
   }

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -15,11 +15,14 @@ std::string from_c_kzg_ret(C_KZG_RET ret) {
         return "C_KZG_OK";
       case C_KZG_RET::C_KZG_BADARGS:
         return "C_KZG_BADARGS";
+      case C_KZG_RET::C_KZG_ERROR:
+        return "C_KZG_ERROR";
       case C_KZG_RET::C_KZG_MALLOC:
         return "C_KZG_MALLOC";
       default:
-      case C_KZG_RET::C_KZG_ERROR:
-        return "C_KZG_ERROR";
+        std::ostringstream msg;
+        msg << "UNKNOWN (" << ret << ")";
+        return msg.str();
         
     }
 }

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -405,7 +405,7 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo& info) {
   Bytes48 *proofs = NULL;
   Napi::Value result = env.Null();
   if (!(info[0].IsArray() && info[1].IsArray() && info[2].IsArray())) {
-    Napi::Error::New(env, "blobs, commitments, and proofs must all be arrays").ThrowAsJavaScriptException();
+    Napi::Error::New(env, "Blobs, commitments, and proofs must all be arrays").ThrowAsJavaScriptException();
     return result;
   }
   Napi::Array blobs_param = info[0].As<Napi::Array>();
@@ -417,7 +417,7 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo& info) {
   }
   uint32_t count = blobs_param.Length();
   if (count != commitments_param.Length() || count != proofs_param.Length()) {
-    Napi::Error::New(env, "requires equal number of blobs/commitments/proofs").ThrowAsJavaScriptException();
+    Napi::Error::New(env, "Requires equal number of blobs/commitments/proofs").ThrowAsJavaScriptException();
     return result;
   }
   blobs = (Blob *)calloc(count, sizeof(Blob));
@@ -485,13 +485,13 @@ out:
 Napi::Object Init(Napi::Env env, Napi::Object exports)  {
   KzgAddonData* data = (KzgAddonData*)malloc(sizeof(KzgAddonData));
   if (data == nullptr) {
-    Napi::Error::New(env, "error allocating memory for kzg setup handle").ThrowAsJavaScriptException();
+    Napi::Error::New(env, "Error allocating memory for kzg setup handle").ThrowAsJavaScriptException();
     return exports;
   }
   data->is_setup = false;
   napi_status status = napi_set_instance_data(env, data, delete_kzg_addon_data, NULL);
   if (status != napi_ok) {
-    Napi::Error::New(env, "error setting kzg bindings instance data").ThrowAsJavaScriptException();
+    Napi::Error::New(env, "Error setting kzg bindings instance data").ThrowAsJavaScriptException();
     return exports;
   }
 

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -413,7 +413,7 @@ describe("C-KZG", () => {
           [commitmentValidLength, commitmentValidLength],
           [proofValidLength, proofValidLength],
         ),
-      ).toThrowError("blobs, commitments, and proofs must all be arrays");
+      ).toThrowError("Blobs, commitments, and proofs must all be arrays");
     });
     it("should reject non-bytearray blob", () => {
       expect(() =>
@@ -467,13 +467,13 @@ describe("C-KZG", () => {
       expect(verifyBlobKzgProofBatch(blobs, commitments, proofs)).toBe(true);
       expect(() =>
         verifyBlobKzgProofBatch(blobs.slice(0, 1), commitments, proofs),
-      ).toThrowError("requires equal number of blobs/commitments/proofs");
+      ).toThrowError("Requires equal number of blobs/commitments/proofs");
       expect(() =>
         verifyBlobKzgProofBatch(blobs, commitments.slice(0, 1), proofs),
-      ).toThrowError("requires equal number of blobs/commitments/proofs");
+      ).toThrowError("Requires equal number of blobs/commitments/proofs");
       expect(() =>
         verifyBlobKzgProofBatch(blobs, commitments, proofs.slice(0, 1)),
-      ).toThrowError("requires equal number of blobs/commitments/proofs");
+      ).toThrowError("Requires equal number of blobs/commitments/proofs");
     });
   });
 });


### PR DESCRIPTION
@jtraglia noticed that some of the older error messages are lower-case.  He requested to standardize them.  He also requested the `C_KZG_RET` be added to error messages where applicable