### PR TITLE
Normalize native return for JS errors

### DIFF
--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -173,11 +173,11 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Blob *blob = get_blob(env, info[0]);
   if (blob == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
 
   KZGCommitment commitment;
@@ -185,7 +185,7 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   if (ret != C_KZG_OK) {
      Napi::Error::New(env, "Failed to convert blob to commitment")
       .ThrowAsJavaScriptException();
-    return env.Null();
+    return env.Undefined();
   }
 
   return Napi::Buffer<uint8_t>::Copy(env, reinterpret_cast<uint8_t *>(&commitment), BYTES_PER_COMMITMENT);
@@ -206,15 +206,15 @@ Napi::Value ComputeKzgProof(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Blob *blob = get_blob(env, info[0]);
   if (blob == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes32 *z_bytes = get_bytes32(env, info[1], "zBytes");
   if (z_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
 
   KZGProof proof;
@@ -230,7 +230,7 @@ Napi::Value ComputeKzgProof(const Napi::CallbackInfo& info) {
   if (ret != C_KZG_OK) {
      Napi::Error::New(env, "Failed to compute proof")
       .ThrowAsJavaScriptException();
-    return env.Null();
+    return env.Undefined();
   }
 
   Napi::Array tuple = Napi::Array::New(env, 2);
@@ -255,15 +255,15 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Blob *blob = get_blob(env, info[0]);
   if (blob == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes48 *commitment_bytes = get_bytes48(env, info[1], "commitmentBytes");
   if (commitment_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
 
   KZGProof proof;
@@ -277,7 +277,7 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo& info) {
   if (ret != C_KZG_OK) {
      Napi::Error::New(env, "Error in computeBlobKzgProof")
       .ThrowAsJavaScriptException();
-    return env.Null();
+    return env.Undefined();
   }
 
   return Napi::Buffer<uint8_t>::Copy(env, reinterpret_cast<uint8_t *>(&proof), BYTES_PER_PROOF);
@@ -299,23 +299,23 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Bytes48 *commitment_bytes = get_bytes48(env, info[0], "commitmentBytes");
   if (commitment_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes32 *z_bytes = get_bytes32(env, info[1], "zBytes");
   if (z_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes32 *y_bytes = get_bytes32(env, info[2], "yBytes");
   if (y_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes48 *proof_bytes = get_bytes48(env, info[3], "proofBytes");
   if (proof_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
 
   bool out;
@@ -330,7 +330,7 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     Napi::TypeError::New(env, "Failed to verify KZG proof").ThrowAsJavaScriptException();
-    return env.Null();
+    return env.Undefined();
   }
 
   return Napi::Boolean::New(env, out);
@@ -352,19 +352,19 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Blob *blob_bytes = get_blob(env, info[0]);
   if (blob_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes48 *commitment_bytes = get_bytes48(env, info[1], "commitmentBytes");
   if (commitment_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   Bytes48 *proof_bytes = get_bytes48(env, info[2], "proofBytes");
   if (proof_bytes == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
 
   bool out;
@@ -377,7 +377,7 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo& info) {
 
   if (ret != C_KZG_OK) {
     Napi::TypeError::New(env, "Error in verifyBlobKzgProof").ThrowAsJavaScriptException();
-    return env.Null();
+    return env.Undefined();
   }
 
   return Napi::Boolean::New(env, out);
@@ -413,7 +413,7 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo& info) {
   Napi::Array proofs_param = info[2].As<Napi::Array>();
   KZGSettings *kzg_settings = get_kzg_settings(env, info);
   if (kzg_settings == nullptr) {
-    return env.Null();
+    return env.Undefined();
   }
   uint32_t count = blobs_param.Length();
   if (count != commitments_param.Length() || count != proofs_param.Length()) {


### PR DESCRIPTION
Normalize the return value when a JS error is raised.  As a note this was a final clean-up thing.  I was speaking with @jtraglia yesterday and he mentioned a couple updates that were added to #266 .  During the discussion I brought this PR up and suggested I would put it up.  This is not something Ii feel strongly about, just think it will make the code a bit cleaner.  I will be happy to update/merge or close as requested by the team.

If an exception is pending the value returned from the native function will never manifest in the JS context.  It is just for readability and standardization.  The actual values do not get used.

`undefined` is the uninitialized/default value in JS so I used that for all cases