### PR TITLE
Run C tests on all platforms

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -34,15 +34,18 @@ jobs:
         working-directory: src
         run: make sanitize
       - name: Clang Static Analyzer
+        if: matrix.os != 'windows-latest'
         working-directory: src
         run: make analyze
       - name: Install LLVM
-        if: matrix.os != 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: egor-tensin/setup-clang@v1
       - name: Generate coverage report
+        if: matrix.os != 'windows-latest'
         working-directory: src
         run: make coverage
       - name: Save coverage report
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v3
         with:
           name: coverage

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -9,12 +9,19 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Check formatting
+        if: matrix.os == 'ubuntu-latest'
         working-directory: src
         run: |
           make format
@@ -23,6 +30,7 @@ jobs:
         working-directory: src
         run: make
       - name: Clang Sanitizers
+        if: matrix.os == 'ubuntu-latest'
         working-directory: src
         run: make sanitize
       - name: Clang Static Analyzer

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -26,9 +26,6 @@ jobs:
         run: |
           make format
           git diff --exit-code
-      - name: Install MSVC
-        if: matrix.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@v1
       - name: Build/Test
         working-directory: src
         run: make

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -26,11 +26,14 @@ jobs:
         run: |
           make format
           git diff --exit-code
+      - name: Install MSVC
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Build/Test
         working-directory: src
         run: make
       - name: Clang Sanitizers
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os != 'windows-latest'
         working-directory: src
         run: make sanitize
       - name: Clang Static Analyzer

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -37,6 +37,7 @@ jobs:
         working-directory: src
         run: make analyze
       - name: Install LLVM
+        if: matrix.os != 'macos-latest'
         uses: egor-tensin/setup-clang@v1
       - name: Generate coverage report
         working-directory: src

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,6 @@ else
 	endif
 endif
 
-
 # Settings for blst.
 BLST_LIBRARY = ../lib/libblst.a
 BLST_BUILDSCRIPT = ../blst/build.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,6 +38,8 @@ ifneq ($(OS),Windows_NT)
         PROFILE += -L$(shell brew --prefix gperftools)/lib
         PROFILE += -I$(shell brew --prefix gperftools)/include
     endif
+else
+    CFLAGS += -D_CRT_SECURE_NO_WARNINGS
 endif
 
 ###############################################################################

--- a/src/Makefile
+++ b/src/Makefile
@@ -127,9 +127,10 @@ profile: \
 ###############################################################################
 
 .PHONY: sanitize_%
+sanitize_%: CFLAGS += -O0 -fsanitize=$*
 sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	@echo Running sanitize=$*...
-	@$(CC) $(CFLAGS) -O0 -fsanitize=$* -o $@ $< $(LIBS)
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
 	    LSAN_OPTIONS=allocator_may_return_null=1 \
 	    ./$@; rm $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ LIBS = $(BLST_LIBRARY)
 ifeq ($(PLATFORM),Windows)
 	CC = gcc
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
-	CFLAGS += -Wl,--stack,8388608
+	CFLAGS += -Wl,--stack,8388608 # 8MB
 else
 	CC = clang
     CFLAGS += -fPIC -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -133,19 +133,17 @@ sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	    LSAN_OPTIONS=allocator_may_return_null=1 \
 	    ./$@; rm $@
 
-ifneq ($(PLATFORM),Windows)
 .PHONY: sanitize
 ifeq ($(PLATFORM),Darwin)
 sanitize: \
 	sanitize_address \
 	sanitize_undefined
-else
+else ifeq ($(PLATFORM),Linux)
 sanitize: \
 	sanitize_address \
 	sanitize_leak \
 	sanitize_safe-stack \
 	sanitize_undefined
-endif
 endif
 
 ###############################################################################

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,11 +20,15 @@ NO_OPTIMIZE = -O0
 BLST_LIBRARY = ../lib/libblst.a
 BLST_BUILDSCRIPT = ../blst/build.sh
 
+# Libraries to include.
+LIBS = $(BLST_LIBRARY)
+
 # Cross-platform compilation settings.
 ifneq ($(OS),Windows_NT)
     CFLAGS += -fPIC
 else
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
+	LIBS += -lmingw32
 endif
 
 # Compiler flags for generating coverage data.
@@ -67,13 +71,13 @@ c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(BLST_LIBRARY)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(LIBS)
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(BLST_LIBRARY)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(LIBS)
 
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(BLST_LIBRARY) $(PROFILER)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(LIBS) $(PROFILER)
 
 .PHONY: test
 test: test_c_kzg_4844
@@ -110,7 +114,7 @@ profile: \
 .PHONY: sanitize_%
 sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	@echo Running sanitize=$*...
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -fsanitize=$* -o $@ $< $(BLST_LIBRARY)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -fsanitize=$* -o $@ $< $(LIBS)
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
 	 LSAN_OPTIONS=allocator_may_return_null=1 \
 	 ./$@; rm $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Configuration Options
+# Configuration
 ###############################################################################
 
 # Platform detection.
@@ -14,10 +14,6 @@ else
 	endif
 endif
 
-# Settings for blst.
-BLST_LIBRARY = ../lib/libblst.a
-BLST_BUILDSCRIPT = ../blst/build.sh
-
 # By default, this is set to the mainnet value.
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
@@ -25,9 +21,6 @@ FIELD_ELEMENTS_PER_BLOB ?= 4096
 CFLAGS += -I../inc
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 CFLAGS += -O2 -Wall -Wextra
-
-# Libraries to include.
-LIBS = $(BLST_LIBRARY)
 
 # Cross-platform compilation settings.
 ifeq ($(PLATFORM),Windows)
@@ -39,13 +32,15 @@ else
 	CFLAGS += -fPIC -Werror
 endif
 
-# Extra setup for macOS.
-ifeq ($(PLATFORM),Darwin)
-	XCRUN = xcrun
-endif
+# Settings for blst.
+BLST_LIBRARY = ../lib/libblst.a
+BLST_BUILDSCRIPT = ../blst/build.sh
+
+# Libraries to build with.
+LIBS = $(BLST_LIBRARY)
 
 ###############################################################################
-# Makefile Rules
+# Core
 ###############################################################################
 
 all: c_kzg_4844.o test
@@ -69,22 +64,21 @@ test_c_kzg_4844: CFLAGS += -O0
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
-test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
-test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
-
-test_c_kzg_4844_prof: LIBS += -lprofiler
-test_c_kzg_4844_prof: CFLAGS += -O0 -DPROFILE
-ifeq ($(PLATFORM),Darwin)
-test_c_kzg_4844_prof: CFLAGS += -L$(shell brew --prefix gperftools)/lib
-test_c_kzg_4844_prof: CFLAGS += -I$(shell brew --prefix gperftools)/include
-endif
-test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
-
 .PHONY: test
 test: test_c_kzg_4844
 	@./test_c_kzg_4844
+
+###############################################################################
+# Coverage
+###############################################################################
+
+ifeq ($(PLATFORM),Darwin)
+	XCRUN = xcrun
+endif
+
+test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
+test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 .PHONY: coverage
 coverage: test_c_kzg_4844_cov
@@ -94,6 +88,19 @@ coverage: test_c_kzg_4844_cov
 	    $< c_kzg_4844.c > coverage.html
 	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
 	    --show-functions $< c_kzg_4844.c
+
+###############################################################################
+# Profile
+###############################################################################
+
+test_c_kzg_4844_prof: LIBS += -lprofiler
+test_c_kzg_4844_prof: CFLAGS += -O0 -DPROFILE
+ifeq ($(PLATFORM),Darwin)
+test_c_kzg_4844_prof: CFLAGS += -L$(shell brew --prefix gperftools)/lib
+test_c_kzg_4844_prof: CFLAGS += -I$(shell brew --prefix gperftools)/include
+endif
+test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 .PHONY: run_profiler
 run_profiler: test_c_kzg_4844_prof
@@ -113,6 +120,10 @@ profile: \
 	profile_verify_kzg_proof \
 	profile_verify_blob_kzg_proof \
 	profile_verify_blob_kzg_proof_batch
+
+###############################################################################
+# Sanitize
+###############################################################################
 
 .PHONY: sanitize_%
 sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
@@ -137,18 +148,26 @@ sanitize: \
 endif
 endif
 
+###############################################################################
+# Analyze
+###############################################################################
+
 .PHONY: analyze
 analyze: c_kzg_4844.c
 	@$(CC) --analyze -Xanalyzer -analyzer-output=html \
 	    -o analysis-report $(CFLAGS) -c $<
 	@[ -d analysis-report ] && exit 1 || exit 0
 
+###############################################################################
+# Cleanup
+###############################################################################
+
+.PHONY: format
+format:
+	@clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c
+
 .PHONY: clean
 clean:
 	@rm -f *.o *.profraw *.profdata *.html xray-log.* *.prof *.pdf \
 	    test_c_kzg_4844 test_c_kzg_4844_cov test_c_kzg_4844_prof
 	@rm -rf analysis-report
-
-.PHONY: format
-format:
-	@clang-format -i --sort-includes c_kzg_4844.* test_c_kzg_4844.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,7 @@ LIBS = $(BLST_LIBRARY)
 ifeq ($(PLATFORM),Windows)
 	CC = gcc
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
+	CFLAGS += -Wl,--stack,8388608
 else
 	CC = clang
     CFLAGS += -fPIC -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,18 @@
 # Configuration Options
 ###############################################################################
 
-# We use clang. Some versions of GCC report missing-braces warnings.
-CC = clang
+# Platform detection.
+ifneq ($(OS),Windows_NT)
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+		PLATFORM = Darwin
+	else
+		PLATFORM = Linux
+    endif
+else
+	PLATFORM = Windows
+endif
+
 
 # Settings for blst.
 BLST_LIBRARY = ../lib/libblst.a
@@ -21,21 +31,17 @@ CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 LIBS = $(BLST_LIBRARY)
 
 # Cross-platform compilation settings.
-ifneq ($(OS),Windows_NT)
-    CFLAGS += -fPIC
-else
+ifeq ($(PLATFORM),Windows)
+	CC = gcc
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
-	CFLAGS += --target=x86_64-w64-mingw32
+else
+	CC = clang
+    CFLAGS += -fPIC
 endif
 
 # Extra setup for macOS.
-ifneq ($(OS),Windows_NT)
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Darwin)
-        XCRUN = xcrun
-        PROFILE += -L$(shell brew --prefix gperftools)/lib
-        PROFILE += -I$(shell brew --prefix gperftools)/include
-    endif
+ifeq ($(PLATFORM),Darwin)
+	XCRUN = xcrun
 endif
 
 ###############################################################################
@@ -59,18 +65,21 @@ blst: $(BLST_LIBRARY)
 c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
+.PHONY: test_c_kzg_4844
 test_c_kzg_4844: CFLAGS += -O0
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
-test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+test_c_kzg_4844_cov: test_c_kzg_4844
 
 test_c_kzg_4844_prof: LIBS += -lprofiler
 test_c_kzg_4844_prof: CFLAGS += -O0 -DPROFILE
-test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+ifeq ($(PLATFORM),Darwin)
+test_c_kzg_4844_prof: CFLAGS += -L$(shell brew --prefix gperftools)/lib
+test_c_kzg_4844_prof: CFLAGS += -I$(shell brew --prefix gperftools)/include
+endif
+test_c_kzg_4844_prof: test_c_kzg_4844
 
 .PHONY: test
 test: test_c_kzg_4844
@@ -78,22 +87,22 @@ test: test_c_kzg_4844
 
 .PHONY: coverage
 coverage: test_c_kzg_4844_cov
-	@LLVM_PROFILE_FILE="ckzg.profraw" ./$<
+	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
 	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \
-	    $< c_kzg_4844.c > coverage.html
+	    test_c_kzg_4844 c_kzg_4844.c > coverage.html
 	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
-	    --show-functions $< c_kzg_4844.c
+	    --show-functions test_c_kzg_4844 c_kzg_4844.c
 
 .PHONY: run_profiler
 run_profiler: test_c_kzg_4844_prof
-	@CPUPROFILE_FREQUENCY=1000000000 ./$<
+	@CPUPROFILE_FREQUENCY=1000000000 ./test_c_kzg_4844
 
 .PHONY: profile_%
 profile_%: run_profiler
 	@echo Profiling $*...
 	@pprof --pdf --nodefraction=0.00001 --edgefraction=0.00001 \
-	    ./test_c_kzg_4844_prof $*.prof > $*.pdf
+	    ./test_c_kzg_4844 $*.prof > $*.pdf
 
 .PHONY: profile
 profile: \
@@ -112,10 +121,9 @@ sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	 LSAN_OPTIONS=allocator_may_return_null=1 \
 	 ./$@; rm $@
 
-ifneq ($(OS),Windows_NT)
-UNAME_S := $(shell uname -s)
+ifneq ($(PLATFORM),Windows)
 .PHONY: sanitize
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(PLATFORM),Darwin)
 sanitize: \
 	sanitize_address \
 	sanitize_undefined

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,11 @@ else
 	endif
 endif
 
+# Some commands need xcode.
+ifeq ($(PLATFORM),Darwin)
+	XCRUN = xcrun
+endif
+
 # By default, this is set to the mainnet value.
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
@@ -71,10 +76,6 @@ test: test_c_kzg_4844
 ###############################################################################
 # Coverage
 ###############################################################################
-
-ifeq ($(PLATFORM),Darwin)
-	XCRUN = xcrun
-endif
 
 test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,9 +17,18 @@ CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 NO_OPTIMIZE = -O0
 
 # Settings for blst.
-BLST_LIBRARY = ../lib/libblst.a
-BLST_BUILDSCRIPT = ../blst/build.sh
 BLST = -L../lib -lblst
+
+# Cross-platform compilation settings.
+ifneq ($(OS),Windows_NT)
+    CFLAGS += -fPIC
+	BLST_LIBRARY = ../lib/libblst.a
+	BLST_BUILDSCRIPT = ../blst/build.sh
+else
+    CFLAGS += -D_CRT_SECURE_NO_WARNINGS
+	BLST_LIBRARY = ../lib/blst.lib
+	BLST_BUILDSCRIPT = ../blst/build.bat
+endif
 
 # Compiler flags for generating coverage data.
 COVERAGE = -fprofile-instr-generate -fcoverage-mapping
@@ -29,17 +38,14 @@ PROFILE = -DPROFILE
 PROFILER = -lprofiler
 PROFILER_OPTS = CPUPROFILE_FREQUENCY=1000000000
 
-# Platform specific options.
+# Extra setup for macOS.
 ifneq ($(OS),Windows_NT)
-    CFLAGS += -fPIC
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Darwin)
         XCRUN = xcrun
         PROFILE += -L$(shell brew --prefix gperftools)/lib
         PROFILE += -I$(shell brew --prefix gperftools)/include
     endif
-else
-    CFLAGS += -D_CRT_SECURE_NO_WARNINGS
 endif
 
 ###############################################################################

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,15 +3,15 @@
 ###############################################################################
 
 # Platform detection.
-ifneq ($(OS),Windows_NT)
+ifeq ($(OS),Windows_NT)
+	PLATFORM = Windows
+else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Darwin)
 		PLATFORM = Darwin
 	else
 		PLATFORM = Linux
     endif
-else
-	PLATFORM = Windows
 endif
 
 
@@ -66,13 +66,13 @@ blst: $(BLST_LIBRARY)
 c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
-.PHONY: test_c_kzg_4844
 test_c_kzg_4844: CFLAGS += -O0
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
 	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
-test_c_kzg_4844_cov: test_c_kzg_4844
+test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 test_c_kzg_4844_prof: LIBS += -lprofiler
 test_c_kzg_4844_prof: CFLAGS += -O0 -DPROFILE
@@ -80,7 +80,8 @@ ifeq ($(PLATFORM),Darwin)
 test_c_kzg_4844_prof: CFLAGS += -L$(shell brew --prefix gperftools)/lib
 test_c_kzg_4844_prof: CFLAGS += -I$(shell brew --prefix gperftools)/include
 endif
-test_c_kzg_4844_prof: test_c_kzg_4844
+test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 .PHONY: test
 test: test_c_kzg_4844
@@ -88,22 +89,22 @@ test: test_c_kzg_4844
 
 .PHONY: coverage
 coverage: test_c_kzg_4844_cov
-	@LLVM_PROFILE_FILE="ckzg.profraw" ./test_c_kzg_4844
+	@LLVM_PROFILE_FILE="ckzg.profraw" ./$<
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
 	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \
-	    test_c_kzg_4844 c_kzg_4844.c > coverage.html
+	    $< c_kzg_4844.c > coverage.html
 	@$(XCRUN) llvm-cov report --instr-profile=ckzg.profdata \
-	    --show-functions test_c_kzg_4844 c_kzg_4844.c
+	    --show-functions $< c_kzg_4844.c
 
 .PHONY: run_profiler
 run_profiler: test_c_kzg_4844_prof
-	@CPUPROFILE_FREQUENCY=1000000000 ./test_c_kzg_4844
+	@CPUPROFILE_FREQUENCY=1000000000 ./$<
 
 .PHONY: profile_%
 profile_%: run_profiler
 	@echo Profiling $*...
 	@pprof --pdf --nodefraction=0.00001 --edgefraction=0.00001 \
-	    ./test_c_kzg_4844 $*.prof > $*.pdf
+	    ./test_c_kzg_4844_prof $*.prof > $*.pdf
 
 .PHONY: profile
 profile: \

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,8 +24,8 @@ FIELD_ELEMENTS_PER_BLOB ?= 4096
 
 # The base compiler flags. More can be added on command line.
 CFLAGS += -I../inc
-CFLAGS += -Wall -Wextra -Werror -O2
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
+CFLAGS += -O2 -Wall -Wextra
 
 # Libraries to include.
 LIBS = $(BLST_LIBRARY)
@@ -36,7 +36,7 @@ ifeq ($(PLATFORM),Windows)
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
 else
 	CC = clang
-    CFLAGS += -fPIC
+    CFLAGS += -fPIC -Werror
 endif
 
 # Extra setup for macOS.

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,12 +6,12 @@
 ifeq ($(OS),Windows_NT)
 	PLATFORM = Windows
 else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Darwin)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
 		PLATFORM = Darwin
 	else
 		PLATFORM = Linux
-    endif
+	endif
 endif
 
 
@@ -33,11 +33,11 @@ LIBS = $(BLST_LIBRARY)
 # Cross-platform compilation settings.
 ifeq ($(PLATFORM),Windows)
 	CC = gcc
-    CFLAGS += -D_CRT_SECURE_NO_WARNINGS
+	CFLAGS += -D_CRT_SECURE_NO_WARNINGS
 	CFLAGS += -Wl,--stack,8388608 # 8MB
 else
 	CC = clang
-    CFLAGS += -fPIC -Werror
+	CFLAGS += -fPIC -Werror
 endif
 
 # Extra setup for macOS.
@@ -120,8 +120,8 @@ sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	@echo Running sanitize=$*...
 	@$(CC) $(CFLAGS) -O0 -fsanitize=$* -o $@ $< $(LIBS)
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
-	 LSAN_OPTIONS=allocator_may_return_null=1 \
-	 ./$@; rm $@
+	    LSAN_OPTIONS=allocator_may_return_null=1 \
+	    ./$@; rm $@
 
 ifneq ($(PLATFORM),Windows)
 .PHONY: sanitize

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,10 @@
 # We use clang. Some versions of GCC report missing-braces warnings.
 CC = clang
 
+# Settings for blst.
+BLST_LIBRARY = ../lib/libblst.a
+BLST_BUILDSCRIPT = ../blst/build.sh
+
 # By default, this is set to the mainnet value.
 FIELD_ELEMENTS_PER_BLOB ?= 4096
 
@@ -12,13 +16,6 @@ FIELD_ELEMENTS_PER_BLOB ?= 4096
 CFLAGS += -I../inc
 CFLAGS += -Wall -Wextra -Werror -O2
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
-
-# Disable optimizations. Put after $CFLAGS.
-NO_OPTIMIZE = -O0
-
-# Settings for blst.
-BLST_LIBRARY = ../lib/libblst.a
-BLST_BUILDSCRIPT = ../blst/build.sh
 
 # Libraries to include.
 LIBS = $(BLST_LIBRARY)
@@ -28,16 +25,8 @@ ifneq ($(OS),Windows_NT)
     CFLAGS += -fPIC
 else
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
-	LIBS += -lmingw32
+	CFLAGS += --target=x86_64-w64-mingw32
 endif
-
-# Compiler flags for generating coverage data.
-COVERAGE = -fprofile-instr-generate -fcoverage-mapping
-
-# Settings for performance profiling.
-PROFILE = -DPROFILE
-PROFILER = -lprofiler
-PROFILER_OPTS = CPUPROFILE_FREQUENCY=1000000000
 
 # Extra setup for macOS.
 ifneq ($(OS),Windows_NT)
@@ -70,14 +59,18 @@ blst: $(BLST_LIBRARY)
 c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
+test_c_kzg_4844: CFLAGS += -O0
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(LIBS)
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
+test_c_kzg_4844_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(LIBS)
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
+test_c_kzg_4844_prof: LIBS += -lprofiler
+test_c_kzg_4844_prof: CFLAGS += -O0 -DPROFILE
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(LIBS) $(PROFILER)
+	@$(CC) $(CFLAGS) -o $@ $< $(LIBS)
 
 .PHONY: test
 test: test_c_kzg_4844
@@ -94,7 +87,7 @@ coverage: test_c_kzg_4844_cov
 
 .PHONY: run_profiler
 run_profiler: test_c_kzg_4844_prof
-	@$(PROFILER_OPTS) ./$<
+	@CPUPROFILE_FREQUENCY=1000000000 ./$<
 
 .PHONY: profile_%
 profile_%: run_profiler
@@ -114,7 +107,7 @@ profile: \
 .PHONY: sanitize_%
 sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	@echo Running sanitize=$*...
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -fsanitize=$* -o $@ $< $(LIBS)
+	@$(CC) $(CFLAGS) -O0 -fsanitize=$* -o $@ $< $(LIBS)
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
 	 LSAN_OPTIONS=allocator_may_return_null=1 \
 	 ./$@; rm $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,17 +17,14 @@ CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 NO_OPTIMIZE = -O0
 
 # Settings for blst.
-BLST = -L../lib -lblst
+BLST_LIBRARY = ../lib/libblst.a
+BLST_BUILDSCRIPT = ../blst/build.sh
 
 # Cross-platform compilation settings.
 ifneq ($(OS),Windows_NT)
     CFLAGS += -fPIC
-	BLST_LIBRARY = ../lib/libblst.a
-	BLST_BUILDSCRIPT = ../blst/build.sh
 else
     CFLAGS += -D_CRT_SECURE_NO_WARNINGS
-	BLST_LIBRARY = ../lib/blst.lib
-	BLST_BUILDSCRIPT = ../blst/build.bat
 endif
 
 # Compiler flags for generating coverage data.
@@ -70,13 +67,13 @@ c_kzg_4844.o: c_kzg_4844.c $(BLST_LIBRARY)
 	@$(CC) $(CFLAGS) -c $<
 
 test_c_kzg_4844: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(BLST)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -o $@ $< $(BLST_LIBRARY)
 
 test_c_kzg_4844_cov: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(BLST)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(COVERAGE) -o $@ $< $(BLST_LIBRARY)
 
 test_c_kzg_4844_prof: test_c_kzg_4844.c c_kzg_4844.c
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(BLST) $(PROFILER)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) $(PROFILE) -o $@ $< $(BLST_LIBRARY) $(PROFILER)
 
 .PHONY: test
 test: test_c_kzg_4844
@@ -113,7 +110,7 @@ profile: \
 .PHONY: sanitize_%
 sanitize_%: test_c_kzg_4844.c c_kzg_4844.c
 	@echo Running sanitize=$*...
-	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -fsanitize=$* -o $@ $< $(BLST)
+	@$(CC) $(CFLAGS) $(NO_OPTIMIZE) -fsanitize=$* -o $@ $< $(BLST_LIBRARY)
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
 	 LSAN_OPTIONS=allocator_may_return_null=1 \
 	 ./$@; rm $@


### PR DESCRIPTION
This PR will build/test the C library on all platforms (Linux, macOS, and Windows).

Also, did general cleanup of the Makefile:

* Define new `PLATFORM` variable which is assigned at the top.
* Define new `LIBS` variable with has all of the libraries to build with.
* Replace all of configuration options with setting in the rules.
* Fix some indentation issues.
* Organize everything better.

### Some notes

I used gcc rather than clang for building on Windows because clang isn't part of the mingw32 toolchain. Using clang led to an unresolved symbol error related to `___chkstk_ms`. This happened because blst was built with gcc, not clang. Although we could build blst with `build.bat` instead of `build.sh`, it was more difficult and caused the Java bindings build to fail on Windows as they also used gcc.

When building with gcc on Windows, the system expected `blst.lib`, but the actual file was `libblst.a`. To fix this, I specified the `../lib/libblst.a` file instead of `-lblst`.

Eventually, I encountered a "Stack Overflow" exception with the error code `-1073741571` (or `0xC00000FD`). This was likely due to the smaller stack size on Windows compared to Linux/macOS, especially when working with large structures like `Blob` and `Polynomials`. As a solution, I increased the stack size to 8MB for Windows. Further investigation into the exact cause of the exception could be done in the future.