### PR TITLE
Add repo link to npm page

### DIFF
--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -28,7 +28,7 @@
   "bugs": {
     "url": "https://github.com/ethereum/c-kzg-4844/issues"
   },
-  "homepage": "https://github.com/ethereum/c-kzg-4844#readme",
+  "homepage": "https://github.com/ethereum/c-kzg-4844",
   "main": "lib/kzg.js",
   "types": "lib/kzg.d.ts",
   "gypfile": true

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -13,6 +13,12 @@
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",
+    "@typescript-eslint/eslint-plugin": "^5.57.0",
+    "@typescript-eslint/parser": "^5.57.0",
+    "eslint": "^8.37.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.2.2",
     "node-gyp": "^9.3.0",
     "prettier": "2.7.1",
@@ -21,6 +27,14 @@
     "glob": "^9.1.0",
     "js-yaml": "^4.1.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ethereum/c-kzg-4844.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ethereum/c-kzg-4844/issues"
+  },
+  "homepage": "https://github.com/ethereum/c-kzg-4844#readme",
   "main": "lib/kzg.js",
   "types": "lib/kzg.d.ts",
   "gypfile": true

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -13,12 +13,6 @@
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",
-    "@typescript-eslint/eslint-plugin": "^5.57.0",
-    "@typescript-eslint/parser": "^5.57.0",
-    "eslint": "^8.37.0",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.2.2",
     "node-gyp": "^9.3.0",
     "prettier": "2.7.1",


### PR DESCRIPTION
I noticed the npm page does not have a repo link. This will fix that.  See the image below for an example

![Screen Shot 2023-03-30 at 5 56 18 PM](https://user-images.githubusercontent.com/18608739/228973220-d62ff72c-4ec2-4d6f-a5ec-8ac48ca2e401.png)

![Screen Shot 2023-03-30 at 5 55 06 PM](https://user-images.githubusercontent.com/18608739/228973131-e69724a7-b2c3-4646-bde3-ed0f86f96fc4.png)
