### PR TITLE
delegate blst build to crate in preparation for windows bindings

### DIFF
--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -53,6 +53,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blst"
+version = "0.3.10"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +73,7 @@ name = "c-kzg"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "blst",
  "criterion",
  "glob",
  "hex",
@@ -77,6 +88,12 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cexpr"
@@ -660,6 +677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,3 +828,23 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
+]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -14,6 +14,7 @@ minimal-spec = []
 hex = "0.4.2"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
+blst = { path = "../../blst/bindings/rust" }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -15,21 +15,12 @@ fn move_file(src: &Path, dst: &Path) -> Result<(), String> {
 
 fn main() {
     let cargo_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let root_dir = cargo_dir.join("../../");
+    let root_dir = cargo_dir
+        .parent()
+        .expect("rust dir is nested")
+        .parent()
+        .expect("bindings dir is nested");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    // Ensure libblst exists in `OUT_DIR`
-    // Assuming blst submodule exists
-    Command::new("make")
-        .current_dir(root_dir.join("src"))
-        .arg("blst")
-        .status()
-        .unwrap();
-    move_file(
-        root_dir.join("lib/libblst.a").as_path(),
-        out_dir.join("libblst.a").as_path(),
-    )
-    .unwrap();
 
     let field_elements_per_blob = if cfg!(feature = "minimal-spec") {
         MINIMAL_FIELD_ELEMENTS_PER_BLOB
@@ -41,7 +32,7 @@ fn main() {
 
     // Deleting any existing assembly and object files to ensure that compiling with a different
     // feature flag changes the final linked library file.
-    let obj_file = root_dir.join("src/c_kzg_4844.o");
+    let obj_file = root_dir.join("src").join("c_kzg_4844.o");
     if obj_file.exists() {
         std::fs::remove_file(obj_file).unwrap();
     }
@@ -63,7 +54,7 @@ fn main() {
         .status()
         .unwrap();
     move_file(
-        root_dir.join("src/libckzg.a").as_path(),
+        root_dir.join("src").join("libckzg.a").as_path(),
         out_dir.join("libckzg.a").as_path(),
     )
     .unwrap();
@@ -71,22 +62,31 @@ fn main() {
     println!("cargo:rustc-link-search={}", out_dir.display());
     println!("cargo:rustc-link-search={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=ckzg");
+    // Tell cargo to search for the static blst exposed by the blst-bindings' crate.
     println!("cargo:rustc-link-lib=static=blst");
 
-    let bindings_out_path = cargo_dir.join("src/bindings/generated.rs");
+    let bindings_out_path = cargo_dir.join("src").join("bindings").join("generated.rs");
     let build_target = env::var("TARGET").unwrap();
     let snapshot_path = cargo_dir.join("snapshots").join(format!(
         "bindings_{build_target}_{field_elements_per_blob}.rs"
     ));
+
+    let header_file_path = root_dir.join("src").join("c_kzg_4844.h");
+    let header_file = header_file_path.to_str().expect("valid header file");
+
+    // Obtain the header files exposed by blst-bindings' crate.
+    let blst_headers_dir =
+        std::env::var_os("DEP_BLST_BINDINGS").expect("BLST exposes header files for bindings");
     make_bindings(
         field_elements_per_blob,
-        &root_dir,
+        header_file,
+        &blst_headers_dir.to_string_lossy(),
         bindings_out_path,
         snapshot_path,
     );
 
     // Cleanup
-    let obj_file = root_dir.join("src/c_kzg_4844.o");
+    let obj_file = root_dir.join("src").join("c_kzg_4844.o");
     if obj_file.exists() {
         std::fs::remove_file(obj_file).unwrap();
     }
@@ -94,7 +94,8 @@ fn main() {
 
 fn make_bindings<P>(
     field_elements_per_blob: usize,
-    root_dir: &Path,
+    header_path: &str,
+    blst_headers_dir: &str,
     bindings_out_path: P,
     snapshot_path: P,
 ) where
@@ -120,12 +121,6 @@ fn make_bindings<P>(
         }
     }
 
-    let header_file_path = root_dir.join("src/c_kzg_4844.h");
-    let header_file = header_file_path.to_str().expect("valid header file");
-
-    let inc_dir_path = root_dir.join("inc");
-    let inc_dir = inc_dir_path.to_str().expect("valid inc dir");
-
     let bindings = Builder::default()
         /*
          * Header definitions.
@@ -136,12 +131,12 @@ fn make_bindings<P>(
             "consts",
             &format!("#define FIELD_ELEMENTS_PER_BLOB {field_elements_per_blob}"),
         )
-        .header(header_file)
-        .clang_args([format!("-I{inc_dir}")])
+        .header(header_path)
+        .clang_args([format!("-I{blst_headers_dir}")])
         // Since this is not part of the header file, needs to be allowed explicitly.
         .allowlist_var("FIELD_ELEMENTS_PER_BLOB")
         // Get bindings only for the header file.
-        .allowlist_file(".*/c_kzg_4844.h")
+        .allowlist_file(".*c_kzg_4844.h")
         /*
          * Cleanup instructions.
          */


### PR DESCRIPTION
Moves the responsibility of building blst from this crate using make, to the rust crate for blst. The blst crate knows the best way to build blst according to features, platform-dependent flags etc. This is necessary in preparation for the windows bindings.

Also updates use of paths everywhere to use os-specific paths instead of linux paths