### PR TITLE
Add some comments & fix some nits

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -941,7 +941,7 @@ C_KZG_RET verify_kzg_proof(
     ret = bytes_to_kzg_proof(&proof_g1, proof_bytes);
     if (ret != C_KZG_OK) return ret;
 
-    /* Do a pairings check */
+    /* Call helper to do pairings check */
     return verify_kzg_proof_impl(
         ok, &commitment_g1, &z_fr, &y_fr, &proof_g1, s
     );
@@ -1204,7 +1204,7 @@ C_KZG_RET verify_blob_kzg_proof(
     );
     if (ret != C_KZG_OK) return ret;
 
-    /* Call helper to do pairing check */
+    /* Call helper to do pairings check */
     return verify_kzg_proof_impl(
         ok, &commitment_g1, &evaluation_challenge_fr, &y_fr, &proof_g1, s
     );

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1501,6 +1501,7 @@ static uint32_t reverse_bits(uint32_t n) {
  * In other words, the bit index of the one bit.
  *
  * @remark Works only for n a power of two, and only for n up to 2^31.
+ * @remark Not the fastest implementation, but it doesn't need to be fast.
  *
  * @param[in] n The power of two
  *

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1737,35 +1737,6 @@ out_success:
 }
 
 /**
- * Free the memory that was previously allocated by new_fft_settings().
- *
- * @remark It's a NOP if `fs` is NULL.
- *
- * @param[in] fs The settings to be freed
- */
-static void free_fft_settings(FFTSettings *fs) {
-    if (fs == NULL) return;
-    c_kzg_free(fs->expanded_roots_of_unity);
-    c_kzg_free(fs->reverse_roots_of_unity);
-    c_kzg_free(fs->roots_of_unity);
-    fs->max_width = 0;
-}
-
-/**
- * Free the memory that was previously allocated by new_kzg_settings().
- *
- * @remark It's a NOP if `ks` is NULL.
- *
- * @param[in] ks The settings to be freed
- */
-static void free_kzg_settings(KZGSettings *s) {
-    if (s == NULL) return;
-    c_kzg_free(s->fs);
-    c_kzg_free(s->g1_values);
-    c_kzg_free(s->g2_values);
-}
-
-/**
  * Load trusted setup into a KZGSettings.
  *
  * @remark Free after use with free_trusted_setup().
@@ -1892,6 +1863,35 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
         g2_bytes,
         TRUSTED_SETUP_NUM_G2_POINTS
     );
+}
+
+/**
+ * Free the memory that was previously allocated by new_fft_settings().
+ *
+ * @remark It's a NOP if `fs` is NULL.
+ *
+ * @param[in] fs The settings to be freed
+ */
+static void free_fft_settings(FFTSettings *fs) {
+    if (fs == NULL) return;
+    c_kzg_free(fs->expanded_roots_of_unity);
+    c_kzg_free(fs->reverse_roots_of_unity);
+    c_kzg_free(fs->roots_of_unity);
+    fs->max_width = 0;
+}
+
+/**
+ * Free the memory that was previously allocated by new_kzg_settings().
+ *
+ * @remark It's a NOP if `ks` is NULL.
+ *
+ * @param[in] ks The settings to be freed
+ */
+static void free_kzg_settings(KZGSettings *s) {
+    if (s == NULL) return;
+    c_kzg_free(s->fs);
+    c_kzg_free(s->g1_values);
+    c_kzg_free(s->g2_values);
 }
 
 /**

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -507,8 +507,10 @@ static bool pairings_verify(
  * @return the log base two of n
  */
 static int log2_pow2(uint32_t n) {
-    /* clz (count leading zero) bits */
-    return 31 - __builtin_clz(n);
+    int position = 0;
+    while (n >>= 1)
+        position++;
+    return position;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -36,9 +36,14 @@ extern "C" {
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
 
+/**
+ * This value represents the number of field elements in a blob. It must be
+ * supplied externally. It is expected to be 4096 for mainnet and 4 for minimal.
+ */
 #ifndef FIELD_ELEMENTS_PER_BLOB
 #error FIELD_ELEMENTS_PER_BLOB must be defined
-#endif // FIELD_ELEMENTS_PER_BLOB
+#endif /* FIELD_ELEMENTS_PER_BLOB */
+
 /**
  * There are only 1<<32 2-adic roots of unity in the field, limiting the
  * possible values of FIELD_ELEMENTS_PER_BLOB. The restriction to 1<<31 is a
@@ -47,7 +52,7 @@ extern "C" {
  */
 #if (FIELD_ELEMENTS_PER_BLOB <= 0) || (FIELD_ELEMENTS_PER_BLOB > (1UL << 31))
 #error FIELD_ELEMENTS_PER_BLOB must be between 1 and 2^31
-#endif // FIELD_ELEMENTS_PER_BLOB
+#endif /* FIELD_ELEMENTS_PER_BLOB */
 
 /**
  * If FIELD_ELEMENTS_PER_BLOB is not a power of 2, the size of the FFT domain
@@ -58,12 +63,19 @@ extern "C" {
  * As this case is neither maintained nor tested, we prefer to not support it.
  */
 #if ((FIELD_ELEMENTS_PER_BLOB) & (FIELD_ELEMENTS_PER_BLOB)-1) != 0
-#error FIELD_ELEMENTS_PER_BLOB is not a power of two
-#endif
+#error FIELD_ELEMENTS_PER_BLOB must be a power of two
+#endif /* FIELD_ELEMENTS_PER_BLOB */
 
+/** The number of bytes in a KZG commitment. */
 #define BYTES_PER_COMMITMENT 48
+
+/** The number of bytes in a KZG proof. */
 #define BYTES_PER_PROOF 48
+
+/** The number of bytes in a BLS scalar field element. */
 #define BYTES_PER_FIELD_ELEMENT 32
+
+/** The number of bytes in a blob. */
 #define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -62,7 +62,7 @@ extern "C" {
  * need the case where FIELD_ELEMENTS_PER_BLOB is not a power of 2.  As this
  * case is neither maintained nor tested, we prefer to not support it.
  */
-#if (FIELD_ELEMENTS_PER_BLOB & (FIELD_ELEMENTS_PER_BLOB-1)) != 0
+#if (FIELD_ELEMENTS_PER_BLOB & (FIELD_ELEMENTS_PER_BLOB - 1)) != 0
 #error FIELD_ELEMENTS_PER_BLOB must be a power of two
 #endif /* FIELD_ELEMENTS_PER_BLOB */
 

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -58,9 +58,9 @@ extern "C" {
  * If FIELD_ELEMENTS_PER_BLOB is not a power of 2, the size of the FFT domain
  * should be chosen as the the next-largest power of two and polynomials
  * represented by their evaluations at a subset of the 2^i'th roots of unity.
- * While the code in this library tries to take this into account,
- * we do not need the case where FIELD_ELEMENTS_PER_BLOB is not a power of 2.
- * As this case is neither maintained nor tested, we prefer to not support it.
+ * While the code in this library tries to take this into account, we do not
+ * need the case where FIELD_ELEMENTS_PER_BLOB is not a power of 2.  As this
+ * case is neither maintained nor tested, we prefer to not support it.
  */
 #if ((FIELD_ELEMENTS_PER_BLOB) & (FIELD_ELEMENTS_PER_BLOB)-1) != 0
 #error FIELD_ELEMENTS_PER_BLOB must be a power of two

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -36,7 +36,7 @@ extern "C" {
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
 
-/**
+/*
  * This value represents the number of field elements in a blob. It must be
  * supplied externally. It is expected to be 4096 for mainnet and 4 for minimal.
  */
@@ -44,7 +44,7 @@ extern "C" {
 #error FIELD_ELEMENTS_PER_BLOB must be defined
 #endif /* FIELD_ELEMENTS_PER_BLOB */
 
-/**
+/*
  * There are only 1<<32 2-adic roots of unity in the field, limiting the
  * possible values of FIELD_ELEMENTS_PER_BLOB. The restriction to 1<<31 is a
  * current implementation limitation. Notably, the size of the FFT setup would
@@ -54,7 +54,7 @@ extern "C" {
 #error FIELD_ELEMENTS_PER_BLOB must be between 1 and 2^31
 #endif /* FIELD_ELEMENTS_PER_BLOB */
 
-/**
+/*
  * If FIELD_ELEMENTS_PER_BLOB is not a power of 2, the size of the FFT domain
  * should be chosen as the the next-largest power of two and polynomials
  * represented by their evaluations at a subset of the 2^i'th roots of unity.

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -50,7 +50,7 @@ extern "C" {
  * current implementation limitation. Notably, the size of the FFT setup would
  * overflow uint32_t, which would cause issues.
  */
-#if (FIELD_ELEMENTS_PER_BLOB <= 0) || (FIELD_ELEMENTS_PER_BLOB > (1UL << 31))
+#if FIELD_ELEMENTS_PER_BLOB <= 0 || FIELD_ELEMENTS_PER_BLOB > (1UL << 31)
 #error FIELD_ELEMENTS_PER_BLOB must be between 1 and 2^31
 #endif /* FIELD_ELEMENTS_PER_BLOB */
 
@@ -62,7 +62,7 @@ extern "C" {
  * need the case where FIELD_ELEMENTS_PER_BLOB is not a power of 2.  As this
  * case is neither maintained nor tested, we prefer to not support it.
  */
-#if ((FIELD_ELEMENTS_PER_BLOB) & (FIELD_ELEMENTS_PER_BLOB)-1) != 0
+#if (FIELD_ELEMENTS_PER_BLOB & (FIELD_ELEMENTS_PER_BLOB-1)) != 0
 #error FIELD_ELEMENTS_PER_BLOB must be a power of two
 #endif /* FIELD_ELEMENTS_PER_BLOB */
 


### PR DESCRIPTION
* Add comments where I felt they were missing.
* Change `log2_pow2` to use simpler Implementation.
  * This is only used in the trusted setup anyway.
* Move a `bytes_to_kzg_proof` call up, to fail faster.
* Change `(uint64_t)1` to `1ULL` to be more concise.
* Move some trusted setup functions down to its section.
* Group trusted setup free funcs together.
* Update error message for `FIELD_ELEMENTS_PER_BLOB` in header.
* Replace `//` comments with `/* */` comments.
* Remove some excess parentheses.