### PR TITLE
For load_trusted_setup_file, take string file path

### DIFF
--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -9,13 +9,8 @@ KZGSettings* load_trusted_setup_wrap(const char* file) {
 
   if (out == NULL) return NULL;
 
-  FILE* f = fopen(file, "r");
+  if (load_trusted_setup_file(out, file) != C_KZG_OK) { free(out); return NULL; }
 
-  if (f == NULL) { free(out); return NULL; }
-
-  if (load_trusted_setup_file(out, f) != C_KZG_OK) { free(out); fclose(f); return NULL; }
-
-  fclose(f);
   return out;
 }
 

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -103,7 +103,7 @@ LoadTrustedSetupFile is the binding for:
 
 	C_KZG_RET load_trusted_setup_file(
 	    KZGSettings *out,
-	    FILE *in);
+	    const char *in);
 */
 func LoadTrustedSetupFile(trustedSetupFile string) error {
 	if loaded {
@@ -111,14 +111,7 @@ func LoadTrustedSetupFile(trustedSetupFile string) error {
 	}
 	cTrustedSetupFile := C.CString(trustedSetupFile)
 	defer C.free(unsafe.Pointer(cTrustedSetupFile))
-	cMode := C.CString("r")
-	defer C.free(unsafe.Pointer(cMode))
-	fp := C.fopen(cTrustedSetupFile, cMode)
-	if fp == nil {
-		panic("error reading trusted setup")
-	}
-	ret := C.load_trusted_setup_file(&settings, fp)
-	C.fclose(fp)
+	ret := C.load_trusted_setup_file(&settings, cTrustedSetupFile)
 	if ret == C.C_KZG_OK {
 		loaded = true
 	}

--- a/bindings/java/c_kzg_4844_jni.c
+++ b/bindings/java/c_kzg_4844_jni.c
@@ -75,20 +75,9 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_loadTrustedSetup__Ljav
 
   const char *file_native = (*env)->GetStringUTFChars(env, file, 0);
 
-  FILE *f = fopen(file_native, "r");
-
-  if (f == NULL)
-  {
-    reset_trusted_setup();
-    (*env)->ReleaseStringUTFChars(env, file, file_native);
-    throw_exception(env, "Couldn't load Trusted Setup. File might not exist or there is a permission issue.");
-    return;
-  }
-
-  C_KZG_RET ret = load_trusted_setup_file(settings, f);
+  C_KZG_RET ret = load_trusted_setup_file(settings, file_native);
 
   (*env)->ReleaseStringUTFChars(env, file, file_native);
-  fclose(f);
 
   if (ret != C_KZG_OK)
   {

--- a/bindings/nim/kzg.nim
+++ b/bindings/nim/kzg.nim
@@ -54,19 +54,11 @@ template verify(res: KZG_RET, ret: untyped): untyped =
 # Public functions
 ##############################################################
 
-proc loadTrustedSetup*(input: File): Result[KzgCtx, string] =
+proc loadTrustedSetup*(filePath: string): Result[KzgCtx, string] =
   let
     ctx = newKzgCtx()
-    res = load_trusted_setup_file(ctx.val, input)
+    res = load_trusted_setup_file(ctx.val, filePath)
   verify(res, ctx)
-
-proc loadTrustedSetup*(fileName: string): Result[KzgCtx, string] =
-  try:
-    let file = open(fileName)
-    result = file.loadTrustedSetup()
-    file.close()
-  except IOError as ex:
-    return err(ex.msg)
 
 proc loadTrustedSetup*(g1: openArray[G1Data],
                        g2: openArray[G2Data]):

--- a/bindings/nim/kzg_abi.nim
+++ b/bindings/nim/kzg_abi.nim
@@ -85,7 +85,7 @@ proc load_trusted_setup*(res: KzgSettings,
                          n2: csize_t): KZG_RET {.kzg_abi.}
 
 proc load_trusted_setup_file*(res: KzgSettings,
-                         input: File): KZG_RET {.kzg_abi.}
+                         filePath: cstring): KZG_RET {.kzg_abi.}
 
 proc free_trusted_setup*(s: KzgSettings) {.kzg_abi.}
 

--- a/bindings/nim/tests/test_abi.nim
+++ b/bindings/nim/tests/test_abi.nim
@@ -36,11 +36,9 @@ proc readSetup(): KzgSettings =
   doAssert(res == KZG_OK,
     "ERROR: " & $res)
 
-proc readSetup(filename: string): KzgSettings =
-  var file = open(filename)
-  let ret =  load_trusted_setup_file(result, file)
+proc readSetup(filePath: string): KzgSettings =
+  let ret = load_trusted_setup_file(result, cstring(filePath))
   doAssert ret == KZG_OK
-  file.close()
 
 proc createKateBlobs(s: KzgSettings, n: int): KateBlobs =
   for i in 0..<n:

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -172,19 +172,13 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo &info) {
         return env.Undefined();
     }
 
-    // Open the trusted setup file
+    // Get the file path from the arguments
     std::string file_path = info[0].As<Napi::String>().Utf8Value();
-    FILE *file_handle = fopen(file_path.c_str(), "r");
-    if (file_handle == nullptr) {
-        Napi::Error::New(env, "Error opening trusted setup file: " + file_path)
-            .ThrowAsJavaScriptException();
-        return env.Undefined();
-    }
 
     // Load the trusted setup from that file
-    C_KZG_RET ret = load_trusted_setup_file(&(data->settings), file_handle);
-    // Close the trusted setup file
-    fclose(file_handle);
+    C_KZG_RET ret = load_trusted_setup_file(
+        &(data->settings), file_path.c_str()
+    );
 
     // Check that loading the trusted setup was successful
     if (ret != C_KZG_OK) {

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -18,7 +18,7 @@ static PyObject* load_trusted_setup_wrap(PyObject *self, PyObject *args) {
 
   if (s == NULL) return PyErr_NoMemory();
 
-  if (load_trusted_setup_file(s, fopen(PyUnicode_AsUTF8(f), "r")) != C_KZG_OK) {
+  if (load_trusted_setup_file(s, PyUnicode_AsUTF8(f)) != C_KZG_OK) {
     free(s);
     return PyErr_Format(PyExc_RuntimeError, "error loading trusted setup");
   }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -140,12 +140,6 @@ fn make_bindings<P>(
         /*
          * Cleanup instructions.
          */
-        // Remove stdio definitions related to FILE.
-        .opaque_type("FILE")
-        // Remove the definition of FILE to use the libc one, which is more convenient.
-        .blocklist_type("FILE")
-        // Inject rust code using libc's FILE
-        .raw_line("use libc::FILE;")
         // Do no generate layout tests.
         .layout_tests(false)
         // Extern functions do not need individual extern blocks.

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -6,7 +6,6 @@ mod test_formats;
 
 include!("generated.rs");
 
-use libc::fopen;
 use std::ffi::CString;
 use std::mem::MaybeUninit;
 use std::os::unix::prelude::OsStrExt;
@@ -107,8 +106,7 @@ impl KZGSettings {
         })?;
         let mut kzg_settings = MaybeUninit::<KZGSettings>::uninit();
         unsafe {
-            let file_ptr = fopen(file_path.as_ptr(), &('r' as libc::c_char));
-            let res = load_trusted_setup_file(kzg_settings.as_mut_ptr(), file_ptr);
+            let res = load_trusted_setup_file(kzg_settings.as_mut_ptr(), file_path.as_ptr());
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(kzg_settings.assume_init())
             } else {

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1888,7 +1888,7 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, const char *in) {
     }
 
     /* Close the file */
-    //CHECK(fclose(fp) == 0);
+    CHECK(fclose(fp) == 0);
 
     return load_trusted_setup(
         out,

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1853,35 +1853,42 @@ out_success:
  * @remark The input file will not be closed.
  *
  * @param[out] out Pointer to the loaded trusted setup data
- * @param[in]  in  File handle for input
+ * @param[in]  in  Path to trusted setup file.
  */
-C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, const char *in) {
     int num_matches;
     uint64_t i;
     uint8_t g1_bytes[TRUSTED_SETUP_NUM_G1_POINTS * BYTES_PER_G1];
     uint8_t g2_bytes[TRUSTED_SETUP_NUM_G2_POINTS * BYTES_PER_G2];
 
+    /* Open the file */
+    FILE *fp = fopen(in, "r");
+    CHECK(fp != NULL);
+
     /* Read the number of g1 points */
-    num_matches = fscanf(in, "%" SCNu64, &i);
+    num_matches = fscanf(fp, "%" SCNu64, &i);
     CHECK(num_matches == 1);
     CHECK(i == TRUSTED_SETUP_NUM_G1_POINTS);
 
     /* Read the number of g2 points */
-    num_matches = fscanf(in, "%" SCNu64, &i);
+    num_matches = fscanf(fp, "%" SCNu64, &i);
     CHECK(num_matches == 1);
     CHECK(i == TRUSTED_SETUP_NUM_G2_POINTS);
 
     /* Read all of the g1 points, byte by byte */
     for (i = 0; i < TRUSTED_SETUP_NUM_G1_POINTS * BYTES_PER_G1; i++) {
-        num_matches = fscanf(in, "%2hhx", &g1_bytes[i]);
+        num_matches = fscanf(fp, "%2hhx", &g1_bytes[i]);
         CHECK(num_matches == 1);
     }
 
     /* Read all of the g2 points, byte by byte */
     for (i = 0; i < TRUSTED_SETUP_NUM_G2_POINTS * BYTES_PER_G2; i++) {
-        num_matches = fscanf(in, "%2hhx", &g2_bytes[i]);
+        num_matches = fscanf(fp, "%2hhx", &g2_bytes[i]);
         CHECK(num_matches == 1);
     }
+
+    /* Close the file */
+    //CHECK(fclose(fp) == 0);
 
     return load_trusted_setup(
         out,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -169,7 +169,7 @@ C_KZG_RET load_trusted_setup(
     size_t n2
 );
 
-C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, const char *in);
 
 void free_trusted_setup(KZGSettings *s);
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1795,18 +1795,11 @@ static void profile_verify_blob_kzg_proof_batch(void) {
 ///////////////////////////////////////////////////////////////////////////////
 
 static void setup(void) {
-    FILE *fp;
     C_KZG_RET ret;
 
-    /* Open the mainnet trusted setup file */
-    fp = fopen("trusted_setup.txt", "r");
-    assert(fp != NULL);
-
     /* Load that trusted setup file */
-    ret = load_trusted_setup_file(&s, fp);
+    ret = load_trusted_setup_file(&s, "trusted_setup.txt");
     assert(ret == C_KZG_OK);
-
-    fclose(fp);
 }
 
 static void teardown(void) {


### PR DESCRIPTION
Instead of taking a `FILE *`, take a `const char *` which is easier for the bindings.

In this comment, I said we should look into changing this behavior:

* https://github.com/ethereum/c-kzg-4844/pull/259#issuecomment-1493192541

Thanks for pointing out how weird this was @divagant-martian.

Fixes #276.