### PR TITLE
Update the nodejs exported  Buffer types to more universal Uint8Array

### DIFF
--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -4,8 +4,8 @@
  */
 export type Bytes32 = Uint8Array; // 32 bytes
 export type Bytes48 = Uint8Array; // 48 bytes
-export type KZGProof = Buffer; // 48 bytes
-export type KZGCommitment = Buffer; // 48 bytes
+export type KZGProof = Uint8Array; // 48 bytes
+export type KZGCommitment = Uint8Array; // 48 bytes
 export type Blob = Uint8Array; // 4096 * 32 bytes
 export type ProofResult = [KZGProof, Bytes32];
 export interface TrustedSetupJson {

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -74,30 +74,11 @@ function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
   return true;
 }
 
-function padToEven(a: string): string {
-  return a.length % 2 ? `0${a}` : a;
-}
-
-function bytesFromHex(hex: string): Uint8Array {
-  if (typeof hex !== "string") {
-    throw new Error(`hex argument type ${typeof hex} must be of type string`);
+function bytesFromHex(hexString: string): Uint8Array {
+  if (hexString.startsWith("0x")) {
+    hexString = hexString.slice(2);
   }
-
-  if (hex.startsWith("0x")) {
-    hex = hex.slice(2);
-  }
-
-  if (hex.length % 2 !== 0) {
-    hex = padToEven(hex);
-  }
-
-  const byteLen = hex.length / 2;
-  const bytes = new Uint8Array(byteLen);
-  for (let i = 0; i < byteLen; i++) {
-    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16);
-    bytes[i] = byte;
-  }
-  return bytes;
+  return Uint8Array.from(Buffer.from(hexString, "hex"));
 }
 
 describe("C-KZG", () => {
@@ -148,7 +129,12 @@ describe("C-KZG", () => {
         }
 
         expect(test.output).not.toBeNull();
-        expect(proof.reduce((acc, pitem, pindex) => acc && bytesEqual(pitem, bytesFromHex(test.output[pindex])), true));
+
+        const [proofBytes, yBytes] = proof;
+        const [expectedProofBytes, expectedYBytes] = test.output.map((out) => bytesFromHex(out));
+
+        expect(bytesEqual(proofBytes, expectedProofBytes));
+        expect(bytesEqual(yBytes, expectedYBytes));
       });
     });
 

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -64,6 +64,13 @@ const proofBadLength = randomBytes(BYTES_PER_PROOF - 1);
 const fieldElementValidLength = randomBytes(BYTES_PER_FIELD_ELEMENT);
 const fieldElementBadLength = randomBytes(BYTES_PER_FIELD_ELEMENT - 1);
 
+function bytesFromHex(hexString: string): Uint8Array {
+  if (hexString.startsWith("0x")) {
+    hexString = hexString.slice(2);
+  }
+  return Uint8Array.from(Buffer.from(hexString, "hex"));
+}
+
 function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
   if (a.length !== b.length) {
     return false;
@@ -72,13 +79,6 @@ function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
-}
-
-function bytesFromHex(hexString: string): Uint8Array {
-  if (hexString.startsWith("0x")) {
-    hexString = hexString.slice(2);
-  }
-  return Uint8Array.from(Buffer.from(hexString, "hex"));
 }
 
 describe("C-KZG", () => {


### PR DESCRIPTION
Replace the `Buffer` types with a more universal `Uint8Array` in the kzg interface

Even though the current implementation only supports nodejs as of now (and using the `Buffer` objects which are just inherited from `Uint8Array`), the libraries which import this interface (think lodestar/ethereumjs) start breaking in the browser.

Even if c-kzg may not aspire to be browser compatible, the interface can be standard and libraries can be dynamically loaded/replaced by the underlying application.