### PR TITLE
[Go] Clean things up a bit

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -21,8 +21,8 @@ For reference, see the `example` module in this directory. You can test it out w
 
 ```
 user@system ~/c-kzg-4844/bindings/go/example $ go run .
-go: downloading github.com/ethereum/c-kzg-4844 v0.0.0-20230321204456-577d146c0a5a
-go: downloading github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2
+go: downloading github.com/ethereum/c-kzg-4844 v0.0.0-20230407130613-fd0a51aa35bc
+go: downloading github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b
 88f1aea383b825371cb98acfbae6c81cce601a2e3129461c3c2b816409af8f3e5080db165fd327db687b3ed632153a62
 ```
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,4 +1,4 @@
-# cgo-kzg-4844
+# Go bindings
 
 This package implements Go bindings (using [Cgo](https://go.dev/blog/cgo)) for the
 exported functions in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).

--- a/bindings/go/example/go.mod
+++ b/bindings/go/example/go.mod
@@ -2,6 +2,6 @@ module example
 
 go 1.19
 
-require github.com/ethereum/c-kzg-4844 v0.0.0-20230330220301-966e40d70e72
+require github.com/ethereum/c-kzg-4844 v0.0.0-20230407130613-fd0a51aa35bc
 
-require github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 // indirect
+require github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b // indirect

--- a/bindings/go/example/go.sum
+++ b/bindings/go/example/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/ethereum/c-kzg-4844 v0.0.0-20230330220301-966e40d70e72 h1:oBooxFAmy0BLUXYlKK0ecyivDlvqUc9OMVxyG0yXi1A=
-github.com/ethereum/c-kzg-4844 v0.0.0-20230330220301-966e40d70e72/go.mod h1:RILWWKloPYRjowfacYdBBTg56GdU2nzxU7hAZ6bwWsw=
+github.com/ethereum/c-kzg-4844 v0.0.0-20230407130613-fd0a51aa35bc h1:bm2sLc9OcgiHkN6+ZlnwIMIXOBMLcPto7SeGyocFQhA=
+github.com/ethereum/c-kzg-4844 v0.0.0-20230407130613-fd0a51aa35bc/go.mod h1:WI2Nd82DMZAAZI1wV2neKGost9EKjvbpQR9OqE5Qqa8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2 h1:wh1wzwAhZBNiZO37uWS/nDaKiIwHz4mDo4pnA+fqTO0=
-github.com/supranational/blst v0.3.11-0.20230124161941-ca03e11a3ff2/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b h1:u49mjRnygnB34h8OKbnNJFVUtWSKIKb1KukdV8bILUM=
+github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -68,7 +68,7 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (b *Bytes32) UnmarshalText(input []byte) error {
-	if string(input)[:2] == "0x" {
+	if string(input[:2]) == "0x" {
 		input = input[2:]
 	}
 	bytes, err := hex.DecodeString(string(input))
@@ -83,7 +83,7 @@ func (b *Bytes32) UnmarshalText(input []byte) error {
 }
 
 func (b *Bytes48) UnmarshalText(input []byte) error {
-	if string(input)[:2] == "0x" {
+	if string(input[:2]) == "0x" {
 		input = input[2:]
 	}
 	bytes, err := hex.DecodeString(string(input))
@@ -98,7 +98,7 @@ func (b *Bytes48) UnmarshalText(input []byte) error {
 }
 
 func (b *Blob) UnmarshalText(input []byte) error {
-	if string(input)[:2] == "0x" {
+	if string(input[:2]) == "0x" {
 		input = input[2:]
 	}
 	bytes, err := hex.DecodeString(string(input))

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -101,14 +101,14 @@ func (b *Blob) UnmarshalText(input []byte) error {
 	if string(input)[:2] == "0x" {
 		input = input[2:]
 	}
-	blobBytes, err := hex.DecodeString(string(input))
+	bytes, err := hex.DecodeString(string(input))
 	if err != nil {
 		return err
 	}
-	if len(blobBytes) != len(b) {
+	if len(bytes) != len(b) {
 		return ErrBadArgs
 	}
-	copy(b[:], blobBytes)
+	copy(b[:], bytes)
 	return nil
 }
 

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -68,10 +68,10 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (b *Bytes32) UnmarshalText(input []byte) error {
-	if string(input)[:2] != "0x" {
-		return ErrBadArgs
+	if string(input)[:2] == "0x" {
+		input = input[2:]
 	}
-	bytes, err := hex.DecodeString(string(input[2:]))
+	bytes, err := hex.DecodeString(string(input))
 	if err != nil {
 		return err
 	}
@@ -83,10 +83,10 @@ func (b *Bytes32) UnmarshalText(input []byte) error {
 }
 
 func (b *Bytes48) UnmarshalText(input []byte) error {
-	if string(input)[:2] != "0x" {
-		return ErrBadArgs
+	if string(input)[:2] == "0x" {
+		input = input[2:]
 	}
-	bytes, err := hex.DecodeString(string(input[2:]))
+	bytes, err := hex.DecodeString(string(input))
 	if err != nil {
 		return err
 	}
@@ -98,10 +98,10 @@ func (b *Bytes48) UnmarshalText(input []byte) error {
 }
 
 func (b *Blob) UnmarshalText(input []byte) error {
-	if string(input)[:2] != "0x" {
-		return ErrBadArgs
+	if string(input)[:2] == "0x" {
+		input = input[2:]
 	}
-	blobBytes, err := hex.DecodeString(string(input[2:]))
+	blobBytes, err := hex.DecodeString(string(input))
 	if err != nil {
 		return err
 	}

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	// So its functions are available during compilation.
@@ -66,36 +67,45 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (b *Bytes32) UnmarshalText(input []byte) error {
+	if !strings.HasPrefix(string(input), "0x") {
+		return ErrBadArgs
+	}
 	bytes, err := hex.DecodeString(string(input[2:]))
 	if err != nil {
 		return err
 	}
 	if len(bytes) != len(b) {
-		return errors.New("invalid Bytes32")
+		return ErrBadArgs
 	}
 	copy(b[:], bytes)
 	return nil
 }
 
 func (b *Bytes48) UnmarshalText(input []byte) error {
+	if !strings.HasPrefix(string(input), "0x") {
+		return ErrBadArgs
+	}
 	bytes, err := hex.DecodeString(string(input[2:]))
 	if err != nil {
 		return err
 	}
 	if len(bytes) != len(b) {
-		return errors.New("invalid Bytes48")
+		return ErrBadArgs
 	}
 	copy(b[:], bytes)
 	return nil
 }
 
 func (b *Blob) UnmarshalText(input []byte) error {
+	if !strings.HasPrefix(string(input), "0x") {
+		return ErrBadArgs
+	}
 	blobBytes, err := hex.DecodeString(string(input[2:]))
 	if err != nil {
 		return err
 	}
 	if len(blobBytes) != len(b) {
-		return errors.New("invalid Blob")
+		return ErrBadArgs
 	}
 	copy(b[:], blobBytes)
 	return nil

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -7,6 +7,7 @@ package cgokzg4844
 import "C"
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"unsafe"
@@ -46,7 +47,7 @@ var (
 )
 
 ///////////////////////////////////////////////////////////////////////////////
-// Helper functions
+// Helper Functions
 ///////////////////////////////////////////////////////////////////////////////
 
 // makeErrorFromRet translates an (integral) return value, as reported
@@ -61,7 +62,47 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Public functions
+// Unmarshal Functions
+///////////////////////////////////////////////////////////////////////////////
+
+func (b *Bytes32) UnmarshalText(input []byte) error {
+	bytes, err := hex.DecodeString(string(input[2:]))
+	if err != nil {
+		return err
+	}
+	if len(bytes) != len(b) {
+		return errors.New("invalid Bytes32")
+	}
+	copy(b[:], bytes)
+	return nil
+}
+
+func (b *Bytes48) UnmarshalText(input []byte) error {
+	bytes, err := hex.DecodeString(string(input[2:]))
+	if err != nil {
+		return err
+	}
+	if len(bytes) != len(b) {
+		return errors.New("invalid Bytes48")
+	}
+	copy(b[:], bytes)
+	return nil
+}
+
+func (b *Blob) UnmarshalText(input []byte) error {
+	blobBytes, err := hex.DecodeString(string(input[2:]))
+	if err != nil {
+		return err
+	}
+	if len(blobBytes) != len(b) {
+		return errors.New("invalid Blob")
+	}
+	copy(b[:], blobBytes)
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Interface Functions
 ///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -283,25 +324,4 @@ func VerifyBlobKZGProofBatch(blobs []Blob, commitmentsBytes, proofsBytes []Bytes
 		(C.size_t)(len(blobs)),
 		&settings)
 	return bool(result), makeErrorFromRet(ret)
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Private functions
-///////////////////////////////////////////////////////////////////////////////
-
-/*
-sha256 is the binding for:
-
-	void blst_sha256(
-		byte out[32],
-		const byte *msg,
-		size_t msg_len);
-*/
-func sha256(msg []byte) Bytes32 {
-	var out Bytes32
-	C.blst_sha256(
-		(*C.byte)(unsafe.Pointer(&out)),
-		*(**C.byte)(unsafe.Pointer(&msg)),
-		(C.size_t)(len(msg)))
-	return out
 }

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -1,4 +1,4 @@
-package cgokzg4844
+package ckzg4844
 
 // #cgo CFLAGS: -I${SRCDIR}/../../src
 // #cgo CFLAGS: -I${SRCDIR}/blst_headers

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"unsafe"
 
 	// So its functions are available during compilation.
@@ -67,7 +66,7 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (b *Bytes32) UnmarshalText(input []byte) error {
-	if !strings.HasPrefix(string(input), "0x") {
+	if string(input)[:2] != "0x" {
 		return ErrBadArgs
 	}
 	bytes, err := hex.DecodeString(string(input[2:]))
@@ -82,7 +81,7 @@ func (b *Bytes32) UnmarshalText(input []byte) error {
 }
 
 func (b *Bytes48) UnmarshalText(input []byte) error {
-	if !strings.HasPrefix(string(input), "0x") {
+	if string(input)[:2] != "0x" {
 		return ErrBadArgs
 	}
 	bytes, err := hex.DecodeString(string(input[2:]))
@@ -97,7 +96,7 @@ func (b *Bytes48) UnmarshalText(input []byte) error {
 }
 
 func (b *Blob) UnmarshalText(input []byte) error {
-	if !strings.HasPrefix(string(input), "0x") {
+	if string(input)[:2] != "0x" {
 		return ErrBadArgs
 	}
 	blobBytes, err := hex.DecodeString(string(input[2:]))

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -1,4 +1,4 @@
-package cgokzg4844
+package ckzg4844
 
 import (
 	"fmt"


### PR DESCRIPTION
This PR will:

* Change package name from `cgokzg4844` to `ckzg4844`.
  * Maybe it'll be easier to find on pkg.go.dev now. 
* Change README header to "go bindings".
* Make `GetRand*` testing functions private.
* Check for "0x" in `UnmarshalText` before stripping.
  * This will allow `0xabcd` and `abcd` now.
* Move `UnmarshalText` functions to `main.go`.
  * Cannot add methods to non-local types.
  * I think these are good to define publicly.
* Remove private functions (`sha256`).
  * Unnecessary, really. Only used for benchmark.
* Update the example's `go.mod` file.
  * And the example output in the readme, just to be extra clear. 