### PR TITLE
[Go] Allow minimal preset

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -43,7 +43,7 @@ go test -bench=Benchmark
 ## Minimal
 
 By default, `FIELD_ELEMENTS_PER_BLOB` will be 4096 (mainnet), but you can
-manually set it to 4 (minimal).
+manually set it to 4 (minimal), like so:
 ```
 CGO_CFLAGS="-DFIELD_ELEMENTS_PER_BLOB=4" go build
 ```

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -40,6 +40,14 @@ Run the benchmarks with this command:
 go test -bench=Benchmark
 ```
 
+## Minimal
+
+By default, `FIELD_ELEMENTS_PER_BLOB` will be 4096 (mainnet), but you can
+manually set it to 4 (minimal).
+```
+CGO_CFLAGS="-DFIELD_ELEMENTS_PER_BLOB=4" go build
+```
+
 ## Note
 
 The `go.mod` and `go.sum` files are in the project's root directory because the

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -2,7 +2,9 @@ package cgokzg4844
 
 // #cgo CFLAGS: -I${SRCDIR}/../../src
 // #cgo CFLAGS: -I${SRCDIR}/blst_headers
-// #cgo CFLAGS: -DFIELD_ELEMENTS_PER_BLOB=4096
+// #ifndef FIELD_ELEMENTS_PER_BLOB
+// #define FIELD_ELEMENTS_PER_BLOB 4096
+// #endif
 // #include "c_kzg_4844.c"
 import "C"
 


### PR DESCRIPTION
A small thing I've been meaning to do for a while. Only define `FIELD_ELEMENTS_PER_BLOB` if it isn't already defined. This allows users (developers) to specify their own, such as the minimal value: 4.