### PR TITLE
chore: Publish 2.0.4 nodejs

### DIFF
--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.1.2",
+  "version": "2.0.4",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",


### PR DESCRIPTION
Published the bindings with updated Uinit8Array type, reflecting the version in main repo