### PR TITLE
Export methods; test on multiple platforms

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-ckzg:
+    name: Build ckzg
     runs-on: ${{ matrix.target.host }}
     strategy:
       matrix:
@@ -61,9 +62,38 @@ jobs:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
 
-  build-ckzg-dotnet:
-    runs-on: ubuntu-latest
+  test-ckzg-dotnet:
+    name: Test .NET wrapper
+    runs-on: ${{ matrix.target.host }}
     needs: build-ckzg
+    strategy:
+      matrix:
+        target:
+          - host: ubuntu-22.04
+            location: linux-x64
+          - host: macos-latest
+            location: osx-x64
+          - host: windows-latest
+            location: win-x64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+    - name: Install dependencies
+      run: cd bindings/csharp && dotnet restore
+    - uses: actions/download-artifact@v3
+      with:
+        name: ckzg-library-wrapper-${{ matrix.target.location }}
+        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
+    - name: Test
+      run: dotnet test -c release bindings/csharp/Ckzg.sln
+
+  build-ckzg-dotnet:
+    name: Build .NET wrapper
+    runs-on: ubuntu-latest
+    needs: test-ckzg-dotnet
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
@@ -86,13 +116,10 @@ jobs:
       with:
         name: ckzg-library-wrapper-linux-arm64
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
-
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
     - name: Install dependencies
       run: cd bindings/csharp && dotnet restore
-    - name: Test
-      run: cd bindings/csharp && dotnet test -c release --no-restore
     - name: Build
       run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package
@@ -100,6 +127,6 @@ jobs:
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
-    - name: Publish package
+    - name: Publish .NET package
       if: github.ref == 'refs/heads/main'
       run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg -k ${{ secrets.CSHARP_NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json

--- a/bindings/csharp/.gitignore
+++ b/bindings/csharp/.gitignore
@@ -3,6 +3,7 @@
 
 .vs
 .vscode
+*.DotSettings.user
 
 Ckzg.Bindings/runtimes/*/native/*
 !**/.gitkeep

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -1,32 +1,37 @@
 ifeq ($(OS),Windows_NT)
-    BLST_BUILDSCRIPT = ./build.bat
-    BLST_OBJ = blst.lib
-    LOCATION ?= win-x64
-    CLANG_EXECUTABLE = clang
-    CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg.dll
+	ifneq (,$(findstring Git/,$(SHELL)))
+		BLST_BUILDSCRIPT = ./build.bat
+	else
+		BLST_BUILDSCRIPT = .\build.bat
+	endif
+	BLST_OBJ = blst.lib
+	LOCATION ?= win-x64
+	CLANG_EXECUTABLE = clang
+	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg.dll
+	CFLAGS += -DDLLEXPORT=__declspec\(dllexport\)
 else
-    BLST_BUILDSCRIPT = ./build.sh
-    BLST_OBJ = libblst.a
-    CLANG_EXECUTABLE = clang
+	BLST_BUILDSCRIPT = ./build.sh
+	BLST_OBJ = libblst.a
+	CLANG_EXECUTABLE = clang
 
-    UNAME_S := $(shell uname -s)
-    UNAME_M := $(shell uname -m)
-    ifeq ($(UNAME_S),Linux)
-        ifeq ($(UNAME_M),x86_64)
-            LOCATION ?= linux-x64
-        else
-            LOCATION ?= linux-arm64
-        endif
-    endif
-    ifeq ($(UNAME_S),Darwin)
-        ifeq ($(UNAME_M),arm64)
-            LOCATION ?= osx-arm64
-        else
-            LOCATION ?= osx-x64
-        endif
-    endif
+	UNAME_S := $(shell uname -s)
+	UNAME_M := $(shell uname -m)
+	ifeq ($(UNAME_S),Linux)
+		ifeq ($(UNAME_M),x86_64)
+			LOCATION ?= linux-x64
+		else
+			LOCATION ?= linux-arm64
+		endif
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		ifeq ($(UNAME_M),arm64)
+			LOCATION ?= osx-arm64
+		else
+			LOCATION ?= osx-x64
+		endif
+	endif
 
-    CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg.so
+	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg.so
 endif
 
 FIELD_ELEMENTS_PER_BLOB ?= 4096

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Windows_NT)
 	LOCATION ?= win-x64
 	CLANG_EXECUTABLE = clang
 	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg.dll
-	CFLAGS += -DDLLEXPORT=__declspec\(dllexport\)
+	CFLAGS += -Wl,/def:ckzg.def
 else
 	BLST_BUILDSCRIPT = ./build.sh
 	BLST_OBJ = libblst.a

--- a/bindings/csharp/ckzg.c
+++ b/bindings/csharp/ckzg.c
@@ -1,8 +1,8 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "c_kzg_4844.h"
 #include "ckzg.h"
+#include "c_kzg_4844.h"
 
 KZGSettings* load_trusted_setup_wrap(const char* file) {
   KZGSettings* out = malloc(sizeof(KZGSettings));

--- a/bindings/csharp/ckzg.def
+++ b/bindings/csharp/ckzg.def
@@ -1,0 +1,15 @@
+LIBRARY ckzg
+
+EXPORTS
+	load_trusted_setup_wrap
+	free_trusted_setup_wrap
+	load_trusted_setup
+	load_trusted_setup_file
+	free_trusted_setup
+	blob_to_kzg_commitment
+	compute_kzg_proof
+	compute_blob_kzg_proof
+	verify_kzg_proof
+	verify_blob_kzg_proof
+	verify_blob_kzg_proof_batch
+

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -4,6 +4,6 @@
 
 #include "c_kzg_4844.h"
 
-DLLEXPORT KZGSettings* load_trusted_setup_wrap(const char* file);
+KZGSettings* load_trusted_setup_wrap(const char* file);
 
-DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
+void free_trusted_setup_wrap(KZGSettings *s);

--- a/bindings/csharp/ckzg.h
+++ b/bindings/csharp/ckzg.h
@@ -1,26 +1,9 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "c_kzg_4844.h"
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT
-#endif
+#include "c_kzg_4844.h"
 
 DLLEXPORT KZGSettings* load_trusted_setup_wrap(const char* file);
 
 DLLEXPORT void free_trusted_setup_wrap(KZGSettings *s);
-
-DLLEXPORT C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZGSettings *s);
-
-DLLEXPORT C_KZG_RET compute_kzg_proof(KZGProof *proof_out, Bytes32 *y_out, const Blob *blob, const Bytes32 *z_bytes, const KZGSettings *s);
-
-DLLEXPORT C_KZG_RET compute_blob_kzg_proof(KZGProof *out, const Blob *blob, const Bytes48 *commitment, const KZGSettings *s);
-
-DLLEXPORT C_KZG_RET verify_kzg_proof(bool *result, const Bytes48 *commitments_bytes, const Bytes32 *z_bytes, const Bytes32 *y_bytes, const Bytes48 *proof_bytes, const KZGSettings *s);
-
-DLLEXPORT C_KZG_RET verify_blob_kzg_proof(bool *result, const Blob *blob, const Bytes48 *commitment_bytes, const Bytes48 *proof_bytes, const KZGSettings *s);
-
-DLLEXPORT C_KZG_RET verify_blob_kzg_proof_batch(bool *result, const Blob *blobs, const Bytes48 *commitments_bytes, const Bytes48 *proofs_bytes, size_t count, const KZGSettings *s);

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -32,14 +32,6 @@
 extern "C" {
 #endif
 
-/**
- * Used to modify the signatures of the interface functions by the wrappers.
- * Required to export the functions when it is compiled as a dll on Windows.
- */
-#ifndef DLLEXPORT
-#define DLLEXPORT
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
@@ -181,7 +173,7 @@ typedef struct {
 // Interface functions
 ///////////////////////////////////////////////////////////////////////////////
 
-DLLEXPORT C_KZG_RET load_trusted_setup(
+C_KZG_RET load_trusted_setup(
     KZGSettings *out,
     const uint8_t *g1_bytes, /* n1 * 48 bytes */
     size_t n1,
@@ -189,15 +181,15 @@ DLLEXPORT C_KZG_RET load_trusted_setup(
     size_t n2
 );
 
-DLLEXPORT C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
 
-DLLEXPORT void free_trusted_setup(KZGSettings *s);
+void free_trusted_setup(KZGSettings *s);
 
-DLLEXPORT C_KZG_RET blob_to_kzg_commitment(
+C_KZG_RET blob_to_kzg_commitment(
     KZGCommitment *out, const Blob *blob, const KZGSettings *s
 );
 
-DLLEXPORT C_KZG_RET compute_kzg_proof(
+C_KZG_RET compute_kzg_proof(
     KZGProof *proof_out,
     Bytes32 *y_out,
     const Blob *blob,
@@ -205,14 +197,14 @@ DLLEXPORT C_KZG_RET compute_kzg_proof(
     const KZGSettings *s
 );
 
-DLLEXPORT C_KZG_RET compute_blob_kzg_proof(
+C_KZG_RET compute_blob_kzg_proof(
     KZGProof *out,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
     const KZGSettings *s
 );
 
-DLLEXPORT C_KZG_RET verify_kzg_proof(
+C_KZG_RET verify_kzg_proof(
     bool *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
@@ -221,7 +213,7 @@ DLLEXPORT C_KZG_RET verify_kzg_proof(
     const KZGSettings *s
 );
 
-DLLEXPORT C_KZG_RET verify_blob_kzg_proof(
+C_KZG_RET verify_blob_kzg_proof(
     bool *ok,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
@@ -229,7 +221,7 @@ DLLEXPORT C_KZG_RET verify_blob_kzg_proof(
     const KZGSettings *s
 );
 
-DLLEXPORT C_KZG_RET verify_blob_kzg_proof_batch(
+C_KZG_RET verify_blob_kzg_proof_batch(
     bool *ok,
     const Blob *blobs,
     const Bytes48 *commitments_bytes,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -32,6 +32,10 @@
 extern "C" {
 #endif
 
+/**
+ * Used to modify the signatures of the interface functions by the wrappers.
+ * Required to export the functions when it is compiled as a dll on Windows.
+ */
 #ifndef DLLEXPORT
 #define DLLEXPORT
 #endif

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -32,6 +32,10 @@
 extern "C" {
 #endif
 
+#ifndef DLLEXPORT
+#define DLLEXPORT
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
@@ -173,7 +177,7 @@ typedef struct {
 // Interface functions
 ///////////////////////////////////////////////////////////////////////////////
 
-C_KZG_RET load_trusted_setup(
+DLLEXPORT C_KZG_RET load_trusted_setup(
     KZGSettings *out,
     const uint8_t *g1_bytes, /* n1 * 48 bytes */
     size_t n1,
@@ -181,15 +185,15 @@ C_KZG_RET load_trusted_setup(
     size_t n2
 );
 
-C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
+DLLEXPORT C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
 
-void free_trusted_setup(KZGSettings *s);
+DLLEXPORT void free_trusted_setup(KZGSettings *s);
 
-C_KZG_RET blob_to_kzg_commitment(
+DLLEXPORT C_KZG_RET blob_to_kzg_commitment(
     KZGCommitment *out, const Blob *blob, const KZGSettings *s
 );
 
-C_KZG_RET compute_kzg_proof(
+DLLEXPORT C_KZG_RET compute_kzg_proof(
     KZGProof *proof_out,
     Bytes32 *y_out,
     const Blob *blob,
@@ -197,14 +201,14 @@ C_KZG_RET compute_kzg_proof(
     const KZGSettings *s
 );
 
-C_KZG_RET compute_blob_kzg_proof(
+DLLEXPORT C_KZG_RET compute_blob_kzg_proof(
     KZGProof *out,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
     const KZGSettings *s
 );
 
-C_KZG_RET verify_kzg_proof(
+DLLEXPORT C_KZG_RET verify_kzg_proof(
     bool *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
@@ -213,7 +217,7 @@ C_KZG_RET verify_kzg_proof(
     const KZGSettings *s
 );
 
-C_KZG_RET verify_blob_kzg_proof(
+DLLEXPORT C_KZG_RET verify_blob_kzg_proof(
     bool *ok,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
@@ -221,7 +225,7 @@ C_KZG_RET verify_blob_kzg_proof(
     const KZGSettings *s
 );
 
-C_KZG_RET verify_blob_kzg_proof_batch(
+DLLEXPORT C_KZG_RET verify_blob_kzg_proof_batch(
     bool *ok,
     const Blob *blobs,
     const Bytes48 *commitments_bytes,


### PR DESCRIPTION
Windows build does not contain proper exports:

```batch
dumpbin /EXPORTS "ckzg.dll"
...
1    0 00001080 free_trusted_setup_wrap
2    1 00001000 load_trusted_setup_wrap
...
```

happens most likely because [wrapper header file](https://github.com/ethereum/c-kzg-4844/blob/main/src/c_kzg_4844.h#L188) cannot change methods' signatures already defined in [c_kzg_4844.h](https://github.com/ethereum/c-kzg-4844/blob/main/src/c_kzg_4844.h#L188)

# Changes
- Fix exports on Windows
- Run unit tests on different platforms
- Support mingw, powershell and cmd on Windows

# Remarks

DLLEXPORT is empty for any case but windows C# wrapper build