### PR TITLE
Support for Windows cross-compilation from Linux

### DIFF
--- a/bindings/nim/kzg_abi.nim
+++ b/bindings/nim/kzg_abi.nim
@@ -5,14 +5,14 @@
 import
   std/[strformat, strutils]
 
-from os import DirSep
+from os import DirSep, AltSep
 
 const
   # FIELD_ELEMENTS_PER_BLOB is overrideable from
   # compiler switch -d: or --define:
   FIELD_ELEMENTS_PER_BLOB* {.intdefine.} = 4096
   # kzgPath: c-kzg-4844 project path, removing 3 last elem
-  kzgPath  = currentSourcePath.rsplit(DirSep, 3)[0] & "/"
+  kzgPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/"
   blstPath = kzgPath & "blst/"
   srcPath  = kzgPath & "src/"
   bindingsPath = blstPath & "bindings"
@@ -65,14 +65,14 @@ type
   # An array of 48 bytes. Represents an untrusted
   # (potentially invalid) commitment/proof.
   KzgBytes48* = array[48, byte]
-  
+
   # An array of 32 bytes. Represents an untrusted
   # (potentially invalid) field element.
   KzgBytes32* = array[32, byte]
 
   # A trusted (valid) KZG commitment.
   KzgCommitment* = KzgBytes48
-  
+
   # A trusted (valid) KZG proof.
   KzgProof* = KzgBytes48
 


### PR DESCRIPTION
Since `DirSep` matches the default separator of the target OS, it's not suitable for performing path operations during compile-time on the host OS.

The particular fix here solves the issue for cross-compiling a Windows build from a Linux host, but Nim seems to need a more general solution for detecting the host OS during compilation, so a host OS specific separator can be used when deriving paths from `currentSourcePath`.