### PR TITLE
Add new validate_kzg_g1 tests

### DIFF
--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -718,7 +718,7 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
-static void test_validate_kzg_g1__fails_with_mask_111(void) {
+static void test_validate_kzg_g1__fails_with_mask_bits_111(void) {
     C_KZG_RET ret;
     Bytes48 g1_bytes;
     g1_t g1;
@@ -732,7 +732,7 @@ static void test_validate_kzg_g1__fails_with_mask_111(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
-static void test_validate_kzg_g1__fails_with_mask_011(void) {
+static void test_validate_kzg_g1__fails_with_mask_bits_011(void) {
     C_KZG_RET ret;
     Bytes48 g1_bytes;
     g1_t g1;
@@ -746,7 +746,7 @@ static void test_validate_kzg_g1__fails_with_mask_011(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
-static void test_validate_kzg_g1__fails_with_mask_001(void) {
+static void test_validate_kzg_g1__fails_with_mask_bits_001(void) {
     C_KZG_RET ret;
     Bytes48 g1_bytes;
     g1_t g1;
@@ -1927,9 +1927,9 @@ int main(void) {
     RUN(test_validate_kzg_g1__fails_with_wrong_c_flag);
     RUN(test_validate_kzg_g1__fails_with_b_flag_and_x_nonzero);
     RUN(test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true);
-    RUN(test_validate_kzg_g1__fails_with_mask_111);
-    RUN(test_validate_kzg_g1__fails_with_mask_011);
-    RUN(test_validate_kzg_g1__fails_with_mask_001);
+    RUN(test_validate_kzg_g1__fails_with_mask_bits_111);
+    RUN(test_validate_kzg_g1__fails_with_mask_bits_011);
+    RUN(test_validate_kzg_g1__fails_with_mask_bits_001);
     RUN(test_reverse_bits__succeeds_round_trip);
     RUN(test_reverse_bits__succeeds_all_bits_are_zero);
     RUN(test_reverse_bits__succeeds_some_bits_are_one);

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -718,6 +718,48 @@ static void test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
+static void test_validate_kzg_g1__fails_with_mask_111(void) {
+    C_KZG_RET ret;
+    Bytes48 g1_bytes;
+    g1_t g1;
+
+    bytes48_from_hex(
+        &g1_bytes,
+        "e491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e264"
+        "4f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
+    );
+    ret = validate_kzg_g1(&g1, &g1_bytes);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+}
+
+static void test_validate_kzg_g1__fails_with_mask_011(void) {
+    C_KZG_RET ret;
+    Bytes48 g1_bytes;
+    g1_t g1;
+
+    bytes48_from_hex(
+        &g1_bytes,
+        "6491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e264"
+        "4f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
+    );
+    ret = validate_kzg_g1(&g1, &g1_bytes);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+}
+
+static void test_validate_kzg_g1__fails_with_mask_001(void) {
+    C_KZG_RET ret;
+    Bytes48 g1_bytes;
+    g1_t g1;
+
+    bytes48_from_hex(
+        &g1_bytes,
+        "2491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e264"
+        "4f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
+    );
+    ret = validate_kzg_g1(&g1, &g1_bytes);
+    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Tests for reverse_bits
 ///////////////////////////////////////////////////////////////////////////////
@@ -1885,6 +1927,9 @@ int main(void) {
     RUN(test_validate_kzg_g1__fails_with_wrong_c_flag);
     RUN(test_validate_kzg_g1__fails_with_b_flag_and_x_nonzero);
     RUN(test_validate_kzg_g1__fails_with_b_flag_and_a_flag_true);
+    RUN(test_validate_kzg_g1__fails_with_mask_111);
+    RUN(test_validate_kzg_g1__fails_with_mask_011);
+    RUN(test_validate_kzg_g1__fails_with_mask_001);
     RUN(test_reverse_bits__succeeds_round_trip);
     RUN(test_reverse_bits__succeeds_all_bits_are_zero);
     RUN(test_reverse_bits__succeeds_some_bits_are_one);


### PR DESCRIPTION
Adds the new deserializing G1 tests from bls12-381-tests, which these tests mirror:
* https://github.com/ethereum/bls12-381-tests/blob/6c5229a9571703ed4b47e08f8611b6a1ab389e15/main.py#L790-L818