### PR TITLE
Check the retval of blst_p2_uncompress

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1786,7 +1786,13 @@ C_KZG_RET load_trusted_setup(
 
     /* Convert all g2 bytes to g2 points */
     for (i = 0; i < n2; i++) {
-        blst_p2_uncompress(&g2_affine, &g2_bytes[BYTES_PER_G2 * i]);
+        BLST_ERROR err = blst_p2_uncompress(
+            &g2_affine, &g2_bytes[BYTES_PER_G2 * i]
+        );
+        if (err != BLST_SUCCESS) {
+            ret = C_KZG_BADARGS;
+            goto out_error;
+        }
         blst_p2_from_affine(&out->g2_values[i], &g2_affine);
     }
 


### PR DESCRIPTION
Noticed that we weren't checking the return value of this call. It's in the trusted setup, so it should be been fine, but I think it's a good idea to check this regardless. Also, I cross-checked all of the other blst functions & can confirm we are checking the return values for everything else.