### PR TITLE
Make C & C# tests use portable blst

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -12,6 +12,9 @@ defaults:
     shell: bash
     working-directory: src
 
+env:
+  CFLAGS: -D__BLST_PORTABLE__
+
 jobs:
   tests:
     runs-on: ${{matrix.os}}
@@ -37,10 +40,9 @@ jobs:
 
       # Build and test with minimal preset.
       - name: Build (minimal)
-        run: |
-          export FIELD_ELEMENTS_PER_BLOB=4
-          make clean && make test_c_kzg_4844
-          unset FIELD_ELEMENTS_PER_BLOB
+        env:
+          FIELD_ELEMENTS_PER_BLOB: 4
+        run: make clean && make test_c_kzg_4844
       - name: Save test binary (minimal)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3
@@ -52,10 +54,9 @@ jobs:
 
       # Build and test with mainnet preset.
       - name: Build (mainnet)
-        run: |
-          export FIELD_ELEMENTS_PER_BLOB=4096
-          make clean && make test_c_kzg_4844
-          unset FIELD_ELEMENTS_PER_BLOB
+        env:
+          FIELD_ELEMENTS_PER_BLOB: 4096
+        run: make clean && make test_c_kzg_4844
       - name: Save test binary (mainnet)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -12,6 +12,7 @@ on:
       - main
 env:
   binding_build_number_based_version: 0.1.2.${{ github.run_number }}
+  CFLAGS: -D__BLST_PORTABLE__
 
 jobs:
   build-ckzg:

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -13,6 +13,7 @@ else
 	BLST_BUILDSCRIPT = ./build.sh
 	BLST_OBJ = libblst.a
 	CLANG_EXECUTABLE = clang
+	CFLAGS += -fPIC
 
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,7 +7,7 @@ const MINIMAL_FIELD_ELEMENTS_PER_BLOB: usize = 4;
 /// Compiles blst.
 //
 // NOTE: This code is taken from https://github.com/supranational/blst `build.rs` `main`. The crate
-// is not used as a depedency to avoid double link issues on dependants.
+// is not used as a dependency to avoid double link issues on dependants.
 fn compile_blst(blst_base_dir: PathBuf) {
     // account for cross-compilation [by examining environment variables]
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();


### PR DESCRIPTION
There are frequent test failures for these two languages. I think using the portable version of blst will fix this.