### PR TITLE
[Go] Make UnmarshalText funcs safer

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -29,7 +29,7 @@ jobs:
             location: linux-arm64
             host: ubuntu-22.04
             ext: .so
-            reqs: sudo apt install -y clang binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
+            reqs: sudo apt update && sudo apt install -y clang binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
           - arch: arm64-darwin
             location: osx-arm64
             host: macos-latest

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	// So its functions are available during compilation.
@@ -68,10 +69,11 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (b *Bytes32) UnmarshalText(input []byte) error {
-	if string(input[:2]) == "0x" {
-		input = input[2:]
+	inputStr := string(input)
+	if strings.HasPrefix(inputStr, "0x") {
+		inputStr = strings.TrimPrefix(inputStr, "0x")
 	}
-	bytes, err := hex.DecodeString(string(input))
+	bytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		return err
 	}
@@ -83,10 +85,11 @@ func (b *Bytes32) UnmarshalText(input []byte) error {
 }
 
 func (b *Bytes48) UnmarshalText(input []byte) error {
-	if string(input[:2]) == "0x" {
-		input = input[2:]
+	inputStr := string(input)
+	if strings.HasPrefix(inputStr, "0x") {
+		inputStr = strings.TrimPrefix(inputStr, "0x")
 	}
-	bytes, err := hex.DecodeString(string(input))
+	bytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		return err
 	}
@@ -98,10 +101,11 @@ func (b *Bytes48) UnmarshalText(input []byte) error {
 }
 
 func (b *Blob) UnmarshalText(input []byte) error {
-	if string(input[:2]) == "0x" {
-		input = input[2:]
+	inputStr := string(input)
+	if strings.HasPrefix(inputStr, "0x") {
+		inputStr = strings.TrimPrefix(inputStr, "0x")
 	}
-	bytes, err := hex.DecodeString(string(input))
+	bytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		return err
 	}
@@ -215,11 +219,11 @@ func BlobToKZGCommitment(blob Blob) (KZGCommitment, error) {
 ComputeKZGProof is the binding for:
 
 	C_KZG_RET compute_kzg_proof(
-			KZGProof *proof_out,
-			Bytes32 *y_out,
-			const Blob *blob,
-			const Bytes32 *z_bytes,
-			const KZGSettings *s);
+	    KZGProof *proof_out,
+	    Bytes32 *y_out,
+	    const Blob *blob,
+	    const Bytes32 *z_bytes,
+	    const KZGSettings *s);
 */
 func ComputeKZGProof(blob Blob, zBytes Bytes32) (KZGProof, Bytes32, error) {
 	if !loaded {
@@ -240,10 +244,10 @@ func ComputeKZGProof(blob Blob, zBytes Bytes32) (KZGProof, Bytes32, error) {
 ComputeBlobKZGProof is the binding for:
 
 	C_KZG_RET compute_blob_kzg_proof(
-			KZGProof *out,
-			const Blob *blob,
-			const Bytes48 *commitment_bytes,
-			const KZGSettings *s);
+	    KZGProof *out,
+	    const Blob *blob,
+	    const Bytes48 *commitment_bytes,
+	    const KZGSettings *s);
 */
 func ComputeBlobKZGProof(blob Blob, commitmentBytes Bytes48) (KZGProof, error) {
 	if !loaded {


### PR DESCRIPTION
Before this PR, these functions would panic if given a string fewer than 2 bytes. This PR addresses that issue & makes it a little easier to read. Also, fix some indentation nits for consistency.