### PR TITLE
Sanity check that trusted setup was loaded in Lagrange form

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1673,7 +1673,7 @@ static C_KZG_RET is_trusted_setup_in_lagrange_form(
 
     /*
      * If the following pairing equation checks out:
-     *     e(G1_SETUP[1], G2_SETUP[0]) ?= e(G1_SETUP[0], G2_setup[1])
+     *     e(G1_SETUP[1], G2_SETUP[0]) ?= e(G1_SETUP[0], G2_SETUP[1])
      * then the trusted setup was loaded in monomial form.
      * If so, error out since we want the trusted setup in Lagrange form.
      */

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1659,23 +1659,24 @@ void free_trusted_setup(KZGSettings *s) {
 /**
  * Basic sanity check that the trusted setup was loaded in Lagrange form.
  *
- * @param[in] trusted_setup  Pointer to the stored trusted setup data
- * @param[in]  n1       Number of `g1` points in trusted_setup
- * @param[in]  n2       Number of `g2` points in trusted_setup
- *
+ * @param[in] s  Pointer to the stored trusted setup data
+ * @param[in] n1 Number of `g1` points in trusted_setup
+ * @param[in] n2 Number of `g2` points in trusted_setup
  */
-C_KZG_RET is_trusted_setup_in_lagrange_form(
+static C_KZG_RET is_trusted_setup_in_lagrange_form(
     const KZGSettings *s, size_t n1, size_t n2
 ) {
-    /* Trusted setup is too small; we can't work with this. */
+    /* Trusted setup is too small; we can't work with this */
     if (n1 < 2 || n2 < 2) {
         return C_KZG_BADARGS;
     }
 
-    /* If the following pairing equation checks out:
-     *           e(G1_SETUP[1], G2_SETUP[0]) ?= e(G1_SETUP[0], G2_setup[1])
+    /*
+     * If the following pairing equation checks out:
+     *     e(G1_SETUP[1], G2_SETUP[0]) ?= e(G1_SETUP[0], G2_setup[1])
      * then the trusted setup was loaded in monomial form.
-     * If so, error out since we want the trusted setup in Lagrange form. */
+     * If so, error out since we want the trusted setup in Lagrange form.
+     */
     bool is_monomial_form = pairings_verify(
         &s->g1_values[1], &s->g2_values[0], &s->g1_values[0], &s->g2_values[1]
     );

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1753,14 +1753,14 @@ C_KZG_RET load_trusted_setup(
         blst_p2_from_affine(&out->g2_values[i], &g2_affine);
     }
 
+    /* Make sure the trusted setup was loaded in Lagrange form */
+    ret = is_trusted_setup_in_lagrange_form(out, n1, n2);
+    if (ret != C_KZG_OK) goto out_error;
+
     /* Compute roots of unity and permute the G1 trusted setup */
     ret = compute_roots_of_unity(out->roots_of_unity, max_scale);
     if (ret != C_KZG_OK) goto out_error;
     ret = bit_reversal_permutation(out->g1_values, sizeof(g1_t), n1);
-    if (ret != C_KZG_OK) goto out_error;
-
-    /* Make sure the trusted setup was loaded in Lagrange form */
-    ret = is_trusted_setup_in_lagrange_form(out, n1, n2);
     if (ret != C_KZG_OK) goto out_error;
 
     goto out_success;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1657,6 +1657,32 @@ void free_trusted_setup(KZGSettings *s) {
 }
 
 /**
+ * Basic sanity check that the trusted setup was loaded in Lagrange form.
+ *
+ * @param[in] trusted_setup  Pointer to the stored trusted setup data
+ * @param[in]  n1       Number of `g1` points in trusted_setup
+ * @param[in]  n2       Number of `g2` points in trusted_setup
+ *
+ */
+C_KZG_RET is_trusted_setup_in_lagrange_form(
+    const KZGSettings *s, size_t n1, size_t n2
+) {
+    /* Trusted setup is too small; we can't work with this. */
+    if (n1 < 2 || n2 < 2) {
+        return C_KZG_BADARGS;
+    }
+
+    /* If the following pairing equation checks out:
+     *           e(G1_SETUP[1], G2_SETUP[0]) ?= e(G1_SETUP[0], G2_setup[1])
+     * then the trusted setup was loaded in monomial form.
+     * If so, error out since we want the trusted setup in Lagrange form. */
+    bool is_monomial_form = pairings_verify(
+        &s->g1_values[1], &s->g2_values[0], &s->g1_values[0], &s->g2_values[1]
+    );
+    return is_monomial_form ? C_KZG_BADARGS : C_KZG_OK;
+}
+
+/**
  * Load trusted setup into a KZGSettings.
  *
  * @remark Free after use with free_trusted_setup().
@@ -1731,6 +1757,10 @@ C_KZG_RET load_trusted_setup(
     ret = compute_roots_of_unity(out->roots_of_unity, max_scale);
     if (ret != C_KZG_OK) goto out_error;
     ret = bit_reversal_permutation(out->g1_values, sizeof(g1_t), n1);
+    if (ret != C_KZG_OK) goto out_error;
+
+    /* Make sure the trusted setup was loaded in Lagrange form */
+    ret = is_trusted_setup_in_lagrange_form(out, n1, n2);
     if (ret != C_KZG_OK) goto out_error;
 
     goto out_success;


### PR DESCRIPTION
We received reports from client devs that they loaded old trusted setup files (with G1 in monomial form) and KZG did not work but without any errors from c-kzg. This PR adds a basic sanity check that the trusted setup was loaded with G1 in lagrange form.