### PR TITLE
chore: Publish to npm version 2.1.0 for big endian release

### DIFF
--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",


### PR DESCRIPTION
Published manually to npm 2.1.0 version for big endian