### PR TITLE
test(node-bindings): add argument count unit tests

### DIFF
--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -102,6 +102,9 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   it("should ignore extra arguments", () => {
     expect(() => fn(...moreArgs)).not.toThrowError();
   });
+  it("should give same result with extra args", () => {
+    expect(fn(...validArgs)).toEqual(fn(...moreArgs));
+  });
   it("should throw for less than expected argument count", () => {
     expect(() => fn(...lessArgs)).toThrowError();
   });

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -81,6 +81,16 @@ function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
   return true;
 }
 
+function getValidTest(testDir: string): any {
+  const tests = globSync(testDir);
+  const validTest = tests.find(
+    (testFile: string) =>
+      !testFile.includes("invalid") && !testFile.includes("incorrect") && !testFile.includes("different")
+  );
+  if (!validTest) throw new Error("Could not find valid test");
+  return yaml.load(readFileSync(validTest, "ascii"));
+}
+
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   const lessArgs = validArgs.length === 1 ? [] : validArgs.slice(0, -1);
   expect(lessArgs.length).toBeLessThan(validArgs.length);
@@ -89,7 +99,7 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   it("should run for expected argument count", () => {
     expect(() => fn(...validArgs)).not.toThrowError();
   });
-  it("should ignore extras arguments", () => {
+  it("should ignore extra arguments", () => {
     expect(() => fn(...moreArgs)).not.toThrowError();
   });
   it("should throw for less than expected argument count", () => {
@@ -251,10 +261,7 @@ describe("C-KZG", () => {
 
   describe("edge cases for blobToKzgCommitment", () => {
     describe("check argument count", () => {
-      const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
-      const validTest = tests.find((testFile: string) => !testFile.includes("invalid"));
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: BlobToKzgCommitmentTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: BlobToKzgCommitmentTest = getValidTest(BLOB_TO_KZG_COMMITMENT_TESTS);
       const blob = bytesFromHex(test.input.blob);
       testArgCount(blobToKzgCommitment, [blob]);
     });
@@ -271,10 +278,7 @@ describe("C-KZG", () => {
   // TODO: add more tests for this function.
   describe("edge cases for computeKzgProof", () => {
     describe("check argument count", () => {
-      const tests = globSync(COMPUTE_KZG_PROOF_TESTS);
-      const validTest = tests.find((testFile: string) => !testFile.includes("invalid"));
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: ComputeKzgProofTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: ComputeKzgProofTest = getValidTest(COMPUTE_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const z = bytesFromHex(test.input.z);
       testArgCount(computeKzgProof, [blob, z]);
@@ -297,10 +301,7 @@ describe("C-KZG", () => {
   // TODO: add more tests for this function.
   describe("edge cases for computeBlobKzgProof", () => {
     describe("check argument count", () => {
-      const tests = globSync(COMPUTE_BLOB_KZG_PROOF_TESTS);
-      const validTest = tests.find((testFile: string) => !testFile.includes("invalid"));
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: ComputeBlobKzgProofTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: ComputeBlobKzgProofTest = getValidTest(COMPUTE_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const commitment = bytesFromHex(test.input.commitment);
       testArgCount(computeBlobKzgProof, [blob, commitment]);
@@ -319,10 +320,7 @@ describe("C-KZG", () => {
 
   describe("edge cases for verifyKzgProof", () => {
     describe("check argument count", () => {
-      const tests = globSync(VERIFY_KZG_PROOF_TESTS);
-      const validTest = tests.find((testFile: string) => testFile.includes("correct_proof"));
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: VerifyKzgProofTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: VerifyKzgProofTest = getValidTest(VERIFY_KZG_PROOF_TESTS);
       const commitment = bytesFromHex(test.input.commitment);
       const z = bytesFromHex(test.input.z);
       const y = bytesFromHex(test.input.y);
@@ -365,10 +363,7 @@ describe("C-KZG", () => {
 
   describe("edge cases for verifyBlobKzgProof", () => {
     describe("check argument count", () => {
-      const tests = globSync(VERIFY_BLOB_KZG_PROOF_TESTS);
-      const validTest = tests.find((testFile: string) => testFile.includes("correct_proof"));
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: VerifyBlobKzgProofTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: VerifyBlobKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const commitment = bytesFromHex(test.input.commitment);
       const proof = bytesFromHex(test.input.proof);
@@ -409,12 +404,7 @@ describe("C-KZG", () => {
 
   describe("edge cases for verifyBlobKzgProofBatch", () => {
     describe("check argument count", () => {
-      const tests = globSync(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
-      const validTest = tests.find(
-        (testFile: string) => !testFile.includes("invalid") && !testFile.includes("different")
-      );
-      if (!validTest) throw new Error("Could not find valid test");
-      const test: VerifyBatchKzgProofTest = yaml.load(readFileSync(validTest, "ascii"));
+      const test: VerifyBatchKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       const blobs = test.input.blobs.map(bytesFromHex);
       const commitments = test.input.commitments.map(bytesFromHex);
       const proofs = test.input.proofs.map(bytesFromHex);

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -93,10 +93,13 @@ function getValidTest(testDir: string): any {
 
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   const lessArgs = validArgs.length === 1 ? [] : validArgs.slice(0, -1);
-  expect(lessArgs.length).toBeLessThan(validArgs.length);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");
-  expect(moreArgs.length).toBeGreaterThan(validArgs.length);
   
+  it("should test for different argument lengths", () => {
+    expect(lessArgs.length).toBeLessThan(validArgs.length);
+    expect(moreArgs.length).toBeGreaterThan(validArgs.length);
+  });
+
   it("should run for expected argument count", () => {
     expect(() => fn(...validArgs)).not.toThrowError();
   });

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -81,6 +81,17 @@ function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
   return true;
 }
 
+/**
+ * Finds a valid test under a glob path to test files. Filters out tests with
+ * "invalid", "incorrect", or "different" in the file name.
+ *
+ * @param {string} testDir Glob path to test files
+ *
+ * @return {any} Test object with valid input and output. Must strongly type
+ *               results at calling location
+ *
+ * @throws {Error} If no valid test is found
+ */
 function getValidTest(testDir: string): any {
   const tests = globSync(testDir);
   const validTest = tests.find(
@@ -91,6 +102,21 @@ function getValidTest(testDir: string): any {
   return yaml.load(readFileSync(validTest, "ascii"));
 }
 
+/**
+ * Runs a suite of tests for the passed function and arguments. Will test base
+ * case to ensure a valid set of arguments was passed with the function being
+ * tested.  Will then test the same function with an extra, invalid, argument
+ * at the end of the argument list to verify extra args are ignored. Checks
+ * validity of the extra argument case against the base case. Finally, will
+ * check that if an argument is removed that an error is thrown.
+ *
+ * @param {(...args: any[]) => any} fn Function to be tested
+ * @param {any[]} validArgs Valid arguments to be passed as base case to fn
+ *
+ * @return {void}
+ *
+ * @throws {Error} If no valid test is found
+ */
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   const lessArgs = validArgs.slice(0, -1);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -94,7 +94,7 @@ function getValidTest(testDir: string): any {
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   const lessArgs = validArgs.slice(0, -1);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");
-  
+
   it("should test for different argument lengths", () => {
     expect(lessArgs.length).toBeLessThan(validArgs.length);
     expect(moreArgs.length).toBeGreaterThan(validArgs.length);
@@ -107,24 +107,22 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   it("should ignore extra arguments", () => {
     expect(() => fn(...moreArgs)).not.toThrowError();
   });
-  
+
   it("should give same result with extra args", () => {
     expect(fn(...validArgs)).toEqual(fn(...moreArgs));
   });
-  
+
   it("should throw for less than expected argument count", () => {
     expect(() => fn(...lessArgs)).toThrowError();
   });
 }
 
 describe("C-KZG", () => {
-
   beforeAll(async () => {
     loadTrustedSetup(SETUP_FILE_PATH);
   });
 
   describe("reference tests should pass", () => {
-
     it("reference tests for blobToKzgCommitment should pass", () => {
       const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
       expect(tests.length).toBeGreaterThan(0);
@@ -272,7 +270,6 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for blobToKzgCommitment", () => {
-
     describe("check argument count", () => {
       const test: BlobToKzgCommitmentTest = getValidTest(BLOB_TO_KZG_COMMITMENT_TESTS);
       const blob = bytesFromHex(test.input.blob);
@@ -292,7 +289,6 @@ describe("C-KZG", () => {
 
   // TODO: add more tests for this function.
   describe("edge cases for computeKzgProof", () => {
-    
     describe("check argument count", () => {
       const test: ComputeKzgProofTest = getValidTest(COMPUTE_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
@@ -318,7 +314,6 @@ describe("C-KZG", () => {
 
   // TODO: add more tests for this function.
   describe("edge cases for computeBlobKzgProof", () => {
-
     describe("check argument count", () => {
       const test: ComputeBlobKzgProofTest = getValidTest(COMPUTE_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
@@ -331,7 +326,7 @@ describe("C-KZG", () => {
       const commitment = blobToKzgCommitment(blob);
       computeBlobKzgProof(blob, commitment);
     });
-    
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() => computeBlobKzgProof(blobBadLength, blobToKzgCommitment(generateRandomBlob()))).toThrowError(
         "Expected blob to be 131072 bytes"
@@ -340,7 +335,6 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyKzgProof", () => {
-
     describe("check argument count", () => {
       const test: VerifyKzgProofTest = getValidTest(VERIFY_KZG_PROOF_TESTS);
       const commitment = bytesFromHex(test.input.commitment);
@@ -387,7 +381,6 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyBlobKzgProof", () => {
-
     describe("check argument count", () => {
       const test: VerifyBlobKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
@@ -433,7 +426,6 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyBlobKzgProofBatch", () => {
-
     describe("check argument count", () => {
       const test: VerifyBatchKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       const blobs = test.input.blobs.map(bytesFromHex);

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -96,26 +96,32 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   expect(lessArgs.length).toBeLessThan(validArgs.length);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");
   expect(moreArgs.length).toBeGreaterThan(validArgs.length);
+  
   it("should run for expected argument count", () => {
     expect(() => fn(...validArgs)).not.toThrowError();
   });
+
   it("should ignore extra arguments", () => {
     expect(() => fn(...moreArgs)).not.toThrowError();
   });
+  
   it("should give same result with extra args", () => {
     expect(fn(...validArgs)).toEqual(fn(...moreArgs));
   });
+  
   it("should throw for less than expected argument count", () => {
     expect(() => fn(...lessArgs)).toThrowError();
   });
 }
 
 describe("C-KZG", () => {
+
   beforeAll(async () => {
     loadTrustedSetup(SETUP_FILE_PATH);
   });
 
   describe("reference tests should pass", () => {
+
     it("reference tests for blobToKzgCommitment should pass", () => {
       const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
       expect(tests.length).toBeGreaterThan(0);
@@ -263,16 +269,19 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for blobToKzgCommitment", () => {
+
     describe("check argument count", () => {
       const test: BlobToKzgCommitmentTest = getValidTest(BLOB_TO_KZG_COMMITMENT_TESTS);
       const blob = bytesFromHex(test.input.blob);
       testArgCount(blobToKzgCommitment, [blob]);
     });
+
     it("throws as expected when given an argument of invalid type", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       expect(() => blobToKzgCommitment("wrong type")).toThrowError("Expected blob to be a Uint8Array");
     });
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() => blobToKzgCommitment(blobBadLength)).toThrowError("Expected blob to be 131072 bytes");
     });
@@ -280,17 +289,20 @@ describe("C-KZG", () => {
 
   // TODO: add more tests for this function.
   describe("edge cases for computeKzgProof", () => {
+    
     describe("check argument count", () => {
       const test: ComputeKzgProofTest = getValidTest(COMPUTE_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const z = bytesFromHex(test.input.z);
       testArgCount(computeKzgProof, [blob, z]);
     });
+
     it("computes a proof from blob/field element", () => {
       const blob = generateRandomBlob();
       const zBytes = new Uint8Array(BYTES_PER_FIELD_ELEMENT).fill(0);
       computeKzgProof(blob, zBytes);
     });
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() => computeKzgProof(blobBadLength, fieldElementValidLength)).toThrowError(
         "Expected blob to be 131072 bytes"
@@ -303,17 +315,20 @@ describe("C-KZG", () => {
 
   // TODO: add more tests for this function.
   describe("edge cases for computeBlobKzgProof", () => {
+
     describe("check argument count", () => {
       const test: ComputeBlobKzgProofTest = getValidTest(COMPUTE_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const commitment = bytesFromHex(test.input.commitment);
       testArgCount(computeBlobKzgProof, [blob, commitment]);
     });
+
     it("computes a proof from blob", () => {
       const blob = generateRandomBlob();
       const commitment = blobToKzgCommitment(blob);
       computeBlobKzgProof(blob, commitment);
     });
+    
     it("throws as expected when given an argument of invalid length", () => {
       expect(() => computeBlobKzgProof(blobBadLength, blobToKzgCommitment(generateRandomBlob()))).toThrowError(
         "Expected blob to be 131072 bytes"
@@ -322,6 +337,7 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyKzgProof", () => {
+
     describe("check argument count", () => {
       const test: VerifyKzgProofTest = getValidTest(VERIFY_KZG_PROOF_TESTS);
       const commitment = bytesFromHex(test.input.commitment);
@@ -330,6 +346,7 @@ describe("C-KZG", () => {
       const proof = bytesFromHex(test.input.proof);
       testArgCount(verifyKzgProof, [commitment, z, y, proof]);
     });
+
     it("valid proof should result in true", () => {
       const commitment = new Uint8Array(BYTES_PER_COMMITMENT).fill(0);
       commitment[0] = 0xc0;
@@ -339,6 +356,7 @@ describe("C-KZG", () => {
       proof[0] = 0xc0;
       expect(verifyKzgProof(commitment, z, y, proof)).toBe(true);
     });
+
     it("invalid proof should result in false", () => {
       const commitment = new Uint8Array(BYTES_PER_COMMITMENT).fill(0);
       commitment[0] = 0xc0;
@@ -348,6 +366,7 @@ describe("C-KZG", () => {
       proof[0] = 0xc0;
       expect(verifyKzgProof(commitment, z, y, proof)).toBe(false);
     });
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() =>
         verifyKzgProof(commitmentBadLength, fieldElementValidLength, fieldElementValidLength, proofValidLength)
@@ -365,6 +384,7 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyBlobKzgProof", () => {
+
     describe("check argument count", () => {
       const test: VerifyBlobKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
@@ -372,18 +392,21 @@ describe("C-KZG", () => {
       const proof = bytesFromHex(test.input.proof);
       testArgCount(verifyBlobKzgProof, [blob, commitment, proof]);
     });
+
     it("correct blob/commitment/proof should verify as true", () => {
       const blob = generateRandomBlob();
       const commitment = blobToKzgCommitment(blob);
       const proof = computeBlobKzgProof(blob, commitment);
       expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(true);
     });
+
     it("incorrect commitment should verify as false", () => {
       const blob = generateRandomBlob();
       const commitment = blobToKzgCommitment(generateRandomBlob());
       const proof = computeBlobKzgProof(blob, commitment);
       expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(false);
     });
+
     it("incorrect proof should verify as false", () => {
       const blob = generateRandomBlob();
       const commitment = blobToKzgCommitment(blob);
@@ -392,6 +415,7 @@ describe("C-KZG", () => {
       const proof = computeBlobKzgProof(randomBlob, randomCommitment);
       expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(false);
     });
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() => verifyBlobKzgProof(blobBadLength, commitmentValidLength, proofValidLength)).toThrowError(
         "Expected blob to be 131072 bytes"
@@ -406,6 +430,7 @@ describe("C-KZG", () => {
   });
 
   describe("edge cases for verifyBlobKzgProofBatch", () => {
+
     describe("check argument count", () => {
       const test: VerifyBatchKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       const blobs = test.input.blobs.map(bytesFromHex);
@@ -413,6 +438,7 @@ describe("C-KZG", () => {
       const proofs = test.input.proofs.map(bytesFromHex);
       testArgCount(verifyBlobKzgProofBatch, [blobs, commitments, proofs]);
     });
+
     it("should reject non-array args", () => {
       expect(() =>
         verifyBlobKzgProofBatch(
@@ -422,6 +448,7 @@ describe("C-KZG", () => {
         )
       ).toThrowError("Blobs, commitments, and proofs must all be arrays");
     });
+
     it("should reject non-bytearray blob", () => {
       expect(() =>
         verifyBlobKzgProofBatch(
@@ -431,6 +458,7 @@ describe("C-KZG", () => {
         )
       ).toThrowError("Expected blob to be a Uint8Array");
     });
+
     it("throws as expected when given an argument of invalid length", () => {
       expect(() =>
         verifyBlobKzgProofBatch(
@@ -454,9 +482,11 @@ describe("C-KZG", () => {
         )
       ).toThrowError("Expected proofBytes to be 48 bytes");
     });
+
     it("zero blobs/commitments/proofs should verify as true", () => {
       expect(verifyBlobKzgProofBatch([], [], [])).toBe(true);
     });
+
     it("mismatching blobs/commitments/proofs should throw error", () => {
       const count = 3;
       const blobs = new Array(count);

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -93,7 +93,7 @@ function bytesFromHex(hexString: string): Uint8Array {
  *
  * @throws {Error} If arrays are not equal length or byte values are unequal
  */
-function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): void {
+function assertBytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): void {
   if (a.length !== b.length) {
     throw new Error("unequal Uint8Array lengths");
   }
@@ -189,7 +189,7 @@ describe("C-KZG", () => {
 
         expect(test.output).not.toBeNull();
         const expectedCommitment = bytesFromHex(test.output);
-        expect(bytesEqual(commitment, expectedCommitment));
+        expect(assertBytesEqual(commitment, expectedCommitment));
       });
     });
 
@@ -216,8 +216,8 @@ describe("C-KZG", () => {
         const [proofBytes, yBytes] = proof;
         const [expectedProofBytes, expectedYBytes] = test.output.map((out) => bytesFromHex(out));
 
-        expect(bytesEqual(proofBytes, expectedProofBytes));
-        expect(bytesEqual(yBytes, expectedYBytes));
+        expect(assertBytesEqual(proofBytes, expectedProofBytes));
+        expect(assertBytesEqual(yBytes, expectedYBytes));
       });
     });
 
@@ -241,7 +241,7 @@ describe("C-KZG", () => {
 
         expect(test.output).not.toBeNull();
         const expectedProof = bytesFromHex(test.output);
-        expect(bytesEqual(proof, expectedProof));
+        expect(assertBytesEqual(proof, expectedProof));
       });
     });
 

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -83,9 +83,9 @@ function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
 
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
   const lessArgs = validArgs.length === 1 ? [] : validArgs.slice(0, -1);
-  expect(lessArgs.length + 1).toEqual(validArgs.length);
+  expect(lessArgs.length).toBeLessThan(validArgs.length);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");
-  expect(moreArgs.length - 1).toEqual(validArgs.length);
+  expect(moreArgs.length).toBeGreaterThan(validArgs.length);
   it("should run for expected argument count", () => {
     expect(() => fn(...validArgs)).not.toThrowError();
   });

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -92,7 +92,7 @@ function getValidTest(testDir: string): any {
 }
 
 function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
-  const lessArgs = validArgs.length === 1 ? [] : validArgs.slice(0, -1);
+  const lessArgs = validArgs.slice(0, -1);
   const moreArgs = validArgs.concat("UNKNOWN_ARGUMENT");
   
   it("should test for different argument lengths", () => {

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -43,18 +43,6 @@ type VerifyKzgProofTest = TestMeta<{commitment: string; y: string; z: string; pr
 type VerifyBlobKzgProofTest = TestMeta<{blob: string; commitment: string; proof: string}, boolean>;
 type VerifyBatchKzgProofTest = TestMeta<{blobs: string[]; commitments: string[]; proofs: string[]}, boolean>;
 
-const generateRandomBlob = (): Uint8Array => {
-  return new Uint8Array(
-    randomBytes(BYTES_PER_BLOB).map((x, i) => {
-      // Set the top byte to be low enough that the field element doesn't overflow the BLS modulus
-      if (x > MAX_TOP_BYTE && i % BYTES_PER_FIELD_ELEMENT == 0) {
-        return Math.floor(Math.random() * MAX_TOP_BYTE);
-      }
-      return x;
-    })
-  );
-};
-
 const blobValidLength = randomBytes(BYTES_PER_BLOB);
 const blobBadLength = randomBytes(BYTES_PER_BLOB - 1);
 const commitmentValidLength = randomBytes(BYTES_PER_COMMITMENT);
@@ -64,6 +52,30 @@ const proofBadLength = randomBytes(BYTES_PER_PROOF - 1);
 const fieldElementValidLength = randomBytes(BYTES_PER_FIELD_ELEMENT);
 const fieldElementBadLength = randomBytes(BYTES_PER_FIELD_ELEMENT - 1);
 
+/**
+ * Generates a random blob of the correct length for the KZG library
+ *
+ * @return {Uint8Array}
+ */
+function generateRandomBlob(): Uint8Array {
+  return new Uint8Array(
+    randomBytes(BYTES_PER_BLOB).map((x, i) => {
+      // Set the top byte to be low enough that the field element doesn't overflow the BLS modulus
+      if (x > MAX_TOP_BYTE && i % BYTES_PER_FIELD_ELEMENT == 0) {
+        return Math.floor(Math.random() * MAX_TOP_BYTE);
+      }
+      return x;
+    })
+  );
+}
+
+/**
+ * Converts hex string to binary Uint8Array
+ *
+ * @param {string} hexString Hex string to convert
+ *
+ * @return {Uint8Array}
+ */
 function bytesFromHex(hexString: string): Uint8Array {
   if (hexString.startsWith("0x")) {
     hexString = hexString.slice(2);
@@ -71,14 +83,23 @@ function bytesFromHex(hexString: string): Uint8Array {
   return Uint8Array.from(Buffer.from(hexString, "hex"));
 }
 
-function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
+/**
+ * Verifies that two Uint8Arrays are bitwise equivalent
+ *
+ * @param {Uint8Array} a
+ * @param {Uint8Array} b
+ *
+ * @return {void}
+ *
+ * @throws {Error} If arrays are not equal length or byte values are unequal
+ */
+function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): void {
   if (a.length !== b.length) {
-    return false;
+    throw new Error("unequal Uint8Array lengths");
   }
   for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
+    if (a[i] !== b[i]) throw new Error(`unequal Uint8Array byte at index ${i}`);
   }
-  return true;
 }
 
 /**


### PR DESCRIPTION
Relates to audit comments.

There was an audit concern about checking argument counts passed to functions.  Node.js helps to ensure argument correctness.  Added unit tests to demonstrate error handling.


### Reviewer Notes
- Followed spec test format for "valid" case (see line [L#118-L#163](https://github.com/matthewkeil/c-kzg-4844/blob/2fb362c298afe7c4088973289d509566fa39cd4a/bindings/node.js/test/kzg.test.ts#L118) for an example)
- Used random valid test from main `tests` folder for each case to ensure base case correctness