### PR TITLE
Add band-aid fix for Windows benchmark issue

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -48,3 +48,8 @@ glob = "0.3"
 [[bench]]
 name = "kzg_benches"
 harness = false
+
+# The benchmarks crash on Windows with Rust 1.70. This is a band-aid fix for
+# that. Refer to #318 for more details. This should be removed if fixed.
+[profile.bench]
+opt-level = 0


### PR DESCRIPTION
While we wait for a solution, I propose this band-aid fix which should mask the issue. @pawanjay176 mentioned that the benchmarks didn't crash with opt-level set to zero, so that's what this PR does. 