### PR TITLE
Use boxes & refs in Rust bindings

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -50,3 +50,8 @@ glob = "0.3"
 [[bench]]
 name = "kzg_benches"
 harness = false
+
+# The benchmarks crash on Windows with Rust 1.70. This is a band-aid fix for
+# that. Refer to #318 for more details. This should be removed if fixed.
+[profile.bench]
+opt-level = 0

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -50,8 +50,3 @@ glob = "0.3"
 [[bench]]
 name = "kzg_benches"
 harness = false
-
-# The benchmarks crash on Windows with Rust 1.70. This is a band-aid fix for
-# that. Refer to #318 for more details. This should be removed if fixed.
-[profile.bench]
-opt-level = 0

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -55,9 +55,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .collect();
 
     c.bench_function("blob_to_kzg_commitment", |b| {
-        b.iter(|| {
-            KzgCommitment::blob_to_kzg_commitment(blobs.first().unwrap(), &kzg_settings)
-        })
+        b.iter(|| KzgCommitment::blob_to_kzg_commitment(blobs.first().unwrap(), &kzg_settings))
     });
 
     c.bench_function("compute_kzg_proof", |b| {

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -55,50 +55,35 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .collect();
 
     c.bench_function("blob_to_kzg_commitment", |b| {
-        b.iter(|| KzgCommitment::blob_to_kzg_commitment(blobs.first().unwrap(), &kzg_settings))
+        let blob = blobs.first().unwrap();
+        b.iter(|| KzgCommitment::blob_to_kzg_commitment(blob, &kzg_settings))
     });
 
     c.bench_function("compute_kzg_proof", |b| {
-        b.iter(|| {
-            KzgProof::compute_kzg_proof(
-                blobs.first().unwrap(),
-                fields.first().unwrap(),
-                &kzg_settings,
-            )
-        })
+        let blob = blobs.first().unwrap();
+        let z = fields.first().unwrap();
+        b.iter(|| KzgProof::compute_kzg_proof(blob, z, &kzg_settings))
     });
 
     c.bench_function("compute_blob_kzg_proof", |b| {
-        b.iter(|| {
-            KzgProof::compute_blob_kzg_proof(
-                blobs.first().unwrap(),
-                commitments.first().unwrap(),
-                &kzg_settings,
-            )
-        })
+        let blob = blobs.first().unwrap();
+        let commitment = commitments.first().unwrap();
+        b.iter(|| KzgProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings))
     });
 
     c.bench_function("verify_kzg_proof", |b| {
-        b.iter(|| {
-            KzgProof::verify_kzg_proof(
-                commitments.first().unwrap(),
-                fields.first().unwrap(),
-                fields.first().unwrap(),
-                proofs.first().unwrap(),
-                &kzg_settings,
-            )
-        })
+        let commitment = commitments.first().unwrap();
+        let z = fields.first().unwrap();
+        let y = fields.first().unwrap();
+        let proof = proofs.first().unwrap();
+        b.iter(|| KzgProof::verify_kzg_proof(commitment, z, y, proof, &kzg_settings))
     });
 
     c.bench_function("verify_blob_kzg_proof", |b| {
-        b.iter(|| {
-            KzgProof::verify_blob_kzg_proof(
-                blobs.first().unwrap(),
-                commitments.first().unwrap(),
-                proofs.first().unwrap(),
-                &kzg_settings,
-            )
-        })
+        let blob = blobs.first().unwrap();
+        let commitment = commitments.first().unwrap();
+        let proof = proofs.first().unwrap();
+        b.iter(|| KzgProof::verify_blob_kzg_proof(blob, commitment, proof, &kzg_settings))
     });
 
     let mut group = c.benchmark_group("verify_blob_kzg_proof_batch");
@@ -128,7 +113,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         &proofs_subset,
                         &kzg_settings,
                     )
-                    .unwrap();
                 },
                 BatchSize::LargeInput,
             );

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,7 +7,7 @@ const MINIMAL_FIELD_ELEMENTS_PER_BLOB: usize = 4;
 /// Compiles blst.
 //
 // NOTE: This code is taken from https://github.com/supranational/blst `build.rs` `main`. The crate
-// is not used as a depedency to avoid double link issues on dependants.
+// is not used as a dependency to avoid double link issues on dependants.
 fn compile_blst(blst_base_dir: PathBuf) {
     // account for cross-compilation [by examining environment variables]
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -351,17 +351,17 @@ impl KZGProof {
         proof_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
-        let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
+        let mut verified: bool = false;
         unsafe {
             let res = verify_blob_kzg_proof(
-                verified.as_mut_ptr(),
+                &mut verified,
                 blob,
                 commitment_bytes,
                 proof_bytes,
                 kzg_settings,
             );
             if let C_KZG_RET::C_KZG_OK = res {
-                Ok(verified.assume_init())
+                Ok(verified)
             } else {
                 Err(Error::CError(res))
             }

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -148,7 +148,7 @@ impl KZGSettings {
                 .as_os_str()
                 .to_str()
                 .ok_or(Error::InvalidTrustedSetup(format!(
-                    "Unsuported non unicode file path"
+                    "Unsupported non unicode file path"
                 )))?
                 .as_bytes()
         };
@@ -180,7 +180,7 @@ impl KZGSettings {
         };
 
         // We don't really care if this succeeds.
-        let _uncheched_close_result = unsafe { libc::fclose(file_ptr) };
+        let _unchecked_close_result = unsafe { libc::fclose(file_ptr) };
         drop(file_path);
 
         result

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -429,10 +429,7 @@ impl KZGCommitment {
         hex::encode(self.bytes)
     }
 
-    pub fn blob_to_kzg_commitment(
-        blob: &Blob,
-        kzg_settings: &KZGSettings,
-    ) -> Result<Self, Error> {
+    pub fn blob_to_kzg_commitment(blob: &Blob, kzg_settings: &KZGSettings) -> Result<Self, Error> {
         let mut kzg_commitment: MaybeUninit<KZGCommitment> = MaybeUninit::uninit();
         unsafe {
             let res = blob_to_kzg_commitment(
@@ -573,9 +570,7 @@ mod tests {
 
         let commitments: Vec<Bytes48> = blobs
             .iter()
-            .map(|blob| {
-                KZGCommitment::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap()
-            })
+            .map(|blob| KZGCommitment::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap())
             .map(|commitment| commitment.to_bytes())
             .collect();
 
@@ -583,8 +578,7 @@ mod tests {
             .iter()
             .zip(commitments.iter())
             .map(|(blob, commitment)| {
-                KZGProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings)
-                    .unwrap()
+                KZGProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings).unwrap()
             })
             .map(|proof| proof.to_bytes())
             .collect();
@@ -599,13 +593,9 @@ mod tests {
 
         blobs.pop();
 
-        let error = KZGProof::verify_blob_kzg_proof_batch(
-            &blobs,
-            &commitments,
-            &proofs,
-            &kzg_settings,
-        )
-        .unwrap_err();
+        let error =
+            KZGProof::verify_blob_kzg_proof_batch(&blobs, &commitments, &proofs, &kzg_settings)
+                .unwrap_err();
         assert!(matches!(error, Error::MismatchLength(_)));
 
         let incorrect_blob = *generate_random_blob(&mut rng);

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -360,6 +360,7 @@ impl KZGProof {
                 proof_bytes,
                 kzg_settings,
             );
+            println!("foobar\n");
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(verified)
             } else {

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -9,7 +9,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         Blob::from_hex(self.blob)
     }
 }

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         Blob::from_hex(self.blob)
     }
 

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -10,7 +10,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         Blob::from_hex(self.blob)
     }
 

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -11,7 +11,7 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
+    pub fn get_blob(&self) -> Result<Box<Blob>, Error> {
         Blob::from_hex(self.blob)
     }
 

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -14,7 +14,7 @@ impl Input {
     pub fn get_blobs(&self) -> Result<Vec<Blob>, Error> {
         let mut v: Vec<Blob> = Vec::new();
         for blob in &self.blobs {
-            v.push(Blob::from_hex(blob)?);
+            v.push(*Blob::from_hex(blob)?);
         }
         return Ok(v);
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -7,8 +7,8 @@ pub use bindings::{
 };
 // Expose the constants.
 pub use bindings::{
-    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_PROOF,
-    FIELD_ELEMENTS_PER_BLOB, BYTES_PER_G1_POINT, BYTES_PER_G2_POINT
+    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT,
+    BYTES_PER_G2_POINT, BYTES_PER_PROOF, FIELD_ELEMENTS_PER_BLOB,
 };
 // Expose the remaining relevant types.
 pub use bindings::{Blob, Bytes32, Bytes48, Error};


### PR DESCRIPTION
This PR fixes the issue with Windows & should be overall more efficient.

* When dealing with individual blobs, box them (store them on the heap).
  * This fixes the segmentation fault crash on Windows on 4844-devnet-7.
  * My theory is that these (relatively large) blobs were overflowing the stack.
* For all of the KZG interface functions, take references.
  * I feel like this should have done this a while ago.
  * It should be more efficient as it saves us from cloning.

Note, this does **not** fix the benchmark issue on Windows:

* #318 