### PR TITLE
chore: add Apache-2.0 to rust license in Cargo.toml

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "c-kzg"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 # XXX: Note that we don't set a `links` attribute for Cargo, because this library may link
 # either `ckzg` or `ckzg_min`. This allows the crate to be linked twice as minimal/mainnet variants
 # without Cargo complaining.


### PR DESCRIPTION
This is required for tools like [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) which we use in reth for CI, for example in https://github.com/paradigmxyz/reth/pull/4084 where it is currently failing:
https://github.com/paradigmxyz/reth/actions/runs/5772358088/job/15647257900