### PR TITLE
Adding constant for bytes per g1/g2 points

### DIFF
--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -67,6 +67,10 @@ public class CKZG4844JNI {
   public static final BigInteger BLS_MODULUS =
       new BigInteger(
           "52435875175126190479447740508185965837690552500527637822603658699938581184513");
+  /** The number of bytes in a g1 point. */
+  public static final int BYTES_PER_G1 = 48;
+  /** The number of bytes in a g2 point. */
+  public static final int BYTES_PER_G2 = 96;
   /** The number of bytes in a KZG commitment */
   public static final int BYTES_PER_COMMITMENT = 48;
   /** The number of bytes in a KZG proof */

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
@@ -205,8 +205,8 @@ public class TestUtils {
       final int g1Count = Integer.parseInt(reader.readLine());
       final int g2Count = Integer.parseInt(reader.readLine());
 
-      final ByteBuffer g1 = ByteBuffer.allocate(g1Count * 48);
-      final ByteBuffer g2 = ByteBuffer.allocate(g2Count * 96);
+      final ByteBuffer g1 = ByteBuffer.allocate(g1Count * CKZG4844JNI.BYTES_PER_G1);
+      final ByteBuffer g2 = ByteBuffer.allocate(g2Count * CKZG4844JNI.BYTES_PER_G2);
 
       for (int i = 0; i < g1Count; i++) {
         g1.put(Bytes.fromHexString(reader.readLine()).toArray());


### PR DESCRIPTION
Just a small nit for the java binding. We use those constants in Teku, so it makes sense to have them in the lib.