### PR TITLE
Upgrade blst to v0.3.11

### DIFF
--- a/bindings/go/blst_headers/blst.h
+++ b/bindings/go/blst_headers/blst.h
@@ -95,10 +95,6 @@ void blst_fr_sqr(blst_fr *ret, const blst_fr *a);
 void blst_fr_cneg(blst_fr *ret, const blst_fr *a, bool flag);
 void blst_fr_eucl_inverse(blst_fr *ret, const blst_fr *a);
 void blst_fr_inverse(blst_fr *ret, const blst_fr *a);
-#ifdef BLST_FR_PENTAROOT
-void blst_fr_pentaroot(blst_fr *ret, const blst_fr *a);
-void blst_fr_pentapow(blst_fr *ret, const blst_fr *a);
-#endif
 
 void blst_fr_from_uint64(blst_fr *ret, const uint64_t a[4]);
 void blst_uint64_from_fr(uint64_t ret[4], const blst_fr *a);
@@ -341,6 +337,9 @@ void blst_sign_pk_in_g2(blst_p1 *out_sig, const blst_p1 *hash,
 #ifndef SWIG
 void blst_miller_loop(blst_fp12 *ret, const blst_p2_affine *Q,
                                       const blst_p1_affine *P);
+void blst_miller_loop_n(blst_fp12 *ret, const blst_p2_affine *const Qs[],
+                                        const blst_p1_affine *const Ps[],
+                                        size_t n);
 void blst_final_exp(blst_fp12 *ret, const blst_fp12 *f);
 void blst_precompute_lines(blst_fp6 Qlines[68], const blst_p2_affine *Q);
 void blst_miller_loop_lines(blst_fp12 *ret, const blst_fp6 Qlines[68],

--- a/bindings/go/blst_headers/blst_aux.h
+++ b/bindings/go/blst_headers/blst_aux.h
@@ -10,8 +10,14 @@
  * depending on their proven/unproven worthiness.
  */
 
+void blst_fr_ct_bfly(blst_fr *x0, blst_fr *x1, const blst_fr *twiddle);
+void blst_fr_gs_bfly(blst_fr *x0, blst_fr *x1, const blst_fr *twiddle);
 void blst_fr_to(blst_fr *ret, const blst_fr *a);
 void blst_fr_from(blst_fr *ret, const blst_fr *a);
+#ifdef BLST_FR_PENTAROOT
+void blst_fr_pentaroot(blst_fr *ret, const blst_fr *a);
+void blst_fr_pentapow(blst_fr *ret, const blst_fr *a);
+#endif
 
 void blst_fp_to(blst_fp *ret, const blst_fp *a);
 void blst_fp_from(blst_fp *ret, const blst_fp *a);

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,7 +7,7 @@ const MINIMAL_FIELD_ELEMENTS_PER_BLOB: usize = 4;
 /// Compiles blst.
 //
 // NOTE: This code is taken from https://github.com/supranational/blst `build.rs` `main`. The crate
-// is not used as a depedency to avoid double link issues on dependants.
+// is not used as a dependency to avoid double link issues on dependants.
 fn compile_blst(blst_base_dir: PathBuf) {
     // account for cross-compilation [by examining environment variables]
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -148,7 +148,7 @@ impl KZGSettings {
                 .as_os_str()
                 .to_str()
                 .ok_or(Error::InvalidTrustedSetup(format!(
-                    "Unsuported non unicode file path"
+                    "Unsupported non unicode file path"
                 )))?
                 .as_bytes()
         };
@@ -180,7 +180,7 @@ impl KZGSettings {
         };
 
         // We don't really care if this succeeds.
-        let _uncheched_close_result = unsafe { libc::fclose(file_ptr) };
+        let _unchecked_close_result = unsafe { libc::fclose(file_ptr) };
         drop(file_path);
 
         result

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1
-	github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b
+	github.com/supranational/blst v0.3.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b h1:u49mjRnygnB34h8OKbnNJFVUtWSKIKb1KukdV8bILUM=
-github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
+github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
A new version of blst was released a few hours ago:

* https://github.com/supranational/blst/releases/tag/v0.3.11

This PR updates c-kzg to use this version. Also, fixes some typos.