### PR TITLE
Test Go bindings on all platforms

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -26,13 +26,15 @@ jobs:
         with:
           submodules: recursive
       - name: Test
-        run: |
-          cd bindings/go
-          CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test
+        run: go test
+        working-directory: bindings/go
+        env:
+          CGO_CFLAGS: "-O2 -D__BLST_PORTABLE__"
       - name: Benchmark
-        run: |
-          cd bindings/go
-          CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test -bench=Benchmark
+        run: go test -bench=Benchmark
+        working-directory: bindings/go
+        env:
+          CGO_CFLAGS: "-O2 -D__BLST_PORTABLE__"
       - name: Check headers
         run: |
           cmp blst/bindings/blst.h bindings/go/blst_headers/blst.h

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -18,7 +18,7 @@ jobs:
           - macos-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: stable
         id: go

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -9,12 +9,18 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: stable
         id: go
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
* Test the Go bindings on Linux, macOS, and Windows.
* Use the latest stable version of Go instead of a static version.