### PR TITLE
Force use of portable blst in Nim bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ analysis-report/
 *bindings/csharp/*.dll
 __pycache__
 .DS_Store
+
+# nimble build dir
+build/

--- a/bindings/nim/kzg_abi.nim
+++ b/bindings/nim/kzg_abi.nim
@@ -21,6 +21,7 @@ when not defined(kzgExternalBlst):
   # Use default blst shipped with c-kzg-4844
   {.compile: blstPath & "build/assembly.S".}
   {.compile: blstPath & "src/server.c"}
+  {.passc: "-D__BLST_PORTABLE__"}
 
 {.compile: srcPath & "c_kzg_4844.c"}
 


### PR DESCRIPTION
* Ignore `build` directory that `nimble test` creates.
* If not using an external blst, pass flag to compiler to build portable version of blst.