### PR TITLE
Force use of portable blst in Rust bindings

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -11,20 +11,10 @@ license = "Apache-2.0"
 
 [features]
 
-# BLST Compilation:
-# By default, compile with ADX extension if the host supports it. Binary can be
-# executed on systems similar to the host.
 default = ["mainnet-spec"]
 mainnet-spec = []
 minimal-spec = []
-# BLST Compilation:
-# Compile in portable mode, without ISA extensions.
-# Binary can be executed on all systems.
-portable = []
-# BLST Compilation:
-# Enable ADX even if the host CPU doesn't support it.
-# Binary can be executed on Broadwell+ and Ryzen+ systems.
-force-adx = []
+
 # BLST Compilation:
 # Suppress multi-threading.
 # Engaged on wasm32 target architecture automatically.

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -58,29 +58,7 @@ fn compile_blst(blst_base_dir: PathBuf) {
     } else {
         cc.define("__BLST_NO_ASM__", None);
     }
-    match (cfg!(feature = "portable"), cfg!(feature = "force-adx")) {
-        (true, false) => {
-            println!("Compiling in portable mode without ISA extensions");
-            cc.define("__BLST_PORTABLE__", None);
-        }
-        (false, true) => {
-            if target_arch.eq("x86_64") {
-                println!("Enabling ADX support via `force-adx` feature");
-                cc.define("__ADX__", None);
-            } else {
-                println!("`force-adx` is ignored for non-x86_64 targets");
-            }
-        }
-        (false, false) =>
-        {
-            #[cfg(target_arch = "x86_64")]
-            if target_arch.eq("x86_64") && std::is_x86_feature_detected!("adx") {
-                println!("Enabling ADX because it was detected on the host");
-                cc.define("__ADX__", None);
-            }
-        }
-        (true, true) => panic!("Cannot compile with both `portable` and `force-adx` features"),
-    }
+    cc.define("__BLST_PORTABLE__", None);
     if env::var("CARGO_CFG_TARGET_ENV").unwrap().eq("msvc") {
         cc.flag("-Zl");
     }


### PR DESCRIPTION
* Remove features for `portable` and `force-adx` which were used by blst.
  * Leave the `no-threads` feature since that's still useful.
* Remove the big `match` block which checks the `portable` and `force-adx` features.
* Add non-configurable define for `__BLST_PORTABLE__` when building blst.