### PR TITLE
Force use of portable blst in nodejs bindings

### DIFF
--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -12,7 +12,10 @@
         "<(module_root_dir)/deps/c-kzg",
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
+      "defines": [
+        "__BLST_PORTABLE__",
+        "NAPI_DISABLE_CPP_EXCEPTIONS"
+      ],
       "conditions": [
         ["OS!='win'", {
           "sources": ["deps/blst/build/assembly.S"],


### PR DESCRIPTION
* Add `__BLST_PORTABLE__` to list of defines for all source files/platforms.

Note, there was this warning in the build step:

> ld: warning: tentative definition of '___blst_platform_cap' with size 4 from 'Release/obj.target/kzg/deps/blst/build/assembly.o' is being replaced by real definition of smaller size 0 from 'Release/obj.target/kzg/deps/blst/src/server.o'

But I think this is fine. Probably a side-effect of blst's implementation. In blst, there is a tentative symbol (aka extern) defined in the assembly file. Then the real variable is defined in C code. Typically, when you list symbols there are two:

```
$ nm libblst.a | ag cap
0000000000000004 C ___blst_platform_cap
00000000000201b8 S ___blst_platform_cap
```

I think nodejs is deleting the tentative symbol/variable and just keeping the real one.

```
$ nm kzg.node | ag cap
0000000000034240 s ___blst_platform_cap
```

Also notice that `S` is now lowercase `s` which I think means it's a local variable.

I made sure that runtime detection was working by:
 * modifying the optimized asm code for sha256 to an illegal instruction,
 * changing `___blst_platform_cap` to a different value,
 * check to see that it doesn't crash (because it's using the portable impl),
 * reverting `___blst_platform_cap`,
 * check that it does crash (because it's using the optimized impl).

To me this checks out, but something we could/should investigate more in the future.