### PR TITLE
Add -fPIC to csharp unix build

### DIFF
--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -13,6 +13,7 @@ else
 	BLST_BUILDSCRIPT = ./build.sh
 	BLST_OBJ = libblst.a
 	CLANG_EXECUTABLE = clang
+	CFLAGS += -fPIC
 
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)


### PR DESCRIPTION
Ran into this issue when creating a docker image for C# tests:

```
$ make
cd ../../blst && ./build.sh -D__BLST_PORTABLE__
+ clang -O2 -fno-builtin -fPIC -Wall -Wextra -Werror -D__ADX__ -D__BLST_PORTABLE__ -c ./src/server.c
+ clang -O2 -fno-builtin -fPIC -Wall -Wextra -Werror -D__ADX__ -D__BLST_PORTABLE__ -c ./build/assembly.S
+ llvm-ar rc libblst.a assembly.o server.o
clang -O2 -Wall -Wextra -shared -DFIELD_ELEMENTS_PER_BLOB=4096 -I../../src -I../../blst/bindings -o Ckzg.Bindings/runtimes/linux-x64/native/ckzg.so ckzg.c ../../src/c_kzg_4844.c ../../blst/libblst.a
/usr/bin/ld: /tmp/ckzg-f1a131.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /tmp/c_kzg_4844-72668e.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:59: ckzg] Error 1
```

Definitely something that should have been there.