### PR TITLE
Use blst crate for Rust blst dep

### DIFF
--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -63,6 +63,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +85,7 @@ name = "c-kzg"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "blst",
  "cc",
  "criterion",
  "glob",
@@ -717,6 +730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,3 +947,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -24,6 +24,7 @@ no-threads = []
 hex = "0.4.2"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
+blst = "0.3.11"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,99 +1,8 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const MAINNET_FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 const MINIMAL_FIELD_ELEMENTS_PER_BLOB: usize = 4;
-
-/// Compiles blst.
-//
-// NOTE: This code is taken from https://github.com/supranational/blst `build.rs` `main`. The crate
-// is not used as a dependency to avoid double link issues on dependants.
-fn compile_blst(blst_base_dir: PathBuf) {
-    // account for cross-compilation [by examining environment variables]
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-
-    if target_os.ne("none") && !env::var("BLST_TEST_NO_STD").is_ok() {
-        println!("cargo:rustc-cfg=feature=\"std\"");
-        if target_arch.eq("wasm32") {
-            println!("cargo:rustc-cfg=feature=\"no-threads\"");
-        }
-    }
-    println!("cargo:rerun-if-env-changed=BLST_TEST_NO_STD");
-
-    println!("Using blst source directory {}", blst_base_dir.display());
-
-    // Set CC environment variable to choose alternative C compiler.
-    // Optimization level depends on whether or not --release is passed
-    // or implied.
-
-    #[cfg(target_env = "msvc")]
-    if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap().eq("32") && !env::var("CC").is_ok() {
-        match std::process::Command::new("clang-cl")
-            .arg("--version")
-            .output()
-        {
-            Ok(out) => {
-                if String::from_utf8(out.stdout)
-                    .unwrap_or("unintelligible".to_string())
-                    .contains("Target: i686-")
-                {
-                    env::set_var("CC", "clang-cl");
-                }
-            }
-            Err(_) => { /* no clang-cl in sight, just ignore the error */ }
-        }
-    }
-
-    let mut cc = cc::Build::new();
-
-    let c_src_dir = blst_base_dir.join("src");
-    println!("cargo:rerun-if-changed={}", c_src_dir.display());
-    let mut file_vec = vec![c_src_dir.join("server.c")];
-
-    if target_arch.eq("x86_64") || target_arch.eq("aarch64") {
-        let asm_dir = blst_base_dir.join("build");
-        println!("cargo:rerun-if-changed={}", asm_dir.display());
-        blst_assembly(&mut file_vec, &asm_dir, &target_arch);
-    } else {
-        cc.define("__BLST_NO_ASM__", None);
-    }
-    cc.define("__BLST_PORTABLE__", None);
-    if env::var("CARGO_CFG_TARGET_ENV").unwrap().eq("msvc") {
-        cc.flag("-Zl");
-    }
-    cc.flag_if_supported("-mno-avx") // avoid costly transitions
-        .flag_if_supported("-fno-builtin")
-        .flag_if_supported("-Wno-unused-function")
-        .flag_if_supported("-Wno-unused-command-line-argument");
-    if target_arch.eq("wasm32") {
-        cc.flag_if_supported("-ffreestanding");
-    }
-    if !cfg!(debug_assertions) {
-        cc.opt_level(2);
-    }
-    cc.files(&file_vec).compile("blst");
-}
-
-/// Adds assembly files for blst compilation.
-fn blst_assembly(file_vec: &mut Vec<PathBuf>, base_dir: &Path, _arch: &String) {
-    #[cfg(target_env = "msvc")]
-    if env::var("CARGO_CFG_TARGET_ENV").unwrap().eq("msvc") {
-        let sfx = match _arch.as_str() {
-            "x86_64" => "x86_64",
-            "aarch64" => "armv8",
-            _ => "unknown",
-        };
-        let files = glob::glob(&format!("{}/win64/*-{}.asm", base_dir.display(), sfx))
-            .expect("unable to collect assembly files");
-        for file in files {
-            file_vec.push(file.unwrap());
-        }
-        return;
-    }
-
-    file_vec.push(base_dir.join("assembly.S"));
-}
 
 fn main() {
     let cargo_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -112,10 +21,8 @@ fn main() {
     eprintln!("Using LIB_PREFIX={lib_name}");
     eprintln!("Using FIELD_ELEMENTS_PER_BLOB={field_elements_per_blob}");
 
-    let blst_base_dir = root_dir.join("blst");
-    compile_blst(blst_base_dir.clone());
-
     // Obtain the header files of blst
+    let blst_base_dir = root_dir.join("blst");
     let blst_headers_dir = blst_base_dir.join("bindings");
 
     let c_src_dir = root_dir.join("src");
@@ -132,9 +39,6 @@ fn main() {
     cc.file(c_src_dir.join("c_kzg_4844.c"));
 
     cc.try_compile(lib_name).expect("Failed to compile ckzg");
-
-    // Tell cargo to search for the static blst exposed by the blst-bindings' crate.
-    println!("cargo:rustc-link-lib=static=blst");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let bindings_out_path = out_dir.join("generated.rs");

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate blst;
+
 mod bindings;
 
 // Expose relevant types with idiomatic names.
@@ -7,8 +9,8 @@ pub use bindings::{
 };
 // Expose the constants.
 pub use bindings::{
-    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_PROOF,
-    FIELD_ELEMENTS_PER_BLOB, BYTES_PER_G1_POINT, BYTES_PER_G2_POINT
+    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT,
+    BYTES_PER_G2_POINT, BYTES_PER_PROOF, FIELD_ELEMENTS_PER_BLOB,
 };
 // Expose the remaining relevant types.
 pub use bindings::{Blob, Bytes32, Bytes48, Error};

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,3 +1,6 @@
+// This `extern crate` invocation tells `rustc` that we actually need the symbols from `blst`.
+// Without it, the compiler won't link to `blst` when compiling this crate.
+// See: https://kornel.ski/rust-sys-crate#linking
 extern crate blst;
 
 mod bindings;


### PR DESCRIPTION
We were getting nasty linker errors in Lighthouse due to different versions of the `blst` library being linked by:

- `crypto/bls`: our BLS wrapper that depends on the `blst` crate from `crates.io`.
- `c_kzg/c_kzg_min`: mainnet/minimal variants of c-kzg which depend on their own `libblst.a` which is built at compile-time.

As well as causing link errors when the `blst` versions get out of sync, the current setup also wastes compilation time by compiling `blst` 3 times.

I think the changes in this PR improve the situation by using a single copy of `blst` throughout. Due to the [`links` attribute](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) in `blst`'s `Cargo.toml`, Cargo will now error if we try to compile with multiple copies of the `blst` crate. We can also make semver-compatible updates to `blst` downstream without having to bump the `blst` version in `c-kzg`, so long as the headers are compatible with the ones vendored in `c-kzg`.