### PR TITLE
Runtime field count

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -38,9 +38,9 @@ jobs:
       # Build and test with minimal preset.
       - name: Build (minimal)
         run: |
-          export FIELD_ELEMENTS_PER_BLOB=4
+          export CFLAGS=-DMINIMAL 
           make clean && make test_c_kzg_4844
-          unset FIELD_ELEMENTS_PER_BLOB
+          unset CFLAGS
       - name: Save test binary (minimal)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3
@@ -53,9 +53,9 @@ jobs:
       # Build and test with mainnet preset.
       - name: Build (mainnet)
         run: |
-          export FIELD_ELEMENTS_PER_BLOB=4096
+          export CFLAGS=-DMAINNET
           make clean && make test_c_kzg_4844
-          unset FIELD_ELEMENTS_PER_BLOB
+          unset CFLAGS
       - name: Save test binary (mainnet)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,12 +19,8 @@ ifeq ($(PLATFORM),Darwin)
 	XCRUN = xcrun
 endif
 
-# By default, this is set to the mainnet value.
-FIELD_ELEMENTS_PER_BLOB ?= 4096
-
 # The base compiler flags. More can be added on command line.
 CFLAGS += -I../inc
-CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 CFLAGS += -O2 -Wall -Wextra
 
 # Cross-platform compilation settings.

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -48,15 +48,6 @@
     } while (0)
 
 ///////////////////////////////////////////////////////////////////////////////
-// Types
-///////////////////////////////////////////////////////////////////////////////
-
-/** Internal representation of a polynomial. */
-typedef struct {
-    fr_t evals[FIELD_ELEMENTS_PER_BLOB];
-} Polynomial;
-
-///////////////////////////////////////////////////////////////////////////////
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -600,11 +591,11 @@ static C_KZG_RET bytes_to_kzg_proof(g1_t *out, const Bytes48 *b) {
  * @param[out] p    The output polynomial (array of field elements)
  * @param[in]  blob The blob (an array of bytes)
  */
-static C_KZG_RET blob_to_polynomial(Polynomial *poly, const uint8_t *blob) {
+static C_KZG_RET blob_to_polynomial(fr_t *poly, const uint8_t *blob) {
     C_KZG_RET ret;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         ret = bytes_to_bls_field(
-            &poly->evals[i], (Bytes32 *)&blob[i * BYTES_PER_FIELD_ELEMENT]
+            &poly[i], (Bytes32 *)&blob[i * BYTES_PER_FIELD_ELEMENT]
         );
         if (ret != C_KZG_OK) return ret;
     }
@@ -787,7 +778,7 @@ static void compute_powers(fr_t *out, const fr_t *x, uint64_t n) {
  * @param[in]  s    The trusted setup
  */
 static C_KZG_RET evaluate_polynomial_in_evaluation_form(
-    fr_t *out, const Polynomial *poly, const fr_t *x, const KZGSettings *s
+    fr_t *out, const fr_t *poly, const fr_t *x, const KZGSettings *s
 ) {
     C_KZG_RET ret;
     fr_t tmp;
@@ -809,7 +800,7 @@ static C_KZG_RET evaluate_polynomial_in_evaluation_form(
          * would divide by zero otherwise.
          */
         if (fr_equal(x, &roots_of_unity[i])) {
-            *out = poly->evals[i];
+            *out = poly[i];
             ret = C_KZG_OK;
             goto out;
         }
@@ -822,7 +813,7 @@ static C_KZG_RET evaluate_polynomial_in_evaluation_form(
     *out = FR_ZERO;
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         blst_fr_mul(&tmp, &inverses[i], &roots_of_unity[i]);
-        blst_fr_mul(&tmp, &tmp, &poly->evals[i]);
+        blst_fr_mul(&tmp, &tmp, &poly[i]);
         blst_fr_add(out, out, &tmp);
     }
     fr_from_uint64(&tmp, FIELD_ELEMENTS_PER_BLOB);
@@ -849,10 +840,10 @@ out:
  * @param[in]  s    The trusted setup
  */
 static C_KZG_RET poly_to_kzg_commitment(
-    g1_t *out, const Polynomial *poly, const KZGSettings *s
+    g1_t *out, const fr_t *poly, const KZGSettings *s
 ) {
     return g1_lincomb_fast(
-        out, s->g1_values, (const fr_t *)(&poly->evals), FIELD_ELEMENTS_PER_BLOB
+        out, s->g1_values, poly, FIELD_ELEMENTS_PER_BLOB
     );
 }
 
@@ -867,15 +858,20 @@ C_KZG_RET BLOB_TO_KZG_COMMITMENT(
     KZGCommitment *out, const uint8_t *blob, const KZGSettings *s
 ) {
     C_KZG_RET ret;
-    Polynomial poly;
+    fr_t *poly = NULL;
     g1_t commitment;
 
-    ret = blob_to_polynomial(&poly, blob);
-    if (ret != C_KZG_OK) return ret;
-    ret = poly_to_kzg_commitment(&commitment, &poly, s);
-    if (ret != C_KZG_OK) return ret;
+    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
+    ret = blob_to_polynomial(poly, blob);
+    if (ret != C_KZG_OK) goto out;
+    ret = poly_to_kzg_commitment(&commitment, poly, s);
+    if (ret != C_KZG_OK) goto out;
     bytes_from_g1(out, &commitment);
-    return C_KZG_OK;
+
+out:
+    c_kzg_free(poly);
+    return ret;
 }
 
 /* Forward function declaration */
@@ -972,7 +968,7 @@ static C_KZG_RET verify_kzg_proof_impl(
 static C_KZG_RET compute_kzg_proof_impl(
     KZGProof *proof_out,
     fr_t *y_out,
-    const Polynomial *poly,
+    const fr_t *poly,
     const fr_t *z,
     const KZGSettings *s
 );
@@ -995,18 +991,21 @@ C_KZG_RET COMPUTE_KZG_PROOF(
     const KZGSettings *s
 ) {
     C_KZG_RET ret;
-    Polynomial poly;
+    fr_t *poly = NULL;
     fr_t frz, fry;
 
-    ret = blob_to_polynomial(&poly, blob);
+    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
+    ret = blob_to_polynomial(poly, blob);
     if (ret != C_KZG_OK) goto out;
     ret = bytes_to_bls_field(&frz, z_bytes);
     if (ret != C_KZG_OK) goto out;
-    ret = compute_kzg_proof_impl(proof_out, &fry, &poly, &frz, s);
+    ret = compute_kzg_proof_impl(proof_out, &fry, poly, &frz, s);
     if (ret != C_KZG_OK) goto out;
     bytes_from_bls_field(y_out, &fry);
 
 out:
+    c_kzg_free(poly);
     return ret;
 }
 
@@ -1024,19 +1023,19 @@ out:
 static C_KZG_RET compute_kzg_proof_impl(
     KZGProof *proof_out,
     fr_t *y_out,
-    const Polynomial *poly,
+    const fr_t *poly,
     const fr_t *z,
     const KZGSettings *s
 ) {
     C_KZG_RET ret;
     fr_t *inverses_in = NULL;
     fr_t *inverses = NULL;
+    fr_t *q_poly = NULL;
 
     ret = evaluate_polynomial_in_evaluation_form(y_out, poly, z, s);
     if (ret != C_KZG_OK) goto out;
 
     fr_t tmp;
-    Polynomial q;
     const fr_t *roots_of_unity = s->roots_of_unity;
     uint64_t i;
     /* m != 0 indicates that the evaluation point z equals root_of_unity[m-1] */
@@ -1045,6 +1044,8 @@ static C_KZG_RET compute_kzg_proof_impl(
     ret = new_fr_array(&inverses_in, FIELD_ELEMENTS_PER_BLOB);
     if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&inverses, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&q_poly, FIELD_ELEMENTS_PER_BLOB);
     if (ret != C_KZG_OK) goto out;
 
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
@@ -1055,7 +1056,7 @@ static C_KZG_RET compute_kzg_proof_impl(
             continue;
         }
         // (p_i - y) / (ω_i - z)
-        blst_fr_sub(&q.evals[i], &poly->evals[i], y_out);
+        blst_fr_sub(&q_poly[i], &poly[i], y_out);
         blst_fr_sub(&inverses_in[i], &roots_of_unity[i], z);
     }
 
@@ -1063,11 +1064,11 @@ static C_KZG_RET compute_kzg_proof_impl(
     if (ret != C_KZG_OK) goto out;
 
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        blst_fr_mul(&q.evals[i], &q.evals[i], &inverses[i]);
+        blst_fr_mul(&q_poly[i], &q_poly[i], &inverses[i]);
     }
 
     if (m != 0) { /* ω_{m-1} == z */
-        q.evals[--m] = FR_ZERO;
+        q_poly[--m] = FR_ZERO;
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
             if (i == m) continue;
             /* Build denominator: z * (z - ω_i) */
@@ -1081,17 +1082,17 @@ static C_KZG_RET compute_kzg_proof_impl(
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
             if (i == m) continue;
             /* Build numerator: ω_i * (p_i - y) */
-            blst_fr_sub(&tmp, &poly->evals[i], y_out);
+            blst_fr_sub(&tmp, &poly[i], y_out);
             blst_fr_mul(&tmp, &tmp, &roots_of_unity[i]);
             /* Do the division: (p_i - y) * ω_i / (z * (z - ω_i)) */
             blst_fr_mul(&tmp, &tmp, &inverses[i]);
-            blst_fr_add(&q.evals[m], &q.evals[m], &tmp);
+            blst_fr_add(&q_poly[m], &q_poly[m], &tmp);
         }
     }
 
     g1_t out_g1;
     ret = g1_lincomb_fast(
-        &out_g1, s->g1_values, (const fr_t *)(&q.evals), FIELD_ELEMENTS_PER_BLOB
+        &out_g1, s->g1_values, q_poly, FIELD_ELEMENTS_PER_BLOB
     );
     if (ret != C_KZG_OK) goto out;
 
@@ -1100,6 +1101,7 @@ static C_KZG_RET compute_kzg_proof_impl(
 out:
     c_kzg_free(inverses_in);
     c_kzg_free(inverses);
+    c_kzg_free(q_poly);
     return ret;
 }
 
@@ -1120,25 +1122,30 @@ C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
     const KZGSettings *s
 ) {
     C_KZG_RET ret;
-    Polynomial poly;
+    fr_t *poly = NULL;
     g1_t commitment_g1;
     fr_t evaluation_challenge_fr;
     fr_t y;
 
+    /* Allocate our polynomial */
+    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
+
     /* Do conversions first to fail fast, compute_challenge is expensive */
     ret = bytes_to_kzg_commitment(&commitment_g1, commitment_bytes);
     if (ret != C_KZG_OK) goto out;
-    ret = blob_to_polynomial(&poly, blob);
+    ret = blob_to_polynomial(poly, blob);
     if (ret != C_KZG_OK) goto out;
 
     /* Compute the challenge for the given blob/commitment */
     compute_challenge(&evaluation_challenge_fr, blob, &commitment_g1);
 
     /* Call helper function to compute proof and y */
-    ret = compute_kzg_proof_impl(out, &y, &poly, &evaluation_challenge_fr, s);
+    ret = compute_kzg_proof_impl(out, &y, poly, &evaluation_challenge_fr, s);
     if (ret != C_KZG_OK) goto out;
 
 out:
+    c_kzg_free(poly);
     return ret;
 }
 
@@ -1160,33 +1167,41 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF(
     const KZGSettings *s
 ) {
     C_KZG_RET ret;
-    Polynomial poly;
+    fr_t *poly = NULL;
     fr_t evaluation_challenge_fr, y_fr;
     g1_t commitment_g1, proof_g1;
 
     *ok = false;
 
+    /* Allocate our polynomial */
+    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
+
     /* Do conversions first to fail fast, compute_challenge is expensive */
     ret = bytes_to_kzg_commitment(&commitment_g1, commitment_bytes);
-    if (ret != C_KZG_OK) return ret;
-    ret = blob_to_polynomial(&poly, blob);
-    if (ret != C_KZG_OK) return ret;
+    if (ret != C_KZG_OK) goto out;
+    ret = blob_to_polynomial(poly, blob);
+    if (ret != C_KZG_OK) goto out;
     ret = bytes_to_kzg_proof(&proof_g1, proof_bytes);
-    if (ret != C_KZG_OK) return ret;
+    if (ret != C_KZG_OK) goto out;
 
     /* Compute challenge for the blob/commitment */
     compute_challenge(&evaluation_challenge_fr, blob, &commitment_g1);
 
     /* Evaluate challenge to get y */
     ret = evaluate_polynomial_in_evaluation_form(
-        &y_fr, &poly, &evaluation_challenge_fr, s
+        &y_fr, poly, &evaluation_challenge_fr, s
     );
-    if (ret != C_KZG_OK) return ret;
+    if (ret != C_KZG_OK) goto out;
 
     /* Call helper to do pairings check */
-    return verify_kzg_proof_impl(
+    ret = verify_kzg_proof_impl(
         ok, &commitment_g1, &evaluation_challenge_fr, &y_fr, &proof_g1, s
     );
+
+out:
+    c_kzg_free(poly);
+    return ret;
 }
 
 /**
@@ -1378,6 +1393,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
     g1_t *proofs_g1 = NULL;
     fr_t *evaluation_challenges_fr = NULL;
     fr_t *ys_fr = NULL;
+    fr_t *poly = NULL;
 
     /* Exit early if we are given zero blobs */
     if (n == 0) {
@@ -1401,10 +1417,10 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
     if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&ys_fr, n);
     if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    if (ret != C_KZG_OK) goto out;
 
     for (size_t i = 0; i < n; i++) {
-        Polynomial poly;
-
         /* Convert each commitment to a g1 point */
         ret = bytes_to_kzg_commitment(
             &commitments_g1[i], &commitments_bytes[i]
@@ -1412,7 +1428,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
         if (ret != C_KZG_OK) goto out;
 
         /* Convert each blob from bytes to a poly */
-        ret = blob_to_polynomial(&poly, &blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_polynomial(poly, &blobs[i * BYTES_PER_BLOB]);
         if (ret != C_KZG_OK) goto out;
 
         compute_challenge(
@@ -1422,7 +1438,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
         );
 
         ret = evaluate_polynomial_in_evaluation_form(
-            &ys_fr[i], &poly, &evaluation_challenges_fr[i], s
+            &ys_fr[i], poly, &evaluation_challenges_fr[i], s
         );
         if (ret != C_KZG_OK) goto out;
 
@@ -1439,6 +1455,7 @@ out:
     c_kzg_free(proofs_g1);
     c_kzg_free(evaluation_challenges_fr);
     c_kzg_free(ys_fr);
+    c_kzg_free(poly);
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1384,15 +1384,13 @@ out:
  * Given a list of blobs and blob KZG proofs, verify that they correspond to the
  * provided commitments.
  *
- * @remark This function assumes that `n` is trusted and that all input arrays
- * contain `n` elements. `n` should be the actual size of the arrays and not
- * read off a length field in the protocol.
- *
+ * @remark This function assumes that `n` is trusted.
  * @remark This function accepts if called with `n==0`.
- * @remark Blobs must be a flattened array of bytes, not pointers.
+ * @remark `blobs` is expected to be `n * BLOB_SIZE` bytes.
+ * @remark `blobs` must be a flattened array of bytes, not pointers.
  *
  * @param[out] ok                True if the proofs are valid, otherwise false
- * @param[in]  blobs             Array of blobs to verify
+ * @param[in]  blobs             Flattened array of blob bytes to verify
  * @param[in]  commitments_bytes Array of commitments to verify
  * @param[in]  proofs_bytes      Array of proofs used for verification
  * @param[in]  n                 The number of blobs/commitments/proofs

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1719,7 +1719,7 @@ C_KZG_RET load_trusted_setup(
 ) {
     C_KZG_RET ret;
 
-    /* Check that the expect counts are correct */
+    /* Check that the counts are correct */
     if (n1 != TRUSTED_SETUP_NUM_G1_POINTS_MAINNET &&
         n1 != TRUSTED_SETUP_NUM_G1_POINTS_MINIMAL) {
         ret = C_KZG_BADARGS;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -867,7 +867,7 @@ static C_KZG_RET poly_to_kzg_commitment(
  * @param[in]  blob The blob representing the polynomial to be committed to
  * @param[in]  s    The trusted setup
  */
-C_KZG_RET BLOB_TO_KZG_COMMITMENT(
+C_KZG_RET blob_to_kzg_commitment(
     KZGCommitment *out, const uint8_t *blob, const KZGSettings *s
 ) {
     C_KZG_RET ret;
@@ -907,7 +907,7 @@ static C_KZG_RET verify_kzg_proof_impl(
  * @param[in]  kzg_proof  The KZG proof
  * @param[in]  s          The trusted setup
  */
-C_KZG_RET VERIFY_KZG_PROOF(
+C_KZG_RET verify_kzg_proof(
     bool *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
@@ -996,7 +996,7 @@ static C_KZG_RET compute_kzg_proof_impl(
  * @param[in]  z         The generator z-value for the evaluation points
  * @param[in]  s         The trusted setup
  */
-C_KZG_RET COMPUTE_KZG_PROOF(
+C_KZG_RET compute_kzg_proof(
     KZGProof *proof_out,
     Bytes32 *y_out,
     const uint8_t *blob,
@@ -1128,7 +1128,7 @@ out:
  * @param[in]  commitment_bytes Commitment to verify
  * @param[in]  s                The trusted setup
  */
-C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
+C_KZG_RET compute_blob_kzg_proof(
     KZGProof *out,
     const uint8_t *blob,
     const Bytes48 *commitment_bytes,
@@ -1173,7 +1173,7 @@ out:
  * @param[in]  proof_bytes      Proof used for verification
  * @param[in]  s                The trusted setup
  */
-C_KZG_RET VERIFY_BLOB_KZG_PROOF(
+C_KZG_RET verify_blob_kzg_proof(
     bool *ok,
     const uint8_t *blob,
     const Bytes48 *commitment_bytes,
@@ -1397,7 +1397,7 @@ out:
  * @param[in]  n                 The number of blobs/commitments/proofs
  * @param[in]  s                 The trusted setup
  */
-C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
+C_KZG_RET verify_blob_kzg_proof_batch(
     bool *ok,
     const uint8_t *blobs,
     const Bytes48 *commitments_bytes,
@@ -1420,7 +1420,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
 
     /* For a single blob, just do a regular single verification */
     if (n == 1) {
-        return VERIFY_BLOB_KZG_PROOF(
+        return verify_blob_kzg_proof(
             ok, &blobs[0], &commitments_bytes[0], &proofs_bytes[0], s
         );
     }
@@ -1660,7 +1660,7 @@ out:
  *
  * @param[in] s The trusted setup to free
  */
-void FREE_TRUSTED_SETUP(KZGSettings *s) {
+void free_trusted_setup(KZGSettings *s) {
     if (s == NULL) return;
     s->field_elements_per_blob = 0;
     s->bytes_per_blob = 0;
@@ -1708,7 +1708,7 @@ static C_KZG_RET is_trusted_setup_in_lagrange_form(
  * @param[in]  g2_bytes Array of G2 points in monomial form
  * @param[in]  n2       Number of `g2` points in g2_bytes
  */
-C_KZG_RET LOAD_TRUSTED_SETUP(
+C_KZG_RET load_trusted_setup(
     KZGSettings *out,
     const uint8_t *g1_bytes,
     size_t n1,
@@ -1781,7 +1781,7 @@ out_error:
      * (roots_of_unity, g1_values, g2_values). It does not free the KZGSettings
      * structure memory. If necessary, that must be done by the caller.
      */
-    FREE_TRUSTED_SETUP(out);
+    free_trusted_setup(out);
 out_success:
     return ret;
 }
@@ -1799,7 +1799,7 @@ out_success:
  * @param[out] out Pointer to the loaded trusted setup data
  * @param[in]  in  File handle for input
  */
-C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in) {
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in) {
     C_KZG_RET ret;
     int num_matches;
     size_t size;
@@ -1863,7 +1863,7 @@ C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in) {
         }
     }
 
-    ret = LOAD_TRUSTED_SETUP(
+    ret = load_trusted_setup(
         out, g1_bytes, num_g1_points, g2_bytes, num_g2_points
     );
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1135,9 +1135,7 @@ C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
     compute_challenge(&evaluation_challenge_fr, blob, &commitment_g1);
 
     /* Call helper function to compute proof and y */
-    ret = compute_kzg_proof_impl(
-        out, &y, &poly, &evaluation_challenge_fr, s
-    );
+    ret = compute_kzg_proof_impl(out, &y, &poly, &evaluation_challenge_fr, s);
     if (ret != C_KZG_OK) goto out;
 
 out:
@@ -1418,7 +1416,9 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
         if (ret != C_KZG_OK) goto out;
 
         compute_challenge(
-            &evaluation_challenges_fr[i], &blobs[i * BYTES_PER_BLOB], &commitments_g1[i]
+            &evaluation_challenges_fr[i],
+            &blobs[i * BYTES_PER_BLOB],
+            &commitments_g1[i]
         );
 
         ret = evaluate_polynomial_in_evaluation_form(

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -66,10 +66,11 @@ static const char *RANDOM_CHALLENGE_KZG_BATCH_DOMAIN = "RCKZGBATCH___V1_";
 /** The number of bytes in a g2 point. */
 #define BYTES_PER_G2 96
 
-/** The number of g1 points in a trusted setup. */
-#define TRUSTED_SETUP_NUM_G1_POINTS FIELD_ELEMENTS_PER_BLOB
-
-/** The number of g2 points in a trusted setup. */
+/** The number of G1 points in the mainnet config. */
+#define TRUSTED_SETUP_NUM_G1_POINTS_MAINNET 4096
+/** The number of G1 points in the minimal config. */
+#define TRUSTED_SETUP_NUM_G1_POINTS_MINIMAL 4
+/** The number of G2 points in mainnet/minimal configs. */
 #define TRUSTED_SETUP_NUM_G2_POINTS 65
 
 // clang-format off
@@ -1812,7 +1813,8 @@ C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in) {
         ret = C_KZG_BADARGS;
         goto out;
     }
-    if (num_g1_points != 4096 && num_g1_points != 4) {
+    if (num_g1_points != TRUSTED_SETUP_NUM_G1_POINTS_MAINNET &&
+        num_g1_points != TRUSTED_SETUP_NUM_G1_POINTS_MINIMAL) {
         ret = C_KZG_BADARGS;
         goto out;
     }
@@ -1824,7 +1826,7 @@ C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in) {
         ret = C_KZG_BADARGS;
         goto out;
     }
-    if (num_g2_points != 65) {
+    if (num_g2_points != TRUSTED_SETUP_NUM_G2_POINTS) {
         ret = C_KZG_BADARGS;
         goto out;
     }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -842,9 +842,7 @@ out:
 static C_KZG_RET poly_to_kzg_commitment(
     g1_t *out, const fr_t *poly, const KZGSettings *s
 ) {
-    return g1_lincomb_fast(
-        out, s->g1_values, poly, FIELD_ELEMENTS_PER_BLOB
-    );
+    return g1_lincomb_fast(out, s->g1_values, poly, FIELD_ELEMENTS_PER_BLOB);
 }
 
 /**

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1389,6 +1389,7 @@ out:
  * read off a length field in the protocol.
  *
  * @remark This function accepts if called with `n==0`.
+ * @remark Blobs must be a flattened array of bytes, not pointers.
  *
  * @param[out] ok                True if the proofs are valid, otherwise false
  * @param[in]  blobs             Array of blobs to verify

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -62,36 +62,6 @@ extern "C" {
 #define LOAD_TRUSTED_SETUP_FILE PREFIX_FUNCNAME(load_trusted_setup_file)
 #define FREE_TRUSTED_SETUP PREFIX_FUNCNAME(free_trusted_setup)
 
-/*
- * This value represents the number of field elements in a blob. It must be
- * supplied externally. It is expected to be 4096 for mainnet and 4 for minimal.
- */
-#ifndef FIELD_ELEMENTS_PER_BLOB
-#error FIELD_ELEMENTS_PER_BLOB must be defined
-#endif /* FIELD_ELEMENTS_PER_BLOB */
-
-/*
- * There are only 1<<32 2-adic roots of unity in the field, limiting the
- * possible values of FIELD_ELEMENTS_PER_BLOB. The restriction to 1<<31 is a
- * current implementation limitation. Notably, the size of the FFT setup would
- * overflow uint32_t, which would cause issues.
- */
-#if FIELD_ELEMENTS_PER_BLOB <= 0 || FIELD_ELEMENTS_PER_BLOB > (1UL << 31)
-#error FIELD_ELEMENTS_PER_BLOB must be between 1 and 2^31
-#endif /* FIELD_ELEMENTS_PER_BLOB */
-
-/*
- * If FIELD_ELEMENTS_PER_BLOB is not a power of 2, the size of the FFT domain
- * should be chosen as the the next-largest power of two and polynomials
- * represented by their evaluations at a subset of the 2^i'th roots of unity.
- * While the code in this library tries to take this into account, we do not
- * need the case where FIELD_ELEMENTS_PER_BLOB is not a power of 2. As this
- * case is neither maintained nor tested, we prefer to not support it.
- */
-#if (FIELD_ELEMENTS_PER_BLOB & (FIELD_ELEMENTS_PER_BLOB - 1)) != 0
-#error FIELD_ELEMENTS_PER_BLOB must be a power of two
-#endif /* FIELD_ELEMENTS_PER_BLOB */
-
 /** The number of bytes in a KZG commitment. */
 #define BYTES_PER_COMMITMENT 48
 
@@ -100,9 +70,6 @@ extern "C" {
 
 /** The number of bytes in a BLS scalar field element. */
 #define BYTES_PER_FIELD_ELEMENT 32
-
-/** The number of bytes in a blob. */
-#define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Types

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -152,6 +152,10 @@ typedef enum {
  * Stores the setup and parameters needed for computing KZG proofs.
  */
 typedef struct {
+    /** Number of field elements in a blob. */
+    uint64_t field_elements_per_blob;
+    /** Number of bytes in a blob. */
+    uint64_t bytes_per_blob;
     /** The length of `roots_of_unity`, a power of 2. */
     uint64_t max_width;
     /** Powers of the primitive root of unity determined by

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -36,32 +36,6 @@ extern "C" {
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
 
-/*
- * Helper function for when LIB_PREFIX is defined.
- */
-#ifdef LIB_PREFIX
-#define CONCAT_IMPL(a, b) a##_##b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define PREFIX_FUNCNAME(name) CONCAT(LIB_PREFIX, name)
-#else
-#define PREFIX_FUNCNAME(name) (name)
-#endif /* LIB_PREFIX */
-
-/*
- * If LIB_PREFIX is defined, the following functions will prepend `LIB_PREFIX`
- * to all public methods of this library. If LIB_PREFIX is undefined,
- * everything stays as is.
- */
-#define BLOB_TO_KZG_COMMITMENT PREFIX_FUNCNAME(blob_to_kzg_commitment)
-#define COMPUTE_KZG_PROOF PREFIX_FUNCNAME(compute_kzg_proof)
-#define COMPUTE_BLOB_KZG_PROOF PREFIX_FUNCNAME(compute_blob_kzg_proof)
-#define VERIFY_KZG_PROOF PREFIX_FUNCNAME(verify_kzg_proof)
-#define VERIFY_BLOB_KZG_PROOF PREFIX_FUNCNAME(verify_blob_kzg_proof)
-#define VERIFY_BLOB_KZG_PROOF_BATCH PREFIX_FUNCNAME(verify_blob_kzg_proof_batch)
-#define LOAD_TRUSTED_SETUP PREFIX_FUNCNAME(load_trusted_setup)
-#define LOAD_TRUSTED_SETUP_FILE PREFIX_FUNCNAME(load_trusted_setup_file)
-#define FREE_TRUSTED_SETUP PREFIX_FUNCNAME(free_trusted_setup)
-
 /** The number of bytes in a KZG commitment. */
 #define BYTES_PER_COMMITMENT 48
 
@@ -140,7 +114,7 @@ typedef struct {
 // Interface functions
 ///////////////////////////////////////////////////////////////////////////////
 
-C_KZG_RET LOAD_TRUSTED_SETUP(
+C_KZG_RET load_trusted_setup(
     KZGSettings *out,
     const uint8_t *g1_bytes, /* n1 * 48 bytes */
     size_t n1,
@@ -148,15 +122,15 @@ C_KZG_RET LOAD_TRUSTED_SETUP(
     size_t n2
 );
 
-C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in);
+C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in);
 
-void FREE_TRUSTED_SETUP(KZGSettings *s);
+void free_trusted_setup(KZGSettings *s);
 
-C_KZG_RET BLOB_TO_KZG_COMMITMENT(
+C_KZG_RET blob_to_kzg_commitment(
     KZGCommitment *out, const uint8_t *blob, const KZGSettings *s
 );
 
-C_KZG_RET COMPUTE_KZG_PROOF(
+C_KZG_RET compute_kzg_proof(
     KZGProof *proof_out,
     Bytes32 *y_out,
     const uint8_t *blob,
@@ -164,14 +138,14 @@ C_KZG_RET COMPUTE_KZG_PROOF(
     const KZGSettings *s
 );
 
-C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
+C_KZG_RET compute_blob_kzg_proof(
     KZGProof *out,
     const uint8_t *blob,
     const Bytes48 *commitment_bytes,
     const KZGSettings *s
 );
 
-C_KZG_RET VERIFY_KZG_PROOF(
+C_KZG_RET verify_kzg_proof(
     bool *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
@@ -180,7 +154,7 @@ C_KZG_RET VERIFY_KZG_PROOF(
     const KZGSettings *s
 );
 
-C_KZG_RET VERIFY_BLOB_KZG_PROOF(
+C_KZG_RET verify_blob_kzg_proof(
     bool *ok,
     const uint8_t *blob,
     const Bytes48 *commitment_bytes,
@@ -188,7 +162,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF(
     const KZGSettings *s
 );
 
-C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
+C_KZG_RET verify_blob_kzg_proof_batch(
     bool *ok,
     const uint8_t *blobs,
     const Bytes48 *commitments_bytes,

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -129,13 +129,6 @@ typedef struct {
 } Bytes48;
 
 /**
- * A basic blob data.
- */
-typedef struct {
-    uint8_t bytes[BYTES_PER_BLOB];
-} Blob;
-
-/**
  * A trusted (valid) KZG commitment.
  */
 typedef Bytes48 KZGCommitment;
@@ -189,20 +182,20 @@ C_KZG_RET LOAD_TRUSTED_SETUP_FILE(KZGSettings *out, FILE *in);
 void FREE_TRUSTED_SETUP(KZGSettings *s);
 
 C_KZG_RET BLOB_TO_KZG_COMMITMENT(
-    KZGCommitment *out, const Blob *blob, const KZGSettings *s
+    KZGCommitment *out, const uint8_t *blob, const KZGSettings *s
 );
 
 C_KZG_RET COMPUTE_KZG_PROOF(
     KZGProof *proof_out,
     Bytes32 *y_out,
-    const Blob *blob,
+    const uint8_t *blob,
     const Bytes32 *z_bytes,
     const KZGSettings *s
 );
 
 C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
     KZGProof *out,
-    const Blob *blob,
+    const uint8_t *blob,
     const Bytes48 *commitment_bytes,
     const KZGSettings *s
 );
@@ -218,7 +211,7 @@ C_KZG_RET VERIFY_KZG_PROOF(
 
 C_KZG_RET VERIFY_BLOB_KZG_PROOF(
     bool *ok,
-    const Blob *blob,
+    const uint8_t *blob,
     const Bytes48 *commitment_bytes,
     const Bytes48 *proof_bytes,
     const KZGSettings *s
@@ -226,7 +219,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF(
 
 C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
     bool *ok,
-    const Blob *blobs,
+    const uint8_t *blobs,
     const Bytes48 *commitments_bytes,
     const Bytes48 *proofs_bytes,
     size_t n,

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -16,16 +16,22 @@
 // Macros
 ///////////////////////////////////////////////////////////////////////////////
 
-#if FIELD_ELEMENTS_PER_BLOB == 4096
+#if defined(MAINNET) && defined(MINIMAL)
+#error Cannot have both defined at the same time
+#endif
+
+#if !defined(MAINNET) && !defined(MINIMAL)
 #define MAINNET
+#endif
+
+#if defined(MAINNET)
 #define TRUSTED_SETUP_FILE "trusted_setup.txt"
 #define MAX_WIDTH 32
-#elif FIELD_ELEMENTS_PER_BLOB == 4
-#define MINIMAL
+#elif defined(MINIMAL)
 #define TRUSTED_SETUP_FILE "trusted_setup_4.txt"
 #define MAX_WIDTH 4
 #else
-#error FIELD_ELEMENTS_PER_BLOB must be 4096 or 4
+#error Must define either MAINNET or MINIMAL
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -986,17 +986,17 @@ static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial(
     void
 ) {
     C_KZG_RET ret;
-    Polynomial p;
+    Polynomial poly;
     fr_t x, y, c;
 
     get_rand_fr(&c);
     get_rand_fr(&x);
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        p.evals[i] = c;
+        poly.evals[i] = c;
     }
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, &poly, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation matches constant", fr_equal(&y, &c));
@@ -1006,17 +1006,17 @@ static void
 test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_range(void
 ) {
     C_KZG_RET ret;
-    Polynomial p;
+    Polynomial poly;
     fr_t x, y, c;
 
     get_rand_fr(&c);
     x = s.roots_of_unity[123];
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        p.evals[i] = c;
+        poly.evals[i] = c;
     }
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, &poly, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation matches constant", fr_equal(&y, &c));
@@ -1026,7 +1026,7 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void
 ) {
     C_KZG_RET ret;
     fr_t poly_coefficients[FIELD_ELEMENTS_PER_BLOB];
-    Polynomial p;
+    Polynomial poly;
     fr_t x, y, check;
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
@@ -1034,13 +1034,13 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void
     }
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        eval_poly(&p.evals[i], poly_coefficients, &s.roots_of_unity[i]);
+        eval_poly(&poly.evals[i], poly_coefficients, &s.roots_of_unity[i]);
     }
 
     get_rand_fr(&x);
     eval_poly(&check, poly_coefficients, &x);
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, &poly, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation methods match", fr_equal(&y, &check));
@@ -1049,7 +1049,7 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void
 
     eval_poly(&check, poly_coefficients, &x);
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, &poly, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation methods match", fr_equal(&y, &check));

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -74,7 +74,7 @@ static void get_rand_g1_bytes(Bytes48 *out) {
     C_KZG_RET ret;
     uint8_t *blob = NULL;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
@@ -428,7 +428,7 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
     uint8_t *blob = NULL;
     Bytes32 field_element;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
@@ -442,7 +442,7 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000"
     );
 
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
@@ -454,7 +454,7 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
     uint8_t *blob = NULL;
     Bytes32 field_element;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
@@ -468,7 +468,7 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
 
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
@@ -480,7 +480,7 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
     uint8_t *blob = NULL;
     Bytes32 field_element;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
@@ -494,7 +494,7 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002"
     );
 
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
@@ -507,11 +507,11 @@ static void test_blob_to_kzg_commitment__succeeds_point_at_infinity(void) {
     Bytes48 point_at_infinity;
     int diff;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Get the commitment for a blob that's all zeros */
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
@@ -533,7 +533,7 @@ static void test_blob_to_kzg_commitment__succeeds_expected_commitment(void) {
     Bytes48 expected_commitment;
     int diff;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
@@ -542,7 +542,7 @@ static void test_blob_to_kzg_commitment__succeeds_expected_commitment(void) {
     );
 
     /* Initialize the blob with a single field element */
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
 
     /* Get a commitment to this particular blob */
@@ -1128,7 +1128,7 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     Bytes48 proof, expected_proof;
     int diff;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
     ASSERT_EQUALS(ret, C_KZG_OK);
@@ -1143,7 +1143,7 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     );
 
     /* Initialize the blob with a single field element */
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
 
     /* Compute the KZG proof for the given blob & z */
@@ -1195,7 +1195,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
     bool ok;
     int diff;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
     ASSERT_EQUALS(ret, C_KZG_OK);
@@ -1251,7 +1251,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         bool ok;
         int diff;
 
-        ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+        ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
         ASSERT_EQUALS(ret, C_KZG_OK);
@@ -1302,7 +1302,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
     fr_t y_fr, z_fr;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
     ASSERT_EQUALS(ret, C_KZG_OK);
@@ -1439,7 +1439,7 @@ static void test_compute_and_verify_blob_kzg_proof__succeeds_round_trip(void) {
     uint8_t *blob = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
@@ -1466,7 +1466,7 @@ static void test_compute_and_verify_blob_kzg_proof__fails_incorrect_proof(void
     uint8_t *blob = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
@@ -1498,7 +1498,7 @@ static void test_compute_and_verify_blob_kzg_proof__fails_proof_not_in_g1(void
     uint8_t *blob = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
@@ -1523,7 +1523,7 @@ test_compute_and_verify_blob_kzg_proof__fails_compute_commitment_not_in_g1(void
     KZGCommitment c;
     uint8_t *blob = NULL;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
@@ -1548,7 +1548,7 @@ test_compute_and_verify_blob_kzg_proof__fails_verify_commitment_not_in_g1(void
     uint8_t *blob = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
@@ -1573,14 +1573,14 @@ static void test_compute_and_verify_blob_kzg_proof__fails_invalid_blob(void) {
     uint8_t *blob = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
         &field_element,
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
-    memset(blob, 0, BYTES_PER_BLOB);
+    memset(blob, 0, s.bytes_per_blob);
     memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     get_rand_g1_bytes(&c);
     get_rand_g1_bytes(&proof);
@@ -1603,18 +1603,18 @@ static void test_verify_kzg_proof_batch__succeeds_round_trip(void) {
     bool ok;
 
     /* Allocate blobs because they are big */
-    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n_samples * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         ret = blob_to_kzg_commitment(
-            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+            &commitments[i], &blobs[i * s.bytes_per_blob], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
+            &proofs[i], &blobs[i * s.bytes_per_blob], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1641,18 +1641,18 @@ static void test_verify_kzg_proof_batch__fails_with_incorrect_proof(void) {
     uint8_t *blobs = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n_samples * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         ret = blob_to_kzg_commitment(
-            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+            &commitments[i], &blobs[i * s.bytes_per_blob], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
+            &proofs[i], &blobs[i * s.bytes_per_blob], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1675,18 +1675,18 @@ static void test_verify_kzg_proof_batch__fails_proof_not_in_g1(void) {
     uint8_t *blobs = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n_samples * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         ret = blob_to_kzg_commitment(
-            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+            &commitments[i], &blobs[i * s.bytes_per_blob], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
+            &proofs[i], &blobs[i * s.bytes_per_blob], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1712,18 +1712,18 @@ static void test_verify_kzg_proof_batch__fails_commitment_not_in_g1(void) {
     uint8_t *blobs = NULL;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n_samples * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         ret = blob_to_kzg_commitment(
-            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+            &commitments[i], &blobs[i * s.bytes_per_blob], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
+            &proofs[i], &blobs[i * s.bytes_per_blob], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1750,18 +1750,18 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
     Bytes32 field_element;
     bool ok;
 
-    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n_samples * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         ret = blob_to_kzg_commitment(
-            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+            &commitments[i], &blobs[i * s.bytes_per_blob], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
+            &proofs[i], &blobs[i * s.bytes_per_blob], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1772,7 +1772,9 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
     memcpy(
-        &blobs[1 * BYTES_PER_BLOB], field_element.bytes, BYTES_PER_FIELD_ELEMENT
+        &blobs[1 * s.bytes_per_blob],
+        field_element.bytes,
+        BYTES_PER_FIELD_ELEMENT
     );
 
     ret = verify_blob_kzg_proof_batch(
@@ -1824,7 +1826,7 @@ static void profile_blob_to_kzg_commitment(void) {
     uint8_t *blob = NULL;
     KZGCommitment c;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_blob(blob);
@@ -1841,7 +1843,7 @@ static void profile_compute_kzg_proof(void) {
     Bytes32 z, y_out;
     KZGProof proof_out;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_blob(blob);
@@ -1859,7 +1861,7 @@ static void profile_compute_blob_kzg_proof(void) {
     Bytes48 commitment;
     KZGProof out;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_blob(blob);
@@ -1894,7 +1896,7 @@ static void profile_verify_blob_kzg_proof(void) {
     Bytes48 commitment, proof;
     bool out;
 
-    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_blob(blob);
@@ -1915,11 +1917,11 @@ static void profile_verify_blob_kzg_proof_batch(void) {
     Bytes48 proofs[n];
     bool out;
 
-    ret = c_kzg_malloc((void **)&blobs, n * BYTES_PER_BLOB);
+    ret = c_kzg_malloc((void **)&blobs, n * s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     for (int i = 0; i < n; i++) {
-        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        get_rand_blob(&blobs[i * s.bytes_per_blob]);
         get_rand_g1_bytes(&commitments[i]);
         get_rand_g1_bytes(&proofs[i]);
     }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1592,7 +1592,9 @@ static void test_verify_kzg_proof_batch__succeeds_round_trip(void) {
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
         get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
+        ret = blob_to_kzg_commitment(
+            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+        );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
             &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
@@ -1628,7 +1630,9 @@ static void test_verify_kzg_proof_batch__fails_with_incorrect_proof(void) {
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
         get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
+        ret = blob_to_kzg_commitment(
+            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+        );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
             &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
@@ -1660,7 +1664,9 @@ static void test_verify_kzg_proof_batch__fails_proof_not_in_g1(void) {
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
         get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
+        ret = blob_to_kzg_commitment(
+            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+        );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
             &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
@@ -1695,7 +1701,9 @@ static void test_verify_kzg_proof_batch__fails_commitment_not_in_g1(void) {
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
         get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
+        ret = blob_to_kzg_commitment(
+            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+        );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
             &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
@@ -1731,7 +1739,9 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
         get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
+        ret = blob_to_kzg_commitment(
+            &commitments[i], &blobs[i * BYTES_PER_BLOB], &s
+        );
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
             &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
@@ -1744,7 +1754,9 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
         &field_element,
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
-    memcpy(&blobs[1 * BYTES_PER_BLOB], field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    memcpy(
+        &blobs[1 * BYTES_PER_BLOB], field_element.bytes, BYTES_PER_FIELD_ELEMENT
+    );
 
     ret = verify_blob_kzg_proof_batch(
         &ok, blobs, commitments, proofs, n_samples, &s

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1166,7 +1166,7 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     ASSERT_EQUALS(diff, 0);
 
     /* Get the expected y by evaluating the polynomial at input_value */
-    ret = blob_to_polynomial(poly, blob);
+    ret = blob_to_polynomial(poly, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ret = bytes_to_bls_field(&z_fr, &input_value);
@@ -1215,7 +1215,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(poly, blob);
+    ret = blob_to_polynomial(poly, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */
@@ -1263,7 +1263,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Get the polynomial version of the blob */
-        ret = blob_to_polynomial(poly, blob);
+        ret = blob_to_polynomial(poly, blob, &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         z_fr = s.roots_of_unity[i];
@@ -1322,7 +1322,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(poly, blob);
+    ret = blob_to_polynomial(poly, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -64,22 +64,25 @@ static void get_rand_fr(fr_t *out) {
     hash_to_bls_field(out, &tmp_bytes);
 }
 
-static void get_rand_blob(Blob *out) {
+static void get_rand_blob(uint8_t *out) {
     for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        get_rand_field_element((Bytes32 *)&out->bytes[i * 32]);
+        get_rand_field_element((Bytes32 *)&out[i * 32]);
     }
 }
 
 static void get_rand_g1_bytes(Bytes48 *out) {
     C_KZG_RET ret;
-    Blob blob;
+    uint8_t *blob = NULL;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * Get the commitment to a random blob.
      * This commitment is a valid g1 point.
      */
-    get_rand_blob(&blob);
-    ret = blob_to_kzg_commitment(out, &blob, &s);
+    get_rand_blob(blob);
+    ret = blob_to_kzg_commitment(out, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
 
@@ -422,8 +425,11 @@ static void test_pairings_verify__bad_pairing(void) {
 static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes32 field_element;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -436,17 +442,20 @@ static void test_blob_to_kzg_commitment__succeeds_x_less_than_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000"
     );
 
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 }
 
 static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes32 field_element;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -459,17 +468,20 @@ static void test_blob_to_kzg_commitment__fails_x_equal_to_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
 
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
     C_KZG_RET ret;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes32 field_element;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * A valid field element is x < BLS_MODULUS.
@@ -482,22 +494,25 @@ static void test_blob_to_kzg_commitment__fails_x_greater_than_modulus(void) {
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002"
     );
 
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
 static void test_blob_to_kzg_commitment__succeeds_point_at_infinity(void) {
     C_KZG_RET ret;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes48 point_at_infinity;
     int diff;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Get the commitment for a blob that's all zeros */
-    memset(&blob, 0, sizeof(blob));
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    memset(blob, 0, BYTES_PER_BLOB);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* The commitment should be the serialized point at infinity */
@@ -513,10 +528,13 @@ static void test_blob_to_kzg_commitment__succeeds_point_at_infinity(void) {
 static void test_blob_to_kzg_commitment__succeeds_expected_commitment(void) {
     C_KZG_RET ret;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes32 field_element;
     Bytes48 expected_commitment;
     int diff;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
         &field_element,
@@ -524,11 +542,11 @@ static void test_blob_to_kzg_commitment__succeeds_expected_commitment(void) {
     );
 
     /* Initialize the blob with a single field element */
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
 
     /* Get a commitment to this particular blob */
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
@@ -1094,12 +1112,15 @@ static void test_is_power_of_two__fails_not_powers_of_two(void) {
 
 static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     C_KZG_RET ret;
-    Blob blob;
+    uint8_t *blob = NULL;
     Polynomial poly;
     fr_t y_fr, z_fr;
     Bytes32 input_value, output_value, field_element, expected_output_value;
     Bytes48 proof, expected_proof;
     int diff;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
         &field_element,
@@ -1111,11 +1132,11 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     );
 
     /* Initialize the blob with a single field element */
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
 
     /* Compute the KZG proof for the given blob & z */
-    ret = compute_kzg_proof(&proof, &output_value, &blob, &input_value, &s);
+    ret = compute_kzg_proof(&proof, &output_value, blob, &input_value, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes48_from_hex(
@@ -1134,7 +1155,7 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     ASSERT_EQUALS(diff, 0);
 
     /* Get the expected y by evaluating the polynomial at input_value */
-    ret = blob_to_polynomial(&poly, &blob);
+    ret = blob_to_polynomial(&poly, blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ret = bytes_to_bls_field(&z_fr, &input_value);
@@ -1157,28 +1178,31 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
     Bytes48 proof;
     Bytes32 z, y, computed_y;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Polynomial poly;
     fr_t y_fr, z_fr;
     bool ok;
     int diff;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     get_rand_field_element(&z);
-    get_rand_blob(&blob);
+    get_rand_blob(blob);
 
     /* Get a commitment to that particular blob */
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Compute the proof */
-    ret = compute_kzg_proof(&proof, &computed_y, &blob, &z, &s);
+    ret = compute_kzg_proof(&proof, &computed_y, blob, &z, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(&poly, &blob);
+    ret = blob_to_polynomial(&poly, blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */
@@ -1205,7 +1229,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
 static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
     for (int i = 0; i < 25; i++) {
         C_KZG_RET ret;
-        Blob blob;
+        uint8_t *blob = NULL;
         KZGCommitment c;
         Polynomial poly;
         Bytes48 proof;
@@ -1214,21 +1238,24 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         bool ok;
         int diff;
 
-        get_rand_blob(&blob);
+        ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+
+        get_rand_blob(blob);
 
         /* Get a commitment to that particular blob */
-        ret = blob_to_kzg_commitment(&c, &blob, &s);
+        ret = blob_to_kzg_commitment(&c, blob, &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Get the polynomial version of the blob */
-        ret = blob_to_polynomial(&poly, &blob);
+        ret = blob_to_polynomial(&poly, blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         z_fr = s.roots_of_unity[i];
         bytes_from_bls_field(&z, &z_fr);
 
         /* Compute the proof */
-        ret = compute_kzg_proof(&proof, &computed_y, &blob, &z, &s);
+        ret = compute_kzg_proof(&proof, &computed_y, blob, &z, &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Now evaluate the poly at `z` to learn `y` */
@@ -1255,27 +1282,30 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
     g1_t proof_g1;
     Bytes32 z, y, computed_y;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     Polynomial poly;
     fr_t y_fr, z_fr;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     get_rand_field_element(&z);
-    get_rand_blob(&blob);
+    get_rand_blob(blob);
 
     /* Get a commitment to that particular blob */
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Compute the proof */
-    ret = compute_kzg_proof(&proof, &computed_y, &blob, &z, &s);
+    ret = compute_kzg_proof(&proof, &computed_y, blob, &z, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /*
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(&poly, &blob);
+    ret = blob_to_polynomial(&poly, blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */
@@ -1389,20 +1419,23 @@ static void test_compute_and_verify_blob_kzg_proof__succeeds_round_trip(void) {
     C_KZG_RET ret;
     Bytes48 proof;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Some preparation */
-    get_rand_blob(&blob);
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    get_rand_blob(blob);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Compute the proof */
-    ret = compute_blob_kzg_proof(&proof, &blob, &c, &s);
+    ret = compute_blob_kzg_proof(&proof, blob, &c, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Finally verify the proof */
-    ret = verify_blob_kzg_proof(&ok, &blob, &c, &proof, &s);
+    ret = verify_blob_kzg_proof(&ok, blob, &c, &proof, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ASSERT_EQUALS(ok, true);
 }
@@ -1413,16 +1446,19 @@ static void test_compute_and_verify_blob_kzg_proof__fails_incorrect_proof(void
     Bytes48 proof;
     g1_t proof_g1;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Some preparation */
-    get_rand_blob(&blob);
-    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    get_rand_blob(blob);
+    ret = blob_to_kzg_commitment(&c, blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Compute the proof */
-    ret = compute_blob_kzg_proof(&proof, &blob, &c, &s);
+    ret = compute_blob_kzg_proof(&proof, blob, &c, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Change the proof so it should not verify */
@@ -1432,7 +1468,7 @@ static void test_compute_and_verify_blob_kzg_proof__fails_incorrect_proof(void
     bytes_from_g1(&proof, &proof_g1);
 
     /* Finally verify the proof */
-    ret = verify_blob_kzg_proof(&ok, &blob, &c, &proof, &s);
+    ret = verify_blob_kzg_proof(&ok, blob, &c, &proof, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ASSERT_EQUALS(ok, false);
 }
@@ -1442,11 +1478,14 @@ static void test_compute_and_verify_blob_kzg_proof__fails_proof_not_in_g1(void
     C_KZG_RET ret;
     Bytes48 proof;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Some preparation */
-    get_rand_blob(&blob);
+    get_rand_blob(blob);
     get_rand_g1_bytes(&c);
     bytes48_from_hex(
         &proof,
@@ -1455,7 +1494,7 @@ static void test_compute_and_verify_blob_kzg_proof__fails_proof_not_in_g1(void
     );
 
     /* Finally verify the proof */
-    ret = verify_blob_kzg_proof(&ok, &blob, &c, &proof, &s);
+    ret = verify_blob_kzg_proof(&ok, blob, &c, &proof, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
@@ -1465,10 +1504,13 @@ test_compute_and_verify_blob_kzg_proof__fails_compute_commitment_not_in_g1(void
     C_KZG_RET ret;
     Bytes48 proof;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
-    get_rand_blob(&blob);
+    get_rand_blob(blob);
     bytes48_from_hex(
         &c,
         "8123456789abcdef0123456789abcdef0123456789abcdef"
@@ -1476,7 +1518,7 @@ test_compute_and_verify_blob_kzg_proof__fails_compute_commitment_not_in_g1(void
     );
 
     /* Finally compute the proof */
-    ret = compute_blob_kzg_proof(&proof, &blob, &c, &s);
+    ret = compute_blob_kzg_proof(&proof, blob, &c, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
@@ -1486,11 +1528,14 @@ test_compute_and_verify_blob_kzg_proof__fails_verify_commitment_not_in_g1(void
     C_KZG_RET ret;
     Bytes48 proof;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Some preparation */
-    get_rand_blob(&blob);
+    get_rand_blob(blob);
     bytes48_from_hex(
         &c,
         "8123456789abcdef0123456789abcdef0123456789abcdef"
@@ -1499,7 +1544,7 @@ test_compute_and_verify_blob_kzg_proof__fails_verify_commitment_not_in_g1(void
     get_rand_g1_bytes(&proof);
 
     /* Finally verify the proof */
-    ret = verify_blob_kzg_proof(&ok, &blob, &c, &proof, &s);
+    ret = verify_blob_kzg_proof(&ok, blob, &c, &proof, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
@@ -1508,20 +1553,23 @@ static void test_compute_and_verify_blob_kzg_proof__fails_invalid_blob(void) {
     Bytes48 proof;
     Bytes32 field_element;
     KZGCommitment c;
-    Blob blob;
+    uint8_t *blob = NULL;
     bool ok;
+
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
         &field_element,
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
-    memset(&blob, 0, sizeof(blob));
-    memcpy(blob.bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    memset(blob, 0, BYTES_PER_BLOB);
+    memcpy(blob, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
     get_rand_g1_bytes(&c);
     get_rand_g1_bytes(&proof);
 
     /* Finally verify the proof */
-    ret = verify_blob_kzg_proof(&ok, &blob, &c, &proof, &s);
+    ret = verify_blob_kzg_proof(&ok, blob, &c, &proof, &s);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
@@ -1534,20 +1582,20 @@ static void test_verify_kzg_proof_batch__succeeds_round_trip(void) {
     const int n_samples = 16;
     Bytes48 proofs[n_samples];
     KZGCommitment commitments[n_samples];
-    Blob *blobs = NULL;
+    uint8_t *blobs = NULL;
     bool ok;
 
     /* Allocate blobs because they are big */
-    ret = c_kzg_malloc((void **)&blobs, n_samples * sizeof(Blob));
+    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i], &s);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i], &commitments[i], &s
+            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1571,16 +1619,19 @@ static void test_verify_kzg_proof_batch__fails_with_incorrect_proof(void) {
     const int n_samples = 2;
     Bytes48 proofs[n_samples];
     KZGCommitment commitments[n_samples];
-    Blob blobs[n_samples];
+    uint8_t *blobs = NULL;
     bool ok;
+
+    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i], &s);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i], &commitments[i], &s
+            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1600,16 +1651,19 @@ static void test_verify_kzg_proof_batch__fails_proof_not_in_g1(void) {
     const int n_samples = 2;
     Bytes48 proofs[n_samples];
     KZGCommitment commitments[n_samples];
-    Blob blobs[n_samples];
+    uint8_t *blobs = NULL;
     bool ok;
+
+    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i], &s);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i], &commitments[i], &s
+            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1632,16 +1686,19 @@ static void test_verify_kzg_proof_batch__fails_commitment_not_in_g1(void) {
     const int n_samples = 2;
     Bytes48 proofs[n_samples];
     KZGCommitment commitments[n_samples];
-    Blob blobs[n_samples];
+    uint8_t *blobs = NULL;
     bool ok;
+
+    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i], &s);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i], &commitments[i], &s
+            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1664,17 +1721,20 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
     const int n_samples = 2;
     Bytes48 proofs[n_samples];
     KZGCommitment commitments[n_samples];
-    Blob blobs[n_samples];
+    uint8_t *blobs = NULL;
     Bytes32 field_element;
     bool ok;
 
+    ret = c_kzg_malloc((void **)&blobs, n_samples * BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     /* Some preparation */
     for (int i = 0; i < n_samples; i++) {
-        get_rand_blob(&blobs[i]);
-        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i], &s);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
+        ret = blob_to_kzg_commitment(&commitments[i], &blobs[i * BYTES_PER_BLOB], &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
         ret = compute_blob_kzg_proof(
-            &proofs[i], &blobs[i], &commitments[i], &s
+            &proofs[i], &blobs[i * BYTES_PER_BLOB], &commitments[i], &s
         );
         ASSERT_EQUALS(ret, C_KZG_OK);
     }
@@ -1684,7 +1744,7 @@ static void test_verify_kzg_proof_batch__fails_invalid_blob(void) {
         &field_element,
         "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
     );
-    memcpy(blobs[1].bytes, field_element.bytes, BYTES_PER_FIELD_ELEMENT);
+    memcpy(&blobs[1 * BYTES_PER_BLOB], field_element.bytes, BYTES_PER_FIELD_ELEMENT);
 
     ret = verify_blob_kzg_proof_batch(
         &ok, blobs, commitments, proofs, n_samples, &s
@@ -1732,44 +1792,53 @@ static void test_expand_root_of_unity__fails_wrong_root_of_unity(void) {
 
 #ifdef PROFILE
 static void profile_blob_to_kzg_commitment(void) {
-    Blob blob;
+    uint8_t *blob = NULL;
     KZGCommitment c;
 
-    get_rand_blob(&blob);
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    get_rand_blob(blob);
 
     ProfilerStart("blob_to_kzg_commitment.prof");
     for (int i = 0; i < 1000; i++) {
-        blob_to_kzg_commitment(&c, &blob, &s);
+        blob_to_kzg_commitment(&c, blob, &s);
     }
     ProfilerStop();
 }
 
 static void profile_compute_kzg_proof(void) {
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes32 z, y_out;
     KZGProof proof_out;
 
-    get_rand_blob(&blob);
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    get_rand_blob(blob);
     get_rand_field_element(&z);
 
     ProfilerStart("compute_kzg_proof.prof");
     for (int i = 0; i < 100; i++) {
-        compute_kzg_proof(&proof_out, &y_out, &blob, &z, &s);
+        compute_kzg_proof(&proof_out, &y_out, blob, &z, &s);
     }
     ProfilerStop();
 }
 
 static void profile_compute_blob_kzg_proof(void) {
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes48 commitment;
     KZGProof out;
 
-    get_rand_blob(&blob);
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    get_rand_blob(blob);
     get_rand_g1_bytes(&commitment);
 
     ProfilerStart("compute_blob_kzg_proof.prof");
     for (int i = 0; i < 10; i++) {
-        compute_blob_kzg_proof(&out, &blob, &commitment, &s);
+        compute_blob_kzg_proof(&out, blob, &commitment, &s);
     }
     ProfilerStop();
 }
@@ -1792,30 +1861,36 @@ static void profile_verify_kzg_proof(void) {
 }
 
 static void profile_verify_blob_kzg_proof(void) {
-    Blob blob;
+    uint8_t *blob = NULL;
     Bytes48 commitment, proof;
     bool out;
 
-    get_rand_blob(&blob);
+    ret = c_kzg_malloc((void **)&blob, BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    get_rand_blob(blob);
     get_rand_g1_bytes(&commitment);
     get_rand_g1_bytes(&proof);
 
     ProfilerStart("verify_blob_kzg_proof.prof");
     for (int i = 0; i < 5000; i++) {
-        verify_blob_kzg_proof(&out, &blob, &commitment, &proof, &s);
+        verify_blob_kzg_proof(&out, blob, &commitment, &proof, &s);
     }
     ProfilerStop();
 }
 
 static void profile_verify_blob_kzg_proof_batch(void) {
     const int n = 16;
-    Blob blobs[n];
+    uint8_t *blobs = NULL;
     Bytes48 commitments[n];
     Bytes48 proofs[n];
     bool out;
 
+    ret = c_kzg_malloc((void **)&blobs, n * BYTES_PER_BLOB);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
     for (int i = 0; i < n; i++) {
-        get_rand_blob(&blobs[i]);
+        get_rand_blob(&blobs[i * BYTES_PER_BLOB]);
         get_rand_g1_bytes(&commitments[i]);
         get_rand_g1_bytes(&proofs[i]);
     }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -65,7 +65,7 @@ static void get_rand_fr(fr_t *out) {
 }
 
 static void get_rand_blob(uint8_t *out) {
-    for (int i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+    for (uint64_t i = 0; i < s.field_elements_per_blob; i++) {
         get_rand_field_element((Bytes32 *)&out[i * 32]);
     }
 }
@@ -125,8 +125,8 @@ static void get_rand_uint32(uint32_t *out) {
 }
 
 static void eval_poly(fr_t *out, fr_t *poly_coefficients, fr_t *x) {
-    *out = poly_coefficients[FIELD_ELEMENTS_PER_BLOB - 1];
-    for (size_t i = FIELD_ELEMENTS_PER_BLOB - 1; i > 0; i--) {
+    *out = poly_coefficients[s.field_elements_per_blob - 1];
+    for (size_t i = s.field_elements_per_blob - 1; i > 0; i--) {
         blst_fr_mul(out, out, x);
         blst_fr_add(out, out, &poly_coefficients[i - 1]);
     }
@@ -1007,13 +1007,13 @@ static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial(
     fr_t *poly = NULL;
     fr_t x, y, c;
 
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_fr(&c);
     get_rand_fr(&x);
 
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+    for (size_t i = 0; i < s.field_elements_per_blob; i++) {
         poly[i] = c;
     }
 
@@ -1030,13 +1030,13 @@ test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_range(void
     fr_t *poly = NULL;
     fr_t x, y, c;
 
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_fr(&c);
     x = s.roots_of_unity[123];
 
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+    for (size_t i = 0; i < s.field_elements_per_blob; i++) {
         poly[i] = c;
     }
 
@@ -1049,18 +1049,18 @@ test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_range(void
 static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void
 ) {
     C_KZG_RET ret;
-    fr_t poly_coefficients[FIELD_ELEMENTS_PER_BLOB];
+    fr_t poly_coefficients[s.field_elements_per_blob];
     fr_t *poly = NULL;
     fr_t x, y, check;
 
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+    for (size_t i = 0; i < s.field_elements_per_blob; i++) {
         get_rand_fr(&poly_coefficients[i]);
     }
 
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+    for (size_t i = 0; i < s.field_elements_per_blob; i++) {
         eval_poly(&poly[i], poly_coefficients, &s.roots_of_unity[i]);
     }
 
@@ -1130,7 +1130,7 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
 
     ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes32_from_hex(
@@ -1197,7 +1197,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
 
     ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_field_element(&z);
@@ -1253,7 +1253,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
 
         ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
-        ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+        ret = new_fr_array(&poly, s.field_elements_per_blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         get_rand_blob(blob);
@@ -1304,7 +1304,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
 
     ret = c_kzg_malloc((void **)&blob, s.bytes_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = new_fr_array(&poly, FIELD_ELEMENTS_PER_BLOB);
+    ret = new_fr_array(&poly, s.field_elements_per_blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     get_rand_field_element(&z);


### PR DESCRIPTION
With this PR, one build of c-kzg-4844 will work with both mainnet and minimal trusted setups. If merged, I will update the bindings in separate PRs. Until then, the CI tests for the bindings are expected to fail.
 
* Remove the `FIELD_ELEMENTS_PER_BLOB` macro (which was either 4096 or 4).
  * This is now accessible via `kzg_settings->field_elements_per_blob` after loading the trusted setup.
* Allocate blobs and polynomials on-demand on the heap.
  * We cannot allocate them on the stack anymore, since the count isn't a constant.
  * This will also reduce stack usage, which should prevent stack overflows.
* Remove type definitions for `Blob` and `Polynomial`.
  * It will now be up to the bindings to define the blob type.
  * I don't want to do `typedef uint8_t Blob` because that could be confusing.
* Remove the `LIB_PREFIX` hack for supporting both builds.
  * This is no longer necessary. 

For the tests:

* Use new `MAINNET` and `MINIMAL` macros to determine which to test.
* Replace stack allocated blobs/polynomials with heap allocated ones.