### PR TITLE
Return uint_8 instead of bool from all ckzg functions

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -43,8 +43,3 @@ glob = "0.3"
 [[bench]]
 name = "kzg_benches"
 harness = false
-
-# The benchmarks crash on Windows with Rust 1.70. This is a band-aid fix for
-# that. Refer to #318 for more details. This should be removed if fixed.
-[profile.bench]
-opt-level = 0

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -328,7 +328,7 @@ impl KZGProof {
         proof_bytes: Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
-        let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
+        let mut verified: MaybeUninit<u8> = MaybeUninit::uninit();
         unsafe {
             let res = verify_kzg_proof(
                 verified.as_mut_ptr(),
@@ -339,7 +339,11 @@ impl KZGProof {
                 kzg_settings,
             );
             if let C_KZG_RET::C_KZG_OK = res {
-                Ok(verified.assume_init())
+                if verified.assume_init() == 0 {
+                    return Ok(false);
+                } else {
+                    return Ok(true);
+                }
             } else {
                 Err(Error::CError(res))
             }
@@ -352,7 +356,7 @@ impl KZGProof {
         proof_bytes: Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
-        let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
+        let mut verified: MaybeUninit<u8> = MaybeUninit::uninit();
         unsafe {
             let res = verify_blob_kzg_proof(
                 verified.as_mut_ptr(),
@@ -362,7 +366,11 @@ impl KZGProof {
                 kzg_settings,
             );
             if let C_KZG_RET::C_KZG_OK = res {
-                Ok(verified.assume_init())
+                if verified.assume_init() == 0 {
+                    return Ok(false);
+                } else {
+                    return Ok(true);
+                }
             } else {
                 Err(Error::CError(res))
             }
@@ -389,7 +397,7 @@ impl KZGProof {
                 proofs_bytes.len()
             )));
         }
-        let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
+        let mut verified: MaybeUninit<u8> = MaybeUninit::uninit();
         unsafe {
             let res = verify_blob_kzg_proof_batch(
                 verified.as_mut_ptr(),
@@ -400,7 +408,11 @@ impl KZGProof {
                 kzg_settings,
             );
             if let C_KZG_RET::C_KZG_OK = res {
-                Ok(verified.assume_init())
+                if verified.assume_init() == 0 {
+                    return Ok(false);
+                } else {
+                    return Ok(true);
+                }
             } else {
                 Err(Error::CError(res))
             }

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -446,7 +446,7 @@ static void g2_sub(g2_t *out, const g2_t *a, const g2_t *b) {
  * @retval true  The pairings were equal
  * @retval false The pairings were not equal
  */
-uint8_t pairings_verify(
+static bool pairings_verify(
     const g1_t *a1, const g2_t *a2, const g1_t *b1, const g2_t *b2
 ) {
     blst_fp12 loop0, loop1, gt_point;

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -446,7 +446,7 @@ static void g2_sub(g2_t *out, const g2_t *a, const g2_t *b) {
  * @retval true  The pairings were equal
  * @retval false The pairings were not equal
  */
-static bool pairings_verify(
+uint8_t pairings_verify(
     const g1_t *a1, const g2_t *a2, const g1_t *b1, const g2_t *b2
 ) {
     blst_fp12 loop0, loop1, gt_point;
@@ -880,7 +880,7 @@ C_KZG_RET BLOB_TO_KZG_COMMITMENT(
 
 /* Forward function declaration */
 static C_KZG_RET verify_kzg_proof_impl(
-    bool *ok,
+    uint8_t *ok,
     const g1_t *commitment,
     const fr_t *z,
     const fr_t *y,
@@ -899,7 +899,7 @@ static C_KZG_RET verify_kzg_proof_impl(
  * @param[in]  s          The trusted setup
  */
 C_KZG_RET VERIFY_KZG_PROOF(
-    bool *ok,
+    uint8_t *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
     const Bytes32 *y_bytes,
@@ -910,7 +910,7 @@ C_KZG_RET VERIFY_KZG_PROOF(
     fr_t z_fr, y_fr;
     g1_t commitment_g1, proof_g1;
 
-    *ok = false;
+    *ok = 0;
 
     /* Convert untrusted inputs to trusted inputs */
     ret = bytes_to_kzg_commitment(&commitment_g1, commitment_bytes);
@@ -944,7 +944,7 @@ C_KZG_RET VERIFY_KZG_PROOF(
  * @param[in]  s          The trusted setup
  */
 static C_KZG_RET verify_kzg_proof_impl(
-    bool *ok,
+    uint8_t *ok,
     const g1_t *commitment,
     const fr_t *z,
     const fr_t *y,
@@ -1155,7 +1155,7 @@ out:
  * @param[in]  s                The trusted setup
  */
 C_KZG_RET VERIFY_BLOB_KZG_PROOF(
-    bool *ok,
+    uint8_t *ok,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
     const Bytes48 *proof_bytes,
@@ -1166,7 +1166,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF(
     fr_t evaluation_challenge_fr, y_fr;
     g1_t commitment_g1, proof_g1;
 
-    *ok = false;
+    *ok = 0;
 
     /* Do conversions first to fail fast, compute_challenge is expensive */
     ret = bytes_to_kzg_commitment(&commitment_g1, commitment_bytes);
@@ -1286,7 +1286,7 @@ out:
  * @param[in]  s              The trusted setup
  */
 static C_KZG_RET verify_kzg_proof_batch(
-    bool *ok,
+    uint8_t *ok,
     const g1_t *commitments_g1,
     const fr_t *zs_fr,
     const fr_t *ys_fr,
@@ -1302,7 +1302,7 @@ static C_KZG_RET verify_kzg_proof_batch(
 
     assert(n > 0);
 
-    *ok = false;
+    *ok = 0;
 
     /* First let's allocate our arrays */
     ret = new_fr_array(&r_powers, n);
@@ -1368,7 +1368,7 @@ out:
  * @param[in]  s                 The trusted setup
  */
 C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
-    bool *ok,
+    uint8_t *ok,
     const Blob *blobs,
     const Bytes48 *commitments_bytes,
     const Bytes48 *proofs_bytes,
@@ -1383,7 +1383,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
 
     /* Exit early if we are given zero blobs */
     if (n == 0) {
-        *ok = true;
+        *ok = 1;
         return C_KZG_OK;
     }
 
@@ -1653,7 +1653,7 @@ static C_KZG_RET is_trusted_setup_in_lagrange_form(
      * then the trusted setup was loaded in monomial form.
      * If so, error out since we want the trusted setup in Lagrange form.
      */
-    bool is_monomial_form = pairings_verify(
+    uint8_t is_monomial_form = pairings_verify(
         &s->g1_values[1], &s->g2_values[0], &s->g1_values[0], &s->g2_values[1]
     );
     return is_monomial_form ? C_KZG_BADARGS : C_KZG_OK;

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -208,7 +208,7 @@ C_KZG_RET COMPUTE_BLOB_KZG_PROOF(
 );
 
 C_KZG_RET VERIFY_KZG_PROOF(
-    bool *ok,
+    uint8_t *ok,
     const Bytes48 *commitment_bytes,
     const Bytes32 *z_bytes,
     const Bytes32 *y_bytes,
@@ -217,7 +217,7 @@ C_KZG_RET VERIFY_KZG_PROOF(
 );
 
 C_KZG_RET VERIFY_BLOB_KZG_PROOF(
-    bool *ok,
+    uint8_t *ok,
     const Blob *blob,
     const Bytes48 *commitment_bytes,
     const Bytes48 *proof_bytes,
@@ -225,7 +225,7 @@ C_KZG_RET VERIFY_BLOB_KZG_PROOF(
 );
 
 C_KZG_RET VERIFY_BLOB_KZG_PROOF_BATCH(
-    bool *ok,
+    uint8_t *ok,
     const Blob *blobs,
     const Bytes48 *commitments_bytes,
     const Bytes48 *proofs_bytes,


### PR DESCRIPTION
I think we might have finally found the root cause of all our windows rust issues.
Thanks to @michaelsproul for helping find this 🙏 

blst.h has this redefinition of bool 
https://github.com/supranational/blst/blob/78fee18b25e16975e27b2d0314f6a323a23e6e83/bindings/blst.h#L27-L31

Because we import `blst.h` In `c-kzg-4844.h`, `bool` in the c source code is redefined as an `int` on windows. So in the c interface for all `verify_*` functions, `bool *ok` is in fact `int *ok`.

When generating the rust bindings, bindgen made the stupid mistake of assuming that a bool in C would be a bool in rust. So on calling the underlying C function, rust allocates 1 byte for the bool type where C required 4. This is probably what was causing the undefined behaviour all this time.

Making this PR just to run CI on the issue. There's probably a better way of fixing this in C.

Running this with lighthouse on devnet 8. No crashes so far 🎉 