### PR TITLE
Set /std:c11 ccflag for Windows in Rust bindings

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -43,8 +43,3 @@ glob = "0.3"
 [[bench]]
 name = "kzg_benches"
 harness = false
-
-# The benchmarks crash on Windows with Rust 1.70. This is a band-aid fix for
-# that. Refer to #318 for more details. This should be removed if fixed.
-[profile.bench]
-opt-level = 0

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -30,7 +30,15 @@ fn main() {
     let mut cc = cc::Build::new();
 
     #[cfg(windows)]
-    cc.flag("-D_CRT_SECURE_NO_WARNINGS");
+    {
+        cc.flag("-D_CRT_SECURE_NO_WARNINGS");
+
+        // In blst, if __STDC_VERSION__ isn't defined as c99 or greater, it will typedef a bool to
+        // an int. There is a bug in bindgen associated with this. It assumes that a bool in C is
+        // the same size as a bool in Rust. This is the root cause of the issues on Windows. If/when
+        // this is fixed in bindgen, it should be safe to remove this compiler flag.
+        cc.flag("/std:c11");
+    }
 
     cc.include(blst_headers_dir.clone());
     cc.warnings(false);


### PR DESCRIPTION
This PR fixes our Windows issues. This is an alternative to #353.

See #353 for details about the problem. To be brief, if `__STDC_VERSION__` isn't defined as c99 or greater, blst will typedef a bool as an int (this check is [here](https://github.com/supranational/blst/blob/78fee18b25e16975e27b2d0314f6a323a23e6e83/bindings/blst.h#L28-L31) btw). There is a bug in bindgen associated with this. MSVC doesn't define `__STDC_VERSION__` by default, but we can use the `/std` flag to set it to `c11`, which is the earliest version it supports.

Fixes #318.
Fixes #331.

Big thanks to @pawanjay176 & @michaelsproul for identifying this.