### PR TITLE
Added AsRef<[u8]> method for Blob

### DIFF
--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -260,6 +260,12 @@ impl Blob {
     }
 }
 
+impl AsRef<[u8]> for Blob {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
 impl Bytes32 {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != 32 {


### PR DESCRIPTION
This is needed so that we can always store blobs in `c_kzg::Blob` form which allows us to eliminate a lot of copying of the blob bytes between formats.