### PR TITLE
Update java bindings to use runtime field count

### DIFF
--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   tests:

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -42,15 +42,7 @@ else
   GRADLE_COMMAND=./gradlew
 endif
 
-PRESET ?= mainnet
-
-ifeq ($(PRESET),minimal)
-  FIELD_ELEMENTS_PER_BLOB ?= 4
-else
-  FIELD_ELEMENTS_PER_BLOB ?= 4096
-endif
-
-LIBRARY_FOLDER=src/main/resources/ethereum/ckzg4844/lib/${OS_ARCH}/${PRESET}
+LIBRARY_FOLDER=src/main/resources/ethereum/ckzg4844/lib/${OS_ARCH}
 
 ifeq ($(JAVA_HOME),)
   $(error JAVA_HOME is not set and autodetection failed)
@@ -61,7 +53,7 @@ all: build test benchmark
 .PHONY: build
 build:
 	mkdir -p ${LIBRARY_FOLDER}
-	${CLANG_EXECUTABLE} ${CC_FLAGS} ${CLANG_FLAGS} ${OPTIMIZATION_LEVEL} -Wall -Wno-missing-braces ${addprefix -I,${INCLUDE_DIRS}} -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/${JNI_INCLUDE_FOLDER}" -DFIELD_ELEMENTS_PER_BLOB=${FIELD_ELEMENTS_PER_BLOB} -o ${LIBRARY_FOLDER}/${LIBRARY_RESOURCE} ${TARGETS}
+	${CLANG_EXECUTABLE} ${CC_FLAGS} ${CLANG_FLAGS} ${OPTIMIZATION_LEVEL} -Wall -Wno-missing-braces ${addprefix -I,${INCLUDE_DIRS}} -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/${JNI_INCLUDE_FOLDER}" -o ${LIBRARY_FOLDER}/${LIBRARY_RESOURCE} ${TARGETS}
 
 .PHONY: test
 test:

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -14,7 +14,7 @@ make build
 ```
 
 This will install the shared library in `src/main/resources/ethereum/ckzg4844/lib` with a folder
-structure and your OS.
+structure and name according to your OS.
 
 All variables which could be passed to the `make` command and the defaults can be found in
 the [Makefile](./Makefile).

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -14,8 +14,7 @@ make build
 ```
 
 This will install the shared library in `src/main/resources/ethereum/ckzg4844/lib` with a folder
-structure
-and name according to the preset selected (mainnet or minimal) and your OS.
+structure and your OS.
 
 All variables which could be passed to the `make` command and the defaults can be found in
 the [Makefile](./Makefile).

--- a/bindings/java/src/jmh/java/ethereum/ckzg4844/CKZG4844JNIBenchmark.java
+++ b/bindings/java/src/jmh/java/ethereum/ckzg4844/CKZG4844JNIBenchmark.java
@@ -1,6 +1,5 @@
 package ethereum.ckzg4844;
 
-import ethereum.ckzg4844.CKZG4844JNI.Preset;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -25,7 +24,7 @@ import org.openjdk.jmh.annotations.Warmup;
 public class CKZG4844JNIBenchmark {
 
   static {
-    CKZG4844JNI.loadNativeLibrary(Preset.MAINNET);
+    CKZG4844JNI.loadNativeLibrary();
   }
 
   @State(Scope.Benchmark)

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -81,8 +81,9 @@ public class CKZG4844JNI {
   }
 
   /**
-   * Retrieves the compile-time configured FIELD_ELEMENTS_PER_BLOB. The value will be based on the
-   * selected {@link Preset} when loading the native library.
+   * Retrieves the number of field elements in a blob. This is a runtime-configured value based on
+   * the trusted setup (either mainnet or minimal) that is loaded. Therefore, the trusted setup must
+   * be loaded prior to calling this method.
    *
    * @return the field elements per blob
    */

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -13,19 +13,10 @@ public class CKZG4844JNI {
   private static final String LIBRARY_NAME = "ckzg4844jni";
   private static final String PLATFORM_NATIVE_LIBRARY_NAME = System.mapLibraryName(LIBRARY_NAME);
 
-  /**
-   * Loads the appropriate native library based on your platform and the selected {@link Preset}
-   *
-   * @param preset the preset
-   */
-  public static void loadNativeLibrary(Preset preset) {
+  /** Loads the appropriate native library based on your platform. */
+  public static void loadNativeLibrary() {
     String libraryResourcePath =
-        "lib/"
-            + System.getProperty("os.arch")
-            + "/"
-            + preset.name().toLowerCase()
-            + "/"
-            + PLATFORM_NATIVE_LIBRARY_NAME;
+        "lib/" + System.getProperty("os.arch") + "/" + PLATFORM_NATIVE_LIBRARY_NAME;
     InputStream libraryResource = CKZG4844JNI.class.getResourceAsStream(libraryResourcePath);
     if (libraryResource == null) {
       try {

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -55,7 +55,7 @@ public class CKZG4844JNITest {
             .map(String::toUpperCase)
             .map(Preset::valueOf)
             .orElse(Preset.MAINNET);
-    CKZG4844JNI.loadNativeLibrary(PRESET);
+    CKZG4844JNI.loadNativeLibrary();
   }
 
   @ParameterizedTest
@@ -157,10 +157,19 @@ public class CKZG4844JNITest {
 
   @Test
   public void getsTheConfiguredFieldElementsPerBlob() {
+    loadTrustedSetup();
     assertEquals(PRESET.fieldElementsPerBlob, CKZG4844JNI.getFieldElementsPerBlob());
     assertEquals(
         PRESET.fieldElementsPerBlob * CKZG4844JNI.BYTES_PER_FIELD_ELEMENT,
         CKZG4844JNI.getBytesPerBlob());
+    CKZG4844JNI.freeTrustedSetup();
+  }
+
+  @Test
+  public void failsToGetFieldElementsPerBlobIfNotLoaded() {
+    final RuntimeException exception =
+        assertThrows(RuntimeException.class, CKZG4844JNI::getFieldElementsPerBlob);
+    assertExceptionIsTrustedSetupIsNotLoaded(exception);
   }
 
   @ParameterizedTest
@@ -382,16 +391,6 @@ public class CKZG4844JNITest {
                     parameters.getG2Count() + 1));
     assertEquals(C_KZG_BADARGS, exception.getError());
     assertTrue(exception.getErrorMessage().contains("Invalid g2 size."));
-  }
-
-  @Test
-  public void shouldThrowExceptionOnIncorrectTrustedSetupFromFile() {
-    final Preset incorrectPreset = PRESET == Preset.MAINNET ? Preset.MINIMAL : Preset.MAINNET;
-    final CKZGException exception =
-        assertThrows(
-            CKZGException.class,
-            () -> CKZG4844JNI.loadTrustedSetup(TRUSTED_SETUP_FILE_BY_PRESET.get(incorrectPreset)));
-    assertEquals(C_KZG_BADARGS, exception.getError());
   }
 
   private void assertExceptionIsTrustedSetupIsNotLoaded(final RuntimeException exception) {


### PR DESCRIPTION
This PR updates the Java bindings to work with runtime field counts.