### PR TITLE
Update python bindings to use runtime field count

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   tests:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -10,7 +10,6 @@ def main():
                 "ckzg",
                 sources=["ckzg.c", "../../src/c_kzg_4844.c"],
                 include_dirs=["../../inc", "../../src"],
-                define_macros=[("FIELD_ELEMENTS_PER_BLOB", "4096")],
                 library_dirs=["../../lib"],
                 libraries=["blst"])])
 


### PR DESCRIPTION
This PR updates the Python bindings to work with runtime field counts.