### PR TITLE
Update C# bindings to use runtime field count

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -8,8 +8,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+
 env:
   binding_build_number_based_version: 0.3.1.${{ github.run_number }}
 

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
@@ -3,6 +3,12 @@ using System.Runtime.Loader;
 
 namespace Ckzg;
 
+public struct KzgSettings {
+    public ulong field_elements_per_blob;
+    public ulong bytes_per_blob;
+    /* The rest doesn't matter */
+}
+
 public static partial class Ckzg
 {
     static Ckzg()
@@ -22,31 +28,31 @@ public static partial class Ckzg
     }
 
     [DllImport("ckzg", EntryPoint = "load_trusted_setup_wrap")]
-    private static extern IntPtr InternalLoadTrustedSetup(string filename);
+    private static extern unsafe KzgSettings* InternalLoadTrustedSetup(string filename);
 
     [DllImport("ckzg", EntryPoint = "free_trusted_setup_wrap", CallingConvention = CallingConvention.Cdecl)]
-    private static extern void InternalFreeTrustedSetup(IntPtr ts);
+    private static extern unsafe void InternalFreeTrustedSetup(KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "blob_to_kzg_commitment", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult BlobToKzgCommitment(byte* commitment, byte* blob, IntPtr ts);
+    private static extern unsafe KzgResult BlobToKzgCommitment(byte* commitment, byte* blob, KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "compute_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeKzgProof(byte* proof_out, byte* y_out, byte* blob, byte* z, IntPtr ts);
+    private static extern unsafe KzgResult ComputeKzgProof(byte* proof_out, byte* y_out, byte* blob, byte* z, KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "compute_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeBlobKzgProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
+    private static extern unsafe KzgResult ComputeBlobKzgProof(byte* proof, byte* blob, byte* commitment, KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
     private static extern unsafe KzgResult VerifyKzgProof(out bool result, byte* commitment, byte* z,
-        byte* y, byte* proof, IntPtr ts);
+        byte* y, byte* proof, KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
     private static extern unsafe KzgResult VerifyBlobKzgProof(out bool result, byte* blob, byte* commitment,
-        byte* proof, IntPtr ts);
+        byte* proof, KzgSettings* ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl)]
     private static extern unsafe KzgResult VerifyBlobKzgProofBatch(out bool result, byte* blobs, byte* commitments,
-        byte* proofs, int count, IntPtr ts);
+        byte* proofs, ulong count, KzgSettings* ts);
 
     private enum KzgResult
     {

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -2,11 +2,9 @@ namespace Ckzg;
 
 public static partial class Ckzg
 {
-    public const int BytesPerFieldElement = 32;
-    public const int FieldElementsPerBlob = 4096;
-    public const int BytesPerBlob = BytesPerFieldElement * FieldElementsPerBlob;
-    public const int BytesPerCommitment = 48;
-    public const int BytesPerProof = 48;
+    public const ulong BytesPerFieldElement = 32;
+    public const ulong BytesPerCommitment = 48;
+    public const ulong BytesPerProof = 48;
 
     /// <summary>
     ///     Loads trusted setup settings from file.
@@ -15,13 +13,13 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when the file path is not correct</exception>
     /// <exception cref="InvalidOperationException">Thrown when unable to load the setup</exception>
     /// <returns>Trusted setup settings as a pointer</returns>
-    public static IntPtr LoadTrustedSetup(string filepath)
+    public static unsafe KzgSettings* LoadTrustedSetup(string filepath)
     {
         if (!File.Exists(filepath)) throw new ArgumentException("Trusted setup file does not exist", nameof(filepath));
 
-        IntPtr ckzgSetup = InternalLoadTrustedSetup(filepath);
+        KzgSettings* ckzgSetup = InternalLoadTrustedSetup(filepath);
 
-        if (ckzgSetup == IntPtr.Zero) throw new InvalidOperationException("Unable to load trusted setup");
+        if (ckzgSetup == null) throw new InvalidOperationException("Unable to load trusted setup");
         return ckzgSetup;
     }
 
@@ -31,7 +29,7 @@ public static partial class Ckzg
     /// <param name="ckzgSetup">Trusted setup settings</param>
     /// <exception cref="ArgumentException">Thrown when settings are not correct</exception>
 
-    public static void FreeTrustedSetup(IntPtr ckzgSetup)
+    public static unsafe void FreeTrustedSetup(KzgSettings* ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
         InternalFreeTrustedSetup(ckzgSetup);
@@ -46,10 +44,10 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void BlobToKzgCommitment(Span<byte> commitment, ReadOnlySpan<byte> blob, IntPtr ckzgSetup)
+    public static unsafe void BlobToKzgCommitment(Span<byte> commitment, ReadOnlySpan<byte> blob, KzgSettings* ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
-        ThrowOnInvalidLength(blob, nameof(blob), BytesPerBlob);
+        ThrowOnInvalidLength(blob, nameof(blob), ckzgSetup->bytes_per_blob);
         ThrowOnInvalidLength(commitment, nameof(commitment), BytesPerCommitment);
 
         fixed (byte* commitmentPtr = commitment, blobPtr = blob)
@@ -71,12 +69,12 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     public static unsafe void ComputeKzgProof(Span<byte> proof, Span<byte> y, ReadOnlySpan<byte> blob,
-        ReadOnlySpan<byte> z, IntPtr ckzgSetup)
+        ReadOnlySpan<byte> z, KzgSettings* ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
         ThrowOnInvalidLength(proof, nameof(proof), BytesPerProof);
         ThrowOnInvalidLength(y, nameof(y), BytesPerFieldElement);
-        ThrowOnInvalidLength(blob, nameof(blob), BytesPerBlob);
+        ThrowOnInvalidLength(blob, nameof(blob), ckzgSetup->bytes_per_blob);
         ThrowOnInvalidLength(z, nameof(z), BytesPerFieldElement);
 
         fixed (byte* proofPtr = proof, yPtr = y, blobPtr = blob, zPtr = z)
@@ -97,11 +95,11 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     public static unsafe void ComputeBlobKzgProof(Span<byte> proof, ReadOnlySpan<byte> blob,
-        ReadOnlySpan<byte> commitment, IntPtr ckzgSetup)
+        ReadOnlySpan<byte> commitment, KzgSettings* ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
         ThrowOnInvalidLength(proof, nameof(proof), BytesPerProof);
-        ThrowOnInvalidLength(blob, nameof(blob), BytesPerBlob);
+        ThrowOnInvalidLength(blob, nameof(blob), ckzgSetup->bytes_per_blob);
         ThrowOnInvalidLength(commitment, nameof(commitment), BytesPerCommitment);
 
         fixed (byte* proofPtr = proof, blobPtr = blob, commitmentPtr = commitment)
@@ -124,7 +122,7 @@ public static partial class Ckzg
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
     public static unsafe bool VerifyKzgProof(ReadOnlySpan<byte> commitment, ReadOnlySpan<byte> z, ReadOnlySpan<byte> y,
-        ReadOnlySpan<byte> proof, IntPtr ckzgSetup)
+        ReadOnlySpan<byte> proof, KzgSettings* ckzgSetup)
     {
 
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -153,10 +151,10 @@ public static partial class Ckzg
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
     public static unsafe bool VerifyBlobKzgProof(ReadOnlySpan<byte> blob, ReadOnlySpan<byte> commitment,
-        ReadOnlySpan<byte> proof, IntPtr ckzgSetup)
+        ReadOnlySpan<byte> proof, KzgSettings* ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
-        ThrowOnInvalidLength(blob, nameof(blob), BytesPerBlob);
+        ThrowOnInvalidLength(blob, nameof(blob), ckzgSetup->bytes_per_blob);
         ThrowOnInvalidLength(commitment, nameof(proof), BytesPerCommitment);
         ThrowOnInvalidLength(proof, nameof(proof), BytesPerProof);
 
@@ -181,10 +179,10 @@ public static partial class Ckzg
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
     public static unsafe bool VerifyBlobKzgProofBatch(ReadOnlySpan<byte> blobs, ReadOnlySpan<byte> commitments,
-        ReadOnlySpan<byte> proofs, int count, IntPtr ckzgSetup)
+        ReadOnlySpan<byte> proofs, ulong count, KzgSettings *ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
-        ThrowOnInvalidLength(blobs, nameof(blobs), BytesPerBlob * count);
+        ThrowOnInvalidLength(blobs, nameof(blobs), ckzgSetup->bytes_per_blob * count);
         ThrowOnInvalidLength(commitments, nameof(proofs), BytesPerCommitment * count);
         ThrowOnInvalidLength(proofs, nameof(proofs), BytesPerProof * count);
 
@@ -211,15 +209,15 @@ public static partial class Ckzg
         }
     }
 
-    private static void ThrowOnUninitializedTrustedSetup(IntPtr ckzgSetup)
+    private static unsafe void ThrowOnUninitializedTrustedSetup(KzgSettings* ckzgSetup)
     {
-        if (ckzgSetup == IntPtr.Zero)
+        if (ckzgSetup == null)
             throw new ArgumentException("Trusted setup is not initialized", nameof(ckzgSetup));
     }
 
-    private static void ThrowOnInvalidLength(ReadOnlySpan<byte> data, string fieldName, int expectedLength)
+    private static void ThrowOnInvalidLength(ReadOnlySpan<byte> data, string fieldName, ulong expectedLength)
     {
-        if (data.Length != expectedLength)
+        if ((ulong)data.Length != expectedLength)
             throw new ArgumentException("Invalid data size", fieldName);
     }
     #endregion

--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -6,7 +6,7 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Ckzg.Test;
 
 [TestFixture]
-public class ReferenceTests
+public unsafe class ReferenceTests
 {
     [OneTimeSetUp]
     public void Setup()
@@ -24,10 +24,10 @@ public class ReferenceTests
     [TestCase]
     public void TestSetupLoaded()
     {
-        Assert.That(_ts, Is.Not.EqualTo(IntPtr.Zero));
+        Assert.True(_ts != null);
     }
 
-    private IntPtr _ts;
+    private KzgSettings* _ts;
     private const string TestDir = "../../../../../../tests";
     private readonly string _blobToKzgCommitmentTests = Path.Join(TestDir, "blob_to_kzg_commitment");
     private readonly string _computeKzgProofTests = Path.Join(TestDir, "compute_kzg_proof");
@@ -339,7 +339,7 @@ public class ReferenceTests
             byte[] blobs = GetFlatBytes(test.Input.Blobs);
             byte[] commitments = GetFlatBytes(test.Input.Commitments);
             byte[] proofs = GetFlatBytes(test.Input.Proofs);
-            int count = blobs.Length / Ckzg.BytesPerBlob;
+            ulong count = (ulong)blobs.Length / _ts->bytes_per_blob;
 
             try
             {

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -35,12 +35,10 @@ else
 	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg.so
 endif
 
-FIELD_ELEMENTS_PER_BLOB ?= 4096
 INCLUDE_DIRS = ../../src ../../blst/bindings
 TARGETS = ckzg.c ../../src/c_kzg_4844.c ../../blst/$(BLST_OBJ)
 
 CFLAGS += -O2 -Wall -Wextra -shared
-CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
 CFLAGS += ${addprefix -I,${INCLUDE_DIRS}}
 BLST_BUILDSCRIPT_FLAGS += -D__BLST_PORTABLE__
 ifdef ARCH


### PR DESCRIPTION
This PR updates the C# bindings to work with runtime field counts. Needed to:

* Define a `KzgSettings` structure that C# can see.
  * This only needs the first two fields, as the others aren't used.
* Mark some functions/classes as `unsafe` so they can use pointers.
* Change `int` variables to `ulong` so they play well together.
  * Probably should have been this way before.
* Change `IntPtr` to `KzgSettings*` everywhere.
* Remove `FIELD_ELEMENTS_PER_BLOB` from Makefile.   