### PR TITLE
[Java binding] Run both mainnet and minimal tests

### DIFF
--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -24,11 +24,7 @@ jobs:
         run: |
           cd src
           make blst
-      - name: Build and Test (mainnet preset)
+      - name: Build and Test
         run: |
           cd bindings/java
           make build test
-      - name: Build and Test (minimal preset)
-        run: |
-          cd bindings/java
-          make PRESET=minimal build test

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class CKZG4844JNITest {
+
   private enum TrustedSetupSource {
     FILE,
     PARAMETERS,
@@ -387,7 +388,7 @@ public class CKZG4844JNITest {
     assertEquals("Trusted Setup is not loaded.", exception.getMessage());
   }
 
-  private static void loadTrustedSetup(Preset preset, TrustedSetupSource trustedSetupSource) {
+  private void loadTrustedSetup(Preset preset, TrustedSetupSource trustedSetupSource) {
     switch (trustedSetupSource) {
       case FILE:
         loadTrustedSetup(preset);
@@ -401,20 +402,20 @@ public class CKZG4844JNITest {
     }
   }
 
-  private static void loadTrustedSetup(Preset preset) {
-    CKZG4844JNI.loadTrustedSetup(TRUSTED_SETUP_FILE_BY_PRESET.get(preset));
-  }
-
-  private static void loadTrustedSetupFromParameters(Preset preset) {
+  private void loadTrustedSetupFromParameters(Preset preset) {
     LoadTrustedSetupParameters parameters =
         TestUtils.createLoadTrustedSetupParameters(TRUSTED_SETUP_FILE_BY_PRESET.get(preset));
     CKZG4844JNI.loadTrustedSetup(
         parameters.getG1(), parameters.getG1Count(), parameters.getG2(), parameters.getG2Count());
   }
 
-  private static void loadTrustedSetupFromResource(Preset preset) {
+  private void loadTrustedSetupFromResource(Preset preset) {
     CKZG4844JNI.loadTrustedSetupFromResource(
         TRUSTED_SETUP_RESOURCE_BY_PRESET.get(preset), CKZG4844JNITest.class);
+  }
+
+  private static void loadTrustedSetup(Preset preset) {
+    CKZG4844JNI.loadTrustedSetup(TRUSTED_SETUP_FILE_BY_PRESET.get(preset));
   }
 
   private static Stream<BlobToKzgCommitmentTest> getBlobToKzgCommitmentTests() {


### PR DESCRIPTION
Before running the tests in the java binding was dependent on the `PRESET` env value. Given it is no longer used since `fieldElementsPerBlob` is runtime value can run both mainnet and minimal tests in once.

- Removed finals to make the test file consistent