### PR TITLE
Enable pedantic warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ FIELD_ELEMENTS_PER_BLOB ?= 4096
 # The base compiler flags. More can be added on command line.
 CFLAGS += -I../inc
 CFLAGS += -DFIELD_ELEMENTS_PER_BLOB=$(FIELD_ELEMENTS_PER_BLOB)
-CFLAGS += -O2 -Wall -Wextra
+CFLAGS += -O2 -Wall -Wextra -Wpedantic
 
 # Cross-platform compilation settings.
 ifeq ($(PLATFORM),Windows)

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -780,20 +780,20 @@ static void test_reverse_bits__succeeds_round_trip(void) {
 }
 
 static void test_reverse_bits__succeeds_all_bits_are_zero(void) {
-    uint32_t original = 0b00000000000000000000000000000000;
-    uint32_t reversed = 0b00000000000000000000000000000000;
+    uint32_t original = 0;
+    uint32_t reversed = 0;
     ASSERT_EQUALS(reverse_bits(original), reversed);
 }
 
 static void test_reverse_bits__succeeds_some_bits_are_one(void) {
-    uint32_t original = 0b10101000011111100000000000000010;
-    uint32_t reversed = 0b01000000000000000111111000010101;
+    uint32_t original = 2826829826;
+    uint32_t reversed = 1073774101;
     ASSERT_EQUALS(reverse_bits(original), reversed);
 }
 
 static void test_reverse_bits__succeeds_all_bits_are_one(void) {
-    uint32_t original = 0b11111111111111111111111111111111;
-    uint32_t reversed = 0b11111111111111111111111111111111;
+    uint32_t original = 4294967295;
+    uint32_t reversed = 4294967295;
     ASSERT_EQUALS(reverse_bits(original), reversed);
 }
 

--- a/src/tinytest.h
+++ b/src/tinytest.h
@@ -71,7 +71,7 @@ const char* tt_current_expression = NULL;
 const char* tt_current_file = NULL;
 int tt_current_line = 0;
 
-void tt_execute(const char* name, void (*test_function)())
+void tt_execute(const char* name, void (*test_function)(void))
 {
   tt_current_test_failed = 0;
   test_function();


### PR DESCRIPTION
Last week I learned that `-Wall` and `-Wextra` doesn't enable *all* warnings; there's `-Wpedantic` too.

When enabled, it had the following warnings (treated as errors):

```
$ make
In file included from test_c_kzg_4844.c:5:
./tinytest.h:74:56: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
   74 | void tt_execute(const char* name, void (*test_function)())
      |                                                        ^
      |                                                         void
test_c_kzg_4844.c:783:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  783 |     uint32_t original = 0b00000000000000000000000000000000;
      |                         ^
test_c_kzg_4844.c:784:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  784 |     uint32_t reversed = 0b00000000000000000000000000000000;
      |                         ^
test_c_kzg_4844.c:789:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  789 |     uint32_t original = 0b10101000011111100000000000000010;
      |                         ^
test_c_kzg_4844.c:790:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  790 |     uint32_t reversed = 0b01000000000000000111111000010101;
      |                         ^
test_c_kzg_4844.c:795:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  795 |     uint32_t original = 0b11111111111111111111111111111111;
      |                         ^
test_c_kzg_4844.c:796:25: error: binary integer literals are a GNU extension [-Werror,-Wgnu-binary-literal]
  796 |     uint32_t reversed = 0b11111111111111111111111111111111;
      |                         ^
7 errors generated.
make: *** [test_c_kzg_4844] Error 1
```
