### PR TITLE
Improve ckzg native library search path + small improvements

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -30,7 +30,7 @@ jobs:
             host: ubuntu-22.04
             ext: .so
             reqs: sudo apt update && sudo apt install -y clang binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
-          - arch: arm64-darwin
+          - arch: arm64-apple-macos11
             location: osx-arm64
             host: macos-latest
             ext: .so

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -33,14 +33,13 @@ jobs:
           - arch: arm64-apple-macos11
             location: osx-arm64
             host: macos-latest
-            ext: .so
+            ext: .dylib
             reqs:
           - arch: x86_64-darwin
             location: osx-x64
             host: macos-latest
-            ext: .so
+            ext: .dylib
             reqs:
-          #TODO: support arch: x86_64-v2-win
           - arch:
             location: win-x64
             host: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ analysis-report/
 .idea/
 *bindings/*/*.so
 *bindings/rust/target
-*bindings/csharp/*.exe
-*bindings/csharp/*.dll
 __pycache__
 .DS_Store
 

--- a/bindings/csharp/.gitignore
+++ b/bindings/csharp/.gitignore
@@ -10,3 +10,5 @@ Ckzg.Bindings/runtimes/*/native/*
 test_ckzg*
 *.so
 *.dll
+*.exe
+*.dylib

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -32,10 +32,12 @@
 
 	<ItemGroup>
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
+		
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.so')" Include="runtimes/osx-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.so" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.so')" Include="runtimes/osx-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.so" />
+
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.dylib')" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.dylib')" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -7,7 +7,8 @@ ifeq ($(OS),Windows_NT)
 	BLST_OBJ = blst.lib
 	LOCATION ?= win-x64
 	CLANG_EXECUTABLE = clang
-	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg.dll
+	EXTENSION ?= ".dll"
+	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg$(EXTENSION)
 	CFLAGS += -Wl,/def:ckzg.def
 else
 	BLST_BUILDSCRIPT = ./build.sh
@@ -18,6 +19,7 @@ else
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)
 	ifeq ($(UNAME_S),Linux)
+		EXTENSION ?= ".so"
 		ifeq ($(UNAME_M),x86_64)
 			LOCATION ?= linux-x64
 		else
@@ -25,6 +27,7 @@ else
 		endif
 	endif
 	ifeq ($(UNAME_S),Darwin)
+		EXTENSION ?= ".dylib"
 		ifeq ($(UNAME_M),arm64)
 			LOCATION ?= osx-arm64
 		else
@@ -32,7 +35,7 @@ else
 		endif
 	endif
 
-	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg.so
+	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg$(EXTENSION)
 endif
 
 FIELD_ELEMENTS_PER_BLOB ?= 4096

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -5,7 +5,7 @@ This directory contains C# bindings for the C-KZG-4844 library.
 ## Prerequisites
 
 Build requires:
-- `clang` as a prefered buid tool for the native wrapper of ckzg. On Windows it's tested with clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
+- `clang` as a preferred build tool for the native wrapper of ckzg. On Windows, it's tested with clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
 - [.NET SDK](https://dotnet.microsoft.com/en-us/download) to build the bindings.
 
 ## Build & test

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -4,8 +4,9 @@ This directory contains C# bindings for the C-KZG-4844 library.
 
 ## Prerequisites
 
-These bindings require .NET 6.0 (not 7.0). This can be found here:
-* https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+Build requires:
+- `clang` as a prefered buid tool for the native wrapper of ckzg. On Windows it's tested with clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download) to build the bindings.
 
 ## Build & test
 


### PR DESCRIPTION
1. `arm64-apple-macos11` is more correct macos target;
1. `dylib` is better extension on Macos for "dynamically linked shared library";
1. We do not care about old arch "x86_64-v2-win" because we will have that runtime check;
1. Library search path should be based on Ckzg.Bindings.dll location, not on the current directory. So `AppContext.BaseDirectory` is used;
1. The library may be built with any SDK.

The main reason for the change is `4.` when someone who uses Ckzg.Bindings as a dependency directly runs their project from source code, the library fails to find the native dependency.