### PR TITLE
Update fuzzers to work with variable sized blobs

### DIFF
--- a/fuzz/blob_to_kzg_commitment/fuzz.c
+++ b/fuzz/blob_to_kzg_commitment/fuzz.c
@@ -1,15 +1,15 @@
 #include "../base_fuzz.h"
 
-static const size_t BLOB_OFFSET = 0;
-static const size_t INPUT_SIZE = BLOB_OFFSET + BYTES_PER_BLOB;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    if (size == INPUT_SIZE) {
+    size_t blob_offset = 0;
+    size_t input_size = blob_offset + s.bytes_per_blob;
+
+    if (size == input_size) {
         KZGCommitment commitment;
         blob_to_kzg_commitment(
             &commitment,
-            (const Blob *)(data + BLOB_OFFSET),
+            (const uint8_t *)(data + blob_offset),
             &s
         );
     }

--- a/fuzz/compute_blob_kzg_proof/fuzz.c
+++ b/fuzz/compute_blob_kzg_proof/fuzz.c
@@ -1,17 +1,17 @@
 #include "../base_fuzz.h"
 
-static const size_t BLOB_OFFSET = 0;
-static const size_t COMMITMENT_OFFSET = BYTES_PER_BLOB;
-static const size_t INPUT_SIZE = COMMITMENT_OFFSET + BYTES_PER_COMMITMENT;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    if (size == INPUT_SIZE) {
+    size_t blob_offset = 0;
+    size_t commitment_offset = s.bytes_per_blob;
+    size_t input_size = commitment_offset + BYTES_PER_COMMITMENT;
+
+    if (size == input_size) {
         KZGProof proof;
         compute_blob_kzg_proof(
             &proof,
-            (const Blob *)(data + BLOB_OFFSET),
-            (const Bytes48 *)(data + COMMITMENT_OFFSET),
+            (const uint8_t *)(data + blob_offset),
+            (const Bytes48 *)(data + commitment_offset),
             &s
         );
     }

--- a/fuzz/compute_kzg_proof/fuzz.c
+++ b/fuzz/compute_kzg_proof/fuzz.c
@@ -1,19 +1,19 @@
 #include "../base_fuzz.h"
 
-static const size_t BLOB_OFFSET = 0;
-static const size_t Z_OFFSET = BLOB_OFFSET + BYTES_PER_BLOB;
-static const size_t INPUT_SIZE = Z_OFFSET + BYTES_PER_FIELD_ELEMENT;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    if (size == INPUT_SIZE) {
+    size_t blob_offset = 0;
+    size_t z_offset = blob_offset + s.bytes_per_blob;
+    size_t input_size = z_offset + BYTES_PER_FIELD_ELEMENT;
+
+    if (size == input_size) {
         KZGProof proof;
         Bytes32 y;
         compute_kzg_proof(
             &proof,
             &y,
-            (const Blob *)(data + BLOB_OFFSET),
-            (const Bytes32 *)(data + Z_OFFSET),
+            (const uint8_t *)(data + blob_offset),
+            (const Bytes32 *)(data + z_offset),
             &s
         );
     }

--- a/fuzz/verify_blob_kzg_proof/fuzz.c
+++ b/fuzz/verify_blob_kzg_proof/fuzz.c
@@ -1,19 +1,19 @@
 #include "../base_fuzz.h"
 
-static const size_t BLOB_OFFSET = 0;
-static const size_t COMMITMENT_OFFSET = BLOB_OFFSET + BYTES_PER_BLOB;
-static const size_t PROOF_OFFSET = COMMITMENT_OFFSET + BYTES_PER_COMMITMENT;
-static const size_t INPUT_SIZE = PROOF_OFFSET + BYTES_PER_PROOF;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    if (size == INPUT_SIZE) {
+    size_t blob_offset = 0;
+    size_t commitment_offset = blob_offset + s.bytes_per_blob;
+    size_t proof_offset = commitment_offset + BYTES_PER_COMMITMENT;
+    size_t input_size = proof_offset + BYTES_PER_PROOF;
+
+    if (size == input_size) {
         bool ok;
         verify_blob_kzg_proof(
             &ok,
-            (const Blob *)(data + BLOB_OFFSET),
-            (const Bytes48 *)(data + COMMITMENT_OFFSET),
-            (const Bytes48 *)(data + PROOF_OFFSET),
+            (const uint8_t *)(data + blob_offset),
+            (const Bytes48 *)(data + commitment_offset),
+            (const Bytes48 *)(data + proof_offset),
             &s
         );
     }

--- a/fuzz/verify_blob_kzg_proof_batch/fuzz.c
+++ b/fuzz/verify_blob_kzg_proof_batch/fuzz.c
@@ -1,19 +1,19 @@
 #include "../base_fuzz.h"
 
-static const size_t BLOBS_OFFSET = 0;
-static const size_t COMMITMENTS_OFFSET = BLOBS_OFFSET + BYTES_PER_BLOB;
-static const size_t PROOFS_OFFSET = COMMITMENTS_OFFSET + BYTES_PER_COMMITMENT;
-static const size_t INPUT_SIZE = PROOFS_OFFSET + BYTES_PER_PROOF;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    size_t count = size / INPUT_SIZE;
+    size_t blobs_offset = 0;
+    size_t commitments_offset = blobs_offset + s.bytes_per_blob;
+    size_t proofs_offset = commitments_offset + BYTES_PER_COMMITMENT;
+    size_t input_size = proofs_offset + BYTES_PER_PROOF;
+    size_t count = size / input_size;
+
     bool ok;
     verify_blob_kzg_proof_batch(
         &ok,
-        (const Blob *)(data + BLOBS_OFFSET * count),
-        (const Bytes48 *)(data + COMMITMENTS_OFFSET * count),
-        (const Bytes48 *)(data + PROOFS_OFFSET * count),
+        (const uint8_t *)(data + blobs_offset * count),
+        (const Bytes48 *)(data + commitments_offset * count),
+        (const Bytes48 *)(data + proofs_offset * count),
         count,
         &s
     );

--- a/fuzz/verify_kzg_proof/fuzz.c
+++ b/fuzz/verify_kzg_proof/fuzz.c
@@ -1,21 +1,21 @@
 #include "../base_fuzz.h"
 
-static const size_t COMMITMENT_OFFSET = 0;
-static const size_t Z_OFFSET = COMMITMENT_OFFSET + BYTES_PER_COMMITMENT;
-static const size_t Y_OFFSET = Z_OFFSET + BYTES_PER_FIELD_ELEMENT;
-static const size_t PROOF_OFFSET = Y_OFFSET + BYTES_PER_FIELD_ELEMENT;
-static const size_t INPUT_SIZE = PROOF_OFFSET + BYTES_PER_PROOF;
-
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     initialize();
-    if (size == INPUT_SIZE) {
+    size_t commitment_offset = 0;
+    size_t z_offset = commitment_offset + BYTES_PER_COMMITMENT;
+    size_t y_offset = z_offset + BYTES_PER_FIELD_ELEMENT;
+    size_t proof_offset = y_offset + BYTES_PER_FIELD_ELEMENT;
+    size_t input_size = proof_offset + BYTES_PER_PROOF;
+
+    if (size == input_size) {
         bool ok;
         verify_kzg_proof(
             &ok,
-            (const Bytes48 *)(data + COMMITMENT_OFFSET),
-            (const Bytes32 *)(data + Z_OFFSET),
-            (const Bytes32 *)(data + Y_OFFSET),
-            (const Bytes48 *)(data + PROOF_OFFSET),
+            (const Bytes48 *)(data + commitment_offset),
+            (const Bytes32 *)(data + z_offset),
+            (const Bytes32 *)(data + y_offset),
+            (const Bytes48 *)(data + proof_offset),
             &s
         );
     }


### PR DESCRIPTION
The `Blob` and `BYTES_PER_BLOB` no longer exist. To fix this, I converted the offset & input_size macros to variables.