### PR TITLE
Fix edge case in expand_root_of_unity

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -1557,13 +1557,16 @@ static C_KZG_RET bit_reversal_permutation(
 static C_KZG_RET expand_root_of_unity(
     fr_t *out, const fr_t *root, uint64_t width
 ) {
+    uint64_t i;
+    CHECK(width >= 2);
     out[0] = FR_ONE;
     out[1] = *root;
 
-    for (uint64_t i = 2; !fr_is_one(&out[i - 1]); i++) {
-        CHECK(i <= width);
+    for (i = 2; i <= width; i++) {
         blst_fr_mul(&out[i], &out[i - 1], root);
+        if (fr_is_one(&out[i])) break;
     }
+    CHECK(i == width);
     CHECK(fr_is_one(&out[width]));
 
     return C_KZG_OK;


### PR DESCRIPTION
Valgrind pointed out usage of an uninitialized value in our tests. Since this is part of the trusted setup initialization, I expect this would never happen, but good to fix nevertheless.

```
==501666== Conditional jump or move depends on uninitialised value(s)
==501666==    at 0x40A5A6: fr_is_one (in /home/devops/jtraglia/c-kzg-4844/src/test_c_kzg_4844)
==501666==    by 0x40A556: expand_root_of_unity (in /home/devops/jtraglia/c-kzg-4844/src/test_c_kzg_4844)
==501666==    by 0x40952E: test_expand_root_of_unity__fails_wrong_root_of_unity (in /home/devops/jtraglia/c-kzg-4844/src/test_c_kzg_4844)
==501666==    by 0x4031C1: tt_execute (in /home/devops/jtraglia/c-kzg-4844/src/test_c_kzg_4844)
==501666==    by 0x403AA3: main (in /home/devops/jtraglia/c-kzg-4844/src/test_c_kzg_4844)
```

In the following test, we provide the wrong root of unity, which causes the loop in `expand_root_of_unity` to break early. Here, the width is 256 but the look will break at 128 (because it encountered a value of one).

https://github.com/ethereum/c-kzg-4844/blob/b2e41491ad1859f1792964a2432a419b64dc6fb2/src/test_c_kzg_4844.c#L1719-L1727

In `expand_root_of_unity`, if the loop breaks early, the final check will occur on an uninitialized value:

https://github.com/ethereum/c-kzg-4844/blob/b2e41491ad1859f1792964a2432a419b64dc6fb2/src/c_kzg_4844.c#L1563-L1567

I also added `CHECK(width >= 2)` as a sanity check and changed the loop to be more "natural" IMO.