### PR TITLE
Rust runtime bindings take 2

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   feature-checks:

--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -77,11 +77,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
 name = "c-kzg"
 version = "0.1.0"
 dependencies = [
  "bindgen",
  "blst",
+ "bytes",
  "cc",
  "criterion",
  "glob",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -22,6 +22,7 @@ minimal-spec = []
 no-threads = []
 
 [dependencies]
+bytes = "1.5.0"
 hex = { version = "0.4.2", default-features = false, features = ["alloc"] }
 libc = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -3,9 +3,7 @@ name = "c-kzg"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-# XXX: Note that we don't set a `links` attribute for Cargo, because this library may link
-# either `ckzg` or `ckzg_min`. This allows the crate to be linked twice as minimal/mainnet variants
-# without Cargo complaining.
+links = "ckzg"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,7 +20,6 @@ minimal-spec = []
 no-threads = []
 
 [dependencies]
-bytes = "1.5.0"
 hex = { version = "0.4.2", default-features = false, features = ["alloc"] }
 libc = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = [
@@ -38,6 +35,7 @@ rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.17"
 serde_json = "1.0.105"
+bytes = "1.5.0"
 
 [build-dependencies]
 bindgen = "0.66.1"

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -3,7 +3,6 @@ use c_kzg::*;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use rand::{rngs::ThreadRng, Rng};
 use std::path::Path;
-use std::sync::Arc;
 
 fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
     let mut arr = [0u8; BYTES_PER_FIELD_ELEMENT];
@@ -28,7 +27,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let trusted_setup_file = Path::new("../../src/trusted_setup.txt");
     assert!(trusted_setup_file.exists());
-    let kzg_settings = Arc::new(KzgSettings::load_trusted_setup_file(trusted_setup_file).unwrap());
+    let kzg_settings = KzgSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
     let blobs: Vec<Bytes> = (0..max_count)
         .map(|_| generate_random_blob(&mut rng, &kzg_settings))

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -12,7 +12,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
 }
 
 fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Vec<u8> {
-    let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+    let mut arr = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
     // each field element contained in the blob is < BLS_MODULUS

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -11,7 +11,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
     arr.into()
 }
 
-fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
+fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Vec<u8> {
     let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
@@ -19,7 +19,7 @@ fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
     for i in 0..s.field_elements_per_blob() {
         arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
     }
-    Blob::from_bytes(arr.as_slice(), s).unwrap()
+    arr
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -29,7 +29,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     assert!(trusted_setup_file.exists());
     let kzg_settings = Arc::new(KzgSettings::load_trusted_setup_file(trusted_setup_file).unwrap());
 
-    let blobs: Vec<Blob> = (0..max_count)
+    let blobs: Vec<Vec<u8>> = (0..max_count)
         .map(|_| generate_random_blob(&mut rng, &kzg_settings))
         .collect();
     let commitments: Vec<Bytes48> = blobs

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -11,15 +11,16 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
     arr.into()
 }
 
-fn generate_random_blob(rng: &mut ThreadRng) -> Blob {
-    let mut arr = [0u8; BYTES_PER_BLOB];
+fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
+    let mut arr: Vec<u8> = Vec::with_capacity(s.get_bytes_per_blob());
+    arr.resize(s.get_bytes_per_blob(), 0);
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
     // each field element contained in the blob is < BLS_MODULUS
-    for i in 0..FIELD_ELEMENTS_PER_BLOB {
+    for i in 0..s.get_field_elements_per_blob() {
         arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
     }
-    arr.into()
+    Blob::from_bytes(arr.as_slice(), s).unwrap()
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -30,7 +31,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let kzg_settings = Arc::new(KzgSettings::load_trusted_setup_file(trusted_setup_file).unwrap());
 
     let blobs: Vec<Blob> = (0..max_count)
-        .map(|_| generate_random_blob(&mut rng))
+        .map(|_| generate_random_blob(&mut rng, &kzg_settings))
         .collect();
     let commitments: Vec<Bytes48> = blobs
         .iter()

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -12,7 +12,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
 }
 
 fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
-    let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+    let mut arr = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
     // each field element contained in the blob is < BLS_MODULUS

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let commitments: Vec<Bytes48> = blobs
         .iter()
         .map(|blob| {
-            KzgCommitment::blob_to_kzg_commitment(blob, &kzg_settings)
+            kzg_settings.blob_to_kzg_commitment(blob)
                 .unwrap()
                 .to_bytes()
         })
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .iter()
         .zip(commitments.iter())
         .map(|(blob, commitment)| {
-            KzgProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings)
+            kzg_settings.compute_blob_kzg_proof(blob, commitment)
                 .unwrap()
                 .to_bytes()
         })
@@ -55,32 +55,31 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .collect();
 
     c.bench_function("blob_to_kzg_commitment", |b| {
-        b.iter(|| KzgCommitment::blob_to_kzg_commitment(&blobs[0], &kzg_settings))
+        b.iter(|| kzg_settings.blob_to_kzg_commitment(&blobs[0]))
     });
 
     c.bench_function("compute_kzg_proof", |b| {
-        b.iter(|| KzgProof::compute_kzg_proof(&blobs[0], &fields[0], &kzg_settings))
+        b.iter(|| kzg_settings.compute_kzg_proof(&blobs[0], &fields[0]))
     });
 
     c.bench_function("compute_blob_kzg_proof", |b| {
-        b.iter(|| KzgProof::compute_blob_kzg_proof(&blobs[0], &commitments[0], &kzg_settings))
+        b.iter(|| kzg_settings.compute_blob_kzg_proof(&blobs[0], &commitments[0]))
     });
 
     c.bench_function("verify_kzg_proof", |b| {
         b.iter(|| {
-            KzgProof::verify_kzg_proof(
+            kzg_settings.verify_kzg_proof(
                 &commitments[0],
                 &fields[0],
                 &fields[0],
                 &proofs[0],
-                &kzg_settings,
             )
         })
     });
 
     c.bench_function("verify_blob_kzg_proof", |b| {
         b.iter(|| {
-            KzgProof::verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0], &kzg_settings)
+            kzg_settings.verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0])
         })
     });
 
@@ -98,11 +97,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 },
                 |(blobs_subset, commitments_subset, proofs_subset)| {
                     let blobs_subset: Vec<_> = blobs_subset.iter().map(AsRef::as_ref).collect();
-                    KzgProof::verify_blob_kzg_proof_batch(
+                    kzg_settings.verify_blob_kzg_proof_batch(
                         &blobs_subset,
                         commitments_subset,
                         proofs_subset,
-                        &kzg_settings,
                     )
                     .unwrap();
                 },

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -12,7 +12,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
 }
 
 fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
-    let mut arr: Vec<u8> = Vec::with_capacity(s.get_bytes_per_blob());
+    let mut arr: Vec<u8> = vec![0; s.get_bytes_per_blob()];
     arr.resize(s.get_bytes_per_blob(), 0);
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -12,12 +12,11 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
 }
 
 fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
-    let mut arr: Vec<u8> = vec![0; s.get_bytes_per_blob()];
-    arr.resize(s.get_bytes_per_blob(), 0);
+    let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
     // each field element contained in the blob is < BLS_MODULUS
-    for i in 0..s.get_field_elements_per_blob() {
+    for i in 0..s.field_elements_per_blob() {
         arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
     }
     Blob::from_bytes(arr.as_slice(), s).unwrap()

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -36,7 +36,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let commitments: Vec<Bytes48> = blobs
         .iter()
         .map(|blob| {
-            kzg_settings.blob_to_kzg_commitment(blob)
+            kzg_settings
+                .blob_to_kzg_commitment(blob)
                 .unwrap()
                 .to_bytes()
         })
@@ -45,7 +46,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .iter()
         .zip(commitments.iter())
         .map(|(blob, commitment)| {
-            kzg_settings.compute_blob_kzg_proof(blob, commitment)
+            kzg_settings
+                .compute_blob_kzg_proof(blob, commitment)
                 .unwrap()
                 .to_bytes()
         })
@@ -68,19 +70,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("verify_kzg_proof", |b| {
         b.iter(|| {
-            kzg_settings.verify_kzg_proof(
-                &commitments[0],
-                &fields[0],
-                &fields[0],
-                &proofs[0],
-            )
+            kzg_settings.verify_kzg_proof(&commitments[0], &fields[0], &fields[0], &proofs[0])
         })
     });
 
     c.bench_function("verify_blob_kzg_proof", |b| {
-        b.iter(|| {
-            kzg_settings.verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0])
-        })
+        b.iter(|| kzg_settings.verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0]))
     });
 
     let mut group = c.benchmark_group("verify_blob_kzg_proof_batch");
@@ -97,12 +92,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 },
                 |(blobs_subset, commitments_subset, proofs_subset)| {
                     let blobs_subset: Vec<_> = blobs_subset.iter().map(AsRef::as_ref).collect();
-                    kzg_settings.verify_blob_kzg_proof_batch(
-                        &blobs_subset,
-                        commitments_subset,
-                        proofs_subset,
-                    )
-                    .unwrap();
+                    kzg_settings
+                        .verify_blob_kzg_proof_batch(
+                            &blobs_subset,
+                            commitments_subset,
+                            proofs_subset,
+                        )
+                        .unwrap();
                 },
                 BatchSize::LargeInput,
             );

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -49,11 +49,8 @@ fn main() {
     println!("cargo:rustc-link-lib=ckzg");
 }
 
-fn make_bindings<P>(
-    header_path: &str,
-    blst_headers_dir: &str,
-    bindings_out_path: P,
-) where
+fn make_bindings<P>(header_path: &str, blst_headers_dir: &str, bindings_out_path: P)
+where
     P: AsRef<std::path::Path>,
 {
     use bindgen::Builder;
@@ -63,12 +60,12 @@ fn make_bindings<P>(
     impl bindgen::callbacks::ParseCallbacks for Callbacks {
         fn int_macro(&self, name: &str, _value: i64) -> Option<bindgen::callbacks::IntKind> {
             match name {
-                | "BYTES_PER_COMMITMENT"
-                | "BYTES_PER_PROOF"
-                | "BYTES_PER_FIELD_ELEMENT" => Some(bindgen::callbacks::IntKind::Custom {
-                    name: "usize",
-                    is_signed: false,
-                }),
+                "BYTES_PER_COMMITMENT" | "BYTES_PER_PROOF" | "BYTES_PER_FIELD_ELEMENT" => {
+                    Some(bindgen::callbacks::IntKind::Custom {
+                        name: "usize",
+                        is_signed: false,
+                    })
+                }
                 _ => None,
             }
         }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,9 +1,6 @@
 use std::env;
 use std::path::PathBuf;
 
-const MAINNET_FIELD_ELEMENTS_PER_BLOB: usize = 4096;
-const MINIMAL_FIELD_ELEMENTS_PER_BLOB: usize = 4;
-
 fn main() {
     let cargo_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let root_dir = cargo_dir
@@ -11,15 +8,6 @@ fn main() {
         .expect("rust dir is nested")
         .parent()
         .expect("bindings dir is nested");
-
-    let (lib_name, field_elements_per_blob) = if cfg!(feature = "minimal-spec") {
-        ("ckzg_min", MINIMAL_FIELD_ELEMENTS_PER_BLOB)
-    } else {
-        ("ckzg", MAINNET_FIELD_ELEMENTS_PER_BLOB)
-    };
-
-    eprintln!("Using LIB_PREFIX={lib_name}");
-    eprintln!("Using FIELD_ELEMENTS_PER_BLOB={field_elements_per_blob}");
 
     // Obtain the header files of blst
     let blst_base_dir = root_dir.join("blst");
@@ -42,11 +30,9 @@ fn main() {
 
     cc.include(blst_headers_dir.clone());
     cc.warnings(false);
-    cc.flag(format!("-DLIB_PREFIX={lib_name}").as_str());
-    cc.flag(format!("-DFIELD_ELEMENTS_PER_BLOB={}", field_elements_per_blob).as_str());
     cc.file(c_src_dir.join("c_kzg_4844.c"));
 
-    cc.try_compile(lib_name).expect("Failed to compile ckzg");
+    cc.try_compile("ckzg").expect("Failed to compile ckzg");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let bindings_out_path = out_dir.join("generated.rs");
@@ -54,20 +40,16 @@ fn main() {
     let header_file = header_file_path.to_str().expect("valid header file");
 
     make_bindings(
-        lib_name,
-        field_elements_per_blob,
         header_file,
         &blst_headers_dir.to_string_lossy(),
         bindings_out_path,
     );
 
-    // Finally, tell cargo this provides ckzg/ckzg_min
-    println!("cargo:rustc-link-lib={lib_name}");
+    // Finally, tell cargo this provides ckzg
+    println!("cargo:rustc-link-lib=ckzg");
 }
 
 fn make_bindings<P>(
-    lib_name: &str,
-    field_elements_per_blob: usize,
     header_path: &str,
     blst_headers_dir: &str,
     bindings_out_path: P,
@@ -81,11 +63,9 @@ fn make_bindings<P>(
     impl bindgen::callbacks::ParseCallbacks for Callbacks {
         fn int_macro(&self, name: &str, _value: i64) -> Option<bindgen::callbacks::IntKind> {
             match name {
-                "FIELD_ELEMENTS_PER_BLOB"
                 | "BYTES_PER_COMMITMENT"
                 | "BYTES_PER_PROOF"
-                | "BYTES_PER_FIELD_ELEMENT"
-                | "BYTES_PER_BLOB" => Some(bindgen::callbacks::IntKind::Custom {
+                | "BYTES_PER_FIELD_ELEMENT" => Some(bindgen::callbacks::IntKind::Custom {
                     name: "usize",
                     is_signed: false,
                 }),
@@ -98,20 +78,8 @@ fn make_bindings<P>(
         /*
          * Header definitions.
          */
-        // Inject the constant as C code so that the C compiler can use it.
-        // -D is not supported by bindgen https://github.com/rust-lang/rust-bindgen/issues/2394
-        .header_contents(
-            "consts",
-            &format!(
-                "#define LIB_PREFIX {lib_name}
-                 #define FIELD_ELEMENTS_PER_BLOB {field_elements_per_blob}"
-            ),
-        )
         .header(header_path)
         .clang_args([format!("-I{blst_headers_dir}")])
-        // Since this is not part of the header file, needs to be allowed explicitly.
-        .allowlist_var("LIB_PREFIX")
-        .allowlist_var("FIELD_ELEMENTS_PER_BLOB")
         // Get bindings only for the header file.
         .allowlist_file(".*c_kzg_4844.h")
         /*
@@ -138,8 +106,6 @@ fn make_bindings<P>(
         .parse_callbacks(Box::new(Callbacks))
         // Add PartialEq and Eq impls to types.
         .derive_eq(true)
-        // Blobs are big, we don't want rust to liberally copy them around.
-        .no_copy("Blob")
         // Do not make fields public. If we want to modify them we can create setters/mutable
         // getters when necessary.
         .default_visibility(bindgen::FieldVisibilityKind::Private)

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -233,7 +233,7 @@ impl KZGSettings {
                 bytes.len()
             )));
         }
-        Ok(Blob { bytes: bytes })
+        Ok(Blob { bytes })
     }
 
     /// Return the `KzgCommitment` for the `Blob` represented by the byte slice.
@@ -304,8 +304,8 @@ impl KZGSettings {
     }
 }
 
-fn blob_to_kzg_commitment_internal<'a>(
-    blob: Blob<'a>,
+fn blob_to_kzg_commitment_internal(
+    blob: Blob<'_>,
     kzg_settings: &KZGSettings,
 ) -> Result<KZGCommitment, Error> {
     let mut kzg_commitment: MaybeUninit<KZGCommitment> = MaybeUninit::uninit();
@@ -330,8 +330,8 @@ unsafe impl Send for KZGSettings {}
 
 /* Internal wrappers to ckzg FFI functions */
 
-fn compute_kzg_proof_internal<'a>(
-    blob: Blob<'a>,
+fn compute_kzg_proof_internal(
+    blob: Blob<'_>,
     z_bytes: &Bytes32,
     kzg_settings: &KZGSettings,
 ) -> Result<(KZGProof, Bytes32), Error> {
@@ -353,8 +353,8 @@ fn compute_kzg_proof_internal<'a>(
     }
 }
 
-fn compute_blob_kzg_proof_internal<'a>(
-    blob: Blob<'a>,
+fn compute_blob_kzg_proof_internal(
+    blob: Blob<'_>,
     commitment_bytes: &Bytes48,
     kzg_settings: &KZGSettings,
 ) -> Result<KZGProof, Error> {
@@ -399,8 +399,8 @@ fn verify_kzg_proof_internal(
     }
 }
 
-fn verify_blob_kzg_proof_internal<'a>(
-    blob: Blob<'a>,
+fn verify_blob_kzg_proof_internal(
+    blob: Blob<'_>,
     commitment_bytes: &Bytes48,
     proof_bytes: &Bytes48,
     kzg_settings: &KZGSettings,
@@ -422,8 +422,8 @@ fn verify_blob_kzg_proof_internal<'a>(
     }
 }
 
-fn verify_blob_kzg_proof_batch_internal<'a>(
-    blobs: Vec<Blob<'a>>,
+fn verify_blob_kzg_proof_batch_internal(
+    blobs: Vec<Blob<'_>>,
     commitments_bytes: &[Bytes48],
     proofs_bytes: &[Bytes48],
     kzg_settings: &KZGSettings,

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -385,7 +385,7 @@ impl KZGProof {
     }
 
     pub fn verify_blob_kzg_proof_batch(
-        blobs: &Vec<Vec<u8>>,
+        blobs: &[Vec<u8>],
         commitments_bytes: &[Bytes48],
         proofs_bytes: &[Bytes48],
         kzg_settings: &KZGSettings,
@@ -558,7 +558,7 @@ mod tests {
     };
 
     fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
-        let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+        let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -212,6 +212,12 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
+    pub fn from_bytes_unsafe(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self {
+            bytes: bytes.to_vec(),
+        })
+    }
+
     pub fn from_bytes(bytes: &[u8], s: &KZGSettings) -> Result<Self, Error> {
         if bytes.len() != s.bytes_per_blob() {
             return Err(Error::InvalidBytesLength(format!(
@@ -220,9 +226,7 @@ impl Blob {
                 bytes.len(),
             )));
         }
-        Ok(Self {
-            bytes: bytes.to_vec(),
-        })
+        Self::from_bytes_unsafe(bytes)
     }
 
     pub fn from_hex(hex_str: &str, s: &KZGSettings) -> Result<Self, Error> {

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -11,6 +11,7 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 use alloc::string::String;
 use alloc::vec::Vec;
+use bytes::Bytes;
 use core::ffi::CStr;
 use core::fmt;
 use core::mem::MaybeUninit;
@@ -23,6 +24,9 @@ use std::path::Path;
 
 pub const BYTES_PER_G1_POINT: usize = 48;
 pub const BYTES_PER_G2_POINT: usize = 96;
+
+/// A trusted (valid) blob.
+pub struct Blob(Bytes);
 
 /// A trusted (valid) KZG commitment.
 // NOTE: this is a type alias to the struct Bytes48, same as [`KZGProof`] in the C header files. To
@@ -207,6 +211,37 @@ impl Drop for KZGSettings {
     }
 }
 
+impl Blob {
+    pub fn from_bytes(bytes: &[u8], kzg_settings: &KZGSettings) -> Result<Blob, Error> {
+        if bytes.len() != kzg_settings.bytes_per_blob() {
+            return Err(Error::InvalidBytesLength(format!(
+                "Invalid byte length. Expected {} got {}",
+                kzg_settings.bytes_per_blob(),
+                bytes.len()
+            )));
+        }
+        Ok(Blob(Bytes::copy_from_slice(bytes)))
+    }
+
+    pub fn from_hex(hex_str: &str, kzg_settings: &KZGSettings) -> Result<Self, Error> {
+        Self::from_bytes(&hex_to_bytes(hex_str)?, kzg_settings)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+}
+
+impl Clone for Blob {
+    fn clone(&self) -> Self {
+        Blob(self.0.clone())
+    }
+}
+
 impl Bytes32 {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != 32 {
@@ -272,7 +307,7 @@ impl KZGProof {
     }
 
     pub fn compute_kzg_proof(
-        blob: &Vec<u8>,
+        blob: &Blob,
         z_bytes: &Bytes32,
         kzg_settings: &KZGSettings,
     ) -> Result<(Self, Bytes32), Error> {
@@ -302,7 +337,7 @@ impl KZGProof {
     }
 
     pub fn compute_blob_kzg_proof(
-        blob: &Vec<u8>,
+        blob: &Blob,
         commitment_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<Self, Error> {
@@ -355,7 +390,7 @@ impl KZGProof {
     }
 
     pub fn verify_blob_kzg_proof(
-        blob: &Vec<u8>,
+        blob: &Blob,
         commitment_bytes: &Bytes48,
         proof_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
@@ -385,7 +420,7 @@ impl KZGProof {
     }
 
     pub fn verify_blob_kzg_proof_batch(
-        blobs: &[Vec<u8>],
+        blobs: &[Blob],
         commitments_bytes: &[Bytes48],
         proofs_bytes: &[Bytes48],
         kzg_settings: &KZGSettings,
@@ -408,14 +443,7 @@ impl KZGProof {
         let mut flat_blobs: Vec<u8> =
             Vec::with_capacity(blobs.len() * kzg_settings.bytes_per_blob());
         for blob in blobs {
-            if blob.len() != kzg_settings.bytes_per_blob() {
-                return Err(Error::MismatchLength(format!(
-                    "Blob has {} bytes, expected {} bytes",
-                    blob.len(),
-                    kzg_settings.bytes_per_blob()
-                )));
-            }
-            flat_blobs.extend_from_slice(&blob);
+            flat_blobs.extend(&blob.0);
         }
 
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
@@ -459,10 +487,7 @@ impl KZGCommitment {
         hex::encode(self.bytes)
     }
 
-    pub fn blob_to_kzg_commitment(
-        blob: &Vec<u8>,
-        kzg_settings: &KZGSettings,
-    ) -> Result<Self, Error> {
+    pub fn blob_to_kzg_commitment(blob: &Blob, kzg_settings: &KZGSettings) -> Result<Self, Error> {
         if blob.len() != kzg_settings.bytes_per_blob() {
             return Err(Error::MismatchLength(format!(
                 "Blob has {} bytes, expected {} bytes",
@@ -557,7 +582,7 @@ mod tests {
         verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
     };
 
-    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
+    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
         let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
@@ -565,7 +590,7 @@ mod tests {
         for i in 0..s.field_elements_per_blob() {
             arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
         }
-        arr
+        Blob(Bytes::from(arr))
     }
 
     fn test_simple(trusted_setup_file: &Path) {
@@ -574,7 +599,7 @@ mod tests {
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
         let num_blobs: usize = rng.gen_range(1..16);
-        let mut blobs: Vec<Vec<u8>> = (0..num_blobs)
+        let mut blobs: Vec<Blob> = (0..num_blobs)
             .map(|_| generate_random_blob(&mut rng, &kzg_settings))
             .collect();
 
@@ -652,7 +677,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: blob_to_kzg_commitment_test::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let Ok(blob) = test.input.get_blob() else {
+            let Ok(blob) = test.input.get_blob(&kzg_settings) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -679,7 +704,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(blob), Ok(z)) = (test.input.get_blob(), test.input.get_z()) else {
+            let (Ok(blob), Ok(z)) = (test.input.get_blob(&kzg_settings), test.input.get_z()) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -709,7 +734,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(blob), Ok(commitment)) = (test.input.get_blob(), test.input.get_commitment())
+            let (Ok(blob), Ok(commitment)) = (test.input.get_blob(&kzg_settings), test.input.get_commitment())
             else {
                 assert!(test.get_output().is_none());
                 continue;
@@ -770,7 +795,7 @@ mod tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(commitment), Ok(proof)) = (
-                test.input.get_blob(),
+                test.input.get_blob(&kzg_settings),
                 test.input.get_commitment(),
                 test.input.get_proof(),
             ) else {
@@ -801,7 +826,7 @@ mod tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof_batch::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blobs), Ok(commitments), Ok(proofs)) = (
-                test.input.get_blobs(),
+                test.input.get_blobs(&kzg_settings),
                 test.input.get_commitments(),
                 test.input.get_proofs(),
             ) else {

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -42,7 +42,6 @@ pub struct KZGProof {
     bytes: [u8; BYTES_PER_PROOF],
 }
 
-#[repr(C)]
 pub struct Blob {
     bytes: Vec<u8>,
 }

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -311,13 +311,6 @@ impl KZGProof {
         z_bytes: &Bytes32,
         kzg_settings: &KZGSettings,
     ) -> Result<(Self, Bytes32), Error> {
-        if blob.len() != kzg_settings.bytes_per_blob() {
-            return Err(Error::MismatchLength(format!(
-                "Blob has {} bytes, expected {} bytes",
-                blob.len(),
-                kzg_settings.bytes_per_blob()
-            )));
-        }
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         let mut y_out = MaybeUninit::<Bytes32>::uninit();
         unsafe {
@@ -341,13 +334,6 @@ impl KZGProof {
         commitment_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<Self, Error> {
-        if blob.len() != kzg_settings.bytes_per_blob() {
-            return Err(Error::MismatchLength(format!(
-                "Blob has {} bytes, expected {} bytes",
-                blob.len(),
-                kzg_settings.bytes_per_blob()
-            )));
-        }
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         unsafe {
             let res = compute_blob_kzg_proof(
@@ -395,13 +381,6 @@ impl KZGProof {
         proof_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
-        if blob.len() != kzg_settings.bytes_per_blob() {
-            return Err(Error::MismatchLength(format!(
-                "Blob has {} bytes, expected {} bytes",
-                blob.len(),
-                kzg_settings.bytes_per_blob()
-            )));
-        }
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
         unsafe {
             let res = verify_blob_kzg_proof(
@@ -488,13 +467,6 @@ impl KZGCommitment {
     }
 
     pub fn blob_to_kzg_commitment(blob: &Blob, kzg_settings: &KZGSettings) -> Result<Self, Error> {
-        if blob.len() != kzg_settings.bytes_per_blob() {
-            return Err(Error::MismatchLength(format!(
-                "Blob has {} bytes, expected {} bytes",
-                blob.len(),
-                kzg_settings.bytes_per_blob()
-            )));
-        }
         let mut kzg_commitment: MaybeUninit<KZGCommitment> = MaybeUninit::uninit();
         unsafe {
             let res =

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -127,12 +127,10 @@ impl KZGSettings {
 
     /// Loads the trusted setup parameters from a file. The file format is as follows:
     ///
-    /// ```
     /// FIELD_ELEMENTS_PER_BLOB
     /// 65 # This is fixed and is used for providing multiproofs up to 64 field elements.
     /// FIELD_ELEMENT_PER_BLOB g1 byte values
     /// 65 g2 byte values
-    /// ```
     #[cfg(feature = "std")]
     pub fn load_trusted_setup_file(file_path: &Path) -> Result<Self, Error> {
         #[cfg(unix)]
@@ -156,12 +154,10 @@ impl KZGSettings {
 
     /// Loads the trusted setup parameters from a file. The file format is as follows:
     ///
-    /// ```
     /// FIELD_ELEMENTS_PER_BLOB
     /// 65 # This is fixed and is used for providing multiproofs up to 64 field elements.
     /// FIELD_ELEMENT_PER_BLOB g1 byte values
     /// 65 g2 byte values
-    /// ```
     #[cfg(not(feature = "std"))]
     pub fn load_trusted_setup_file(file_path: &CStr) -> Result<Self, Error> {
         Self::load_trusted_setup_file_inner(file_path)

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -212,12 +212,12 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
-    pub fn from_bytes(bytes: &[u8], kzg_settings: &KZGSettings) -> Result<Blob, Error> {
+    pub fn from_bytes(bytes: &[u8], kzg_settings: &KZGSettings) -> Result<Self, Error> {
         if bytes.len() != kzg_settings.bytes_per_blob() {
             return Err(Error::InvalidBytesLength(format!(
                 "Invalid byte length. Expected {} got {}",
                 kzg_settings.bytes_per_blob(),
-                bytes.len()
+                bytes.len(),
             )));
         }
         Ok(Blob(Bytes::copy_from_slice(bytes)))

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -9,30 +9,6 @@ mod test_formats;
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
-#[cfg(not(feature = "minimal-spec"))]
-use {
-    ckzg_blob_to_kzg_commitment as blob_to_kzg_commitment,
-    ckzg_compute_blob_kzg_proof as compute_blob_kzg_proof,
-    ckzg_compute_kzg_proof as compute_kzg_proof, ckzg_free_trusted_setup as free_trusted_setup,
-    ckzg_load_trusted_setup as load_trusted_setup,
-    ckzg_load_trusted_setup_file as load_trusted_setup_file,
-    ckzg_verify_blob_kzg_proof as verify_blob_kzg_proof,
-    ckzg_verify_blob_kzg_proof_batch as verify_blob_kzg_proof_batch,
-    ckzg_verify_kzg_proof as verify_kzg_proof,
-};
-#[cfg(feature = "minimal-spec")]
-use {
-    ckzg_min_blob_to_kzg_commitment as blob_to_kzg_commitment,
-    ckzg_min_compute_blob_kzg_proof as compute_blob_kzg_proof,
-    ckzg_min_compute_kzg_proof as compute_kzg_proof,
-    ckzg_min_free_trusted_setup as free_trusted_setup,
-    ckzg_min_load_trusted_setup as load_trusted_setup,
-    ckzg_min_load_trusted_setup_file as load_trusted_setup_file,
-    ckzg_min_verify_blob_kzg_proof as verify_blob_kzg_proof,
-    ckzg_min_verify_blob_kzg_proof_batch as verify_blob_kzg_proof_batch,
-    ckzg_min_verify_kzg_proof as verify_kzg_proof,
-};
-
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ffi::CStr;
@@ -47,10 +23,6 @@ use std::path::Path;
 
 pub const BYTES_PER_G1_POINT: usize = 48;
 pub const BYTES_PER_G2_POINT: usize = 96;
-
-/// Number of G2 points required for the kzg trusted setup.
-/// 65 is fixed and is used for providing multiproofs up to 64 field elements.
-const NUM_G2_POINTS: usize = 65;
 
 /// A trusted (valid) KZG commitment.
 // NOTE: this is a type alias to the struct Bytes48, same as [`KZGProof`] in the C header files. To
@@ -68,6 +40,11 @@ pub struct KZGCommitment {
 #[repr(C)]
 pub struct KZGProof {
     bytes: [u8; BYTES_PER_PROOF],
+}
+
+#[repr(C)]
+pub struct Blob {
+    bytes: Vec<u8>,
 }
 
 #[derive(Debug)]
@@ -120,20 +97,6 @@ impl KZGSettings {
         g1_bytes: &[[u8; BYTES_PER_G1_POINT]],
         g2_bytes: &[[u8; BYTES_PER_G2_POINT]],
     ) -> Result<Self, Error> {
-        if g1_bytes.len() != FIELD_ELEMENTS_PER_BLOB {
-            return Err(Error::InvalidTrustedSetup(format!(
-                "Invalid number of g1 points in trusted setup. Expected {} got {}",
-                FIELD_ELEMENTS_PER_BLOB,
-                g1_bytes.len()
-            )));
-        }
-        if g2_bytes.len() != NUM_G2_POINTS {
-            return Err(Error::InvalidTrustedSetup(format!(
-                "Invalid number of g2 points in trusted setup. Expected {} got {}",
-                NUM_G2_POINTS,
-                g2_bytes.len()
-            )));
-        }
         let mut kzg_settings = MaybeUninit::<KZGSettings>::uninit();
         unsafe {
             let res = load_trusted_setup(
@@ -233,6 +196,14 @@ impl KZGSettings {
 
         result
     }
+
+    pub fn get_field_elements_per_blob(self: &Self) -> usize {
+        return self.field_elements_per_blob as usize;
+    }
+
+    pub fn get_bytes_per_blob(self: &Self) -> usize {
+        return self.bytes_per_blob as usize;
+    }
 }
 
 impl Drop for KZGSettings {
@@ -242,21 +213,21 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != BYTES_PER_BLOB {
+    pub fn from_bytes(bytes: &[u8], s: &KZGSettings) -> Result<Self, Error> {
+        if bytes.len() != s.get_bytes_per_blob() {
             return Err(Error::InvalidBytesLength(format!(
                 "Invalid byte length. Expected {} got {}",
-                BYTES_PER_BLOB,
+                s.get_bytes_per_blob(),
                 bytes.len(),
             )));
         }
-        let mut new_bytes = [0; BYTES_PER_BLOB];
-        new_bytes.copy_from_slice(bytes);
-        Ok(Self { bytes: new_bytes })
+        Ok(Self {
+            bytes: bytes.to_vec(),
+        })
     }
 
-    pub fn from_hex(hex_str: &str) -> Result<Self, Error> {
-        Self::from_bytes(&hex_to_bytes(hex_str)?)
+    pub fn from_hex(hex_str: &str, s: &KZGSettings) -> Result<Self, Error> {
+        Self::from_bytes(&hex_to_bytes(hex_str)?, s)
     }
 }
 
@@ -329,13 +300,20 @@ impl KZGProof {
         z_bytes: &Bytes32,
         kzg_settings: &KZGSettings,
     ) -> Result<(Self, Bytes32), Error> {
+        if blob.bytes.len() != kzg_settings.get_bytes_per_blob() {
+            return Err(Error::MismatchLength(format!(
+                "Blob has {} bytes, expected {} bytes",
+                blob.bytes.len(),
+                kzg_settings.get_bytes_per_blob()
+            )));
+        }
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         let mut y_out = MaybeUninit::<Bytes32>::uninit();
         unsafe {
             let res = compute_kzg_proof(
                 kzg_proof.as_mut_ptr(),
                 y_out.as_mut_ptr(),
-                blob,
+                blob.bytes.as_ptr(),
                 z_bytes,
                 kzg_settings,
             );
@@ -352,11 +330,18 @@ impl KZGProof {
         commitment_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<Self, Error> {
+        if blob.bytes.len() != kzg_settings.get_bytes_per_blob() {
+            return Err(Error::MismatchLength(format!(
+                "Blob has {} bytes, expected {} bytes",
+                blob.bytes.len(),
+                kzg_settings.get_bytes_per_blob()
+            )));
+        }
         let mut kzg_proof = MaybeUninit::<KZGProof>::uninit();
         unsafe {
             let res = compute_blob_kzg_proof(
                 kzg_proof.as_mut_ptr(),
-                blob,
+                blob.bytes.as_ptr(),
                 commitment_bytes,
                 kzg_settings,
             );
@@ -399,11 +384,18 @@ impl KZGProof {
         proof_bytes: &Bytes48,
         kzg_settings: &KZGSettings,
     ) -> Result<bool, Error> {
+        if blob.bytes.len() != kzg_settings.get_bytes_per_blob() {
+            return Err(Error::MismatchLength(format!(
+                "Blob has {} bytes, expected {} bytes",
+                blob.bytes.len(),
+                kzg_settings.get_bytes_per_blob()
+            )));
+        }
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
         unsafe {
             let res = verify_blob_kzg_proof(
                 verified.as_mut_ptr(),
-                blob,
+                blob.bytes.as_ptr(),
                 commitment_bytes,
                 proof_bytes,
                 kzg_settings,
@@ -436,11 +428,25 @@ impl KZGProof {
                 proofs_bytes.len()
             )));
         }
+
+        let mut flatBlobs: Vec<u8> =
+            Vec::with_capacity(blobs.len() * kzg_settings.get_bytes_per_blob());
+        for blob in blobs {
+            if blob.bytes.len() != kzg_settings.get_bytes_per_blob() {
+                return Err(Error::MismatchLength(format!(
+                    "Blob has {} bytes, expected {} bytes",
+                    blob.bytes.len(),
+                    kzg_settings.get_bytes_per_blob()
+                )));
+            }
+            flatBlobs.extend_from_slice(&blob.bytes);
+        }
+
         let mut verified: MaybeUninit<bool> = MaybeUninit::uninit();
         unsafe {
             let res = verify_blob_kzg_proof_batch(
                 verified.as_mut_ptr(),
-                blobs.as_ptr(),
+                flatBlobs.as_ptr(),
                 commitments_bytes.as_ptr(),
                 proofs_bytes.as_ptr(),
                 blobs.len(),
@@ -478,9 +484,20 @@ impl KZGCommitment {
     }
 
     pub fn blob_to_kzg_commitment(blob: &Blob, kzg_settings: &KZGSettings) -> Result<Self, Error> {
+        if blob.bytes.len() != kzg_settings.get_bytes_per_blob() {
+            return Err(Error::MismatchLength(format!(
+                "Blob has {} bytes, expected {} bytes",
+                blob.bytes.len(),
+                kzg_settings.get_bytes_per_blob()
+            )));
+        }
         let mut kzg_commitment: MaybeUninit<KZGCommitment> = MaybeUninit::uninit();
         unsafe {
-            let res = blob_to_kzg_commitment(kzg_commitment.as_mut_ptr(), blob, kzg_settings);
+            let res = blob_to_kzg_commitment(
+                kzg_commitment.as_mut_ptr(),
+                blob.bytes.as_ptr(),
+                kzg_settings,
+            );
             if let C_KZG_RET::C_KZG_OK = res {
                 Ok(kzg_commitment.assume_init())
             } else {
@@ -498,12 +515,6 @@ impl From<[u8; BYTES_PER_COMMITMENT]> for KZGCommitment {
 
 impl From<[u8; BYTES_PER_PROOF]> for KZGProof {
     fn from(value: [u8; BYTES_PER_PROOF]) -> Self {
-        Self { bytes: value }
-    }
-}
-
-impl From<[u8; BYTES_PER_BLOB]> for Blob {
-    fn from(value: [u8; BYTES_PER_BLOB]) -> Self {
         Self { bytes: value }
     }
 }
@@ -541,7 +552,7 @@ impl DerefMut for Bytes48 {
 }
 
 impl Deref for Blob {
-    type Target = [u8; BYTES_PER_BLOB];
+    type Target = Vec<u8>;
     fn deref(&self) -> &Self::Target {
         &self.bytes
     }
@@ -555,7 +566,9 @@ impl DerefMut for Blob {
 
 impl Clone for Blob {
     fn clone(&self) -> Self {
-        Blob { bytes: self.bytes }
+        Blob {
+            bytes: self.bytes.clone(),
+        }
     }
 }
 
@@ -589,15 +602,18 @@ mod tests {
         verify_blob_kzg_proof, verify_blob_kzg_proof_batch, verify_kzg_proof,
     };
 
-    fn generate_random_blob(rng: &mut ThreadRng) -> Blob {
-        let mut arr = [0u8; BYTES_PER_BLOB];
+    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
+        let mut arr: Vec<u8> = Vec::with_capacity(s.get_bytes_per_blob());
+        arr.resize(s.get_bytes_per_blob(), 0);
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
-        for i in 0..FIELD_ELEMENTS_PER_BLOB {
+        for i in 0..s.get_field_elements_per_blob() {
             arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
         }
-        arr.into()
+        Blob {
+            bytes: arr.to_vec(),
+        }
     }
 
     fn test_simple(trusted_setup_file: &Path) {
@@ -607,7 +623,7 @@ mod tests {
 
         let num_blobs: usize = rng.gen_range(1..16);
         let mut blobs: Vec<Blob> = (0..num_blobs)
-            .map(|_| generate_random_blob(&mut rng))
+            .map(|_| generate_random_blob(&mut rng, &kzg_settings))
             .collect();
 
         let commitments: Vec<Bytes48> = blobs
@@ -640,7 +656,7 @@ mod tests {
                 .unwrap_err();
         assert!(matches!(error, Error::MismatchLength(_)));
 
-        let incorrect_blob = generate_random_blob(&mut rng);
+        let incorrect_blob = generate_random_blob(&mut rng, &kzg_settings);
         blobs.push(incorrect_blob);
 
         assert!(!KZGProof::verify_blob_kzg_proof_batch(
@@ -684,7 +700,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: blob_to_kzg_commitment_test::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let Ok(blob) = test.input.get_blob() else {
+            let Ok(blob) = test.input.get_blob(&kzg_settings) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -711,7 +727,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(blob), Ok(z)) = (test.input.get_blob(), test.input.get_z()) else {
+            let (Ok(blob), Ok(z)) = (test.input.get_blob(&kzg_settings), test.input.get_z()) else {
                 assert!(test.get_output().is_none());
                 continue;
             };
@@ -741,7 +757,7 @@ mod tests {
         for test_file in test_files {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: compute_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
-            let (Ok(blob), Ok(commitment)) = (test.input.get_blob(), test.input.get_commitment())
+            let (Ok(blob), Ok(commitment)) = (test.input.get_blob(&kzg_settings), test.input.get_commitment())
             else {
                 assert!(test.get_output().is_none());
                 continue;
@@ -802,7 +818,7 @@ mod tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blob), Ok(commitment), Ok(proof)) = (
-                test.input.get_blob(),
+                test.input.get_blob(&kzg_settings),
                 test.input.get_commitment(),
                 test.input.get_proof(),
             ) else {
@@ -833,7 +849,7 @@ mod tests {
             let yaml_data = fs::read_to_string(test_file).unwrap();
             let test: verify_blob_kzg_proof_batch::Test = serde_yaml::from_str(&yaml_data).unwrap();
             let (Ok(blobs), Ok(commitments), Ok(proofs)) = (
-                test.input.get_blobs(),
+                test.input.get_blobs(&kzg_settings),
                 test.input.get_commitments(),
                 test.input.get_proofs(),
             ) else {

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -1,6 +1,6 @@
 //! Serde serialization and deserialization for the basic types in this crate.
 
-use crate::{Blob, Bytes32, Bytes48};
+use crate::{Bytes32, Bytes48};
 use alloc::string::String;
 use alloc::vec::Vec;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -18,21 +18,6 @@ fn deserialize_hex<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>
     let s = String::deserialize(deserializer)?;
     let hex_bytes = s.strip_prefix("0x").unwrap_or(&s);
     hex::decode(hex_bytes).map_err(Error::custom)
-}
-
-impl Serialize for Blob {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_bytes(self.bytes.as_slice(), serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for Blob {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Blob::from_bytes_unsafe(&deserialize_hex(deserializer)?).map_err(Error::custom)
-    }
 }
 
 impl Serialize for Bytes48 {

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -55,7 +55,7 @@ mod tests {
     use super::super::*;
     use rand::{rngs::ThreadRng, Rng};
 
-    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
+    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
         let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
@@ -63,7 +63,7 @@ mod tests {
         for i in 0..s.field_elements_per_blob() {
             arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
         }
-        arr.into()
+        Blob::from_bytes(&arr, &s).unwrap()
     }
 
     fn trusted_setup_file() -> &'static Path {

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -55,8 +55,8 @@ mod tests {
     use super::super::*;
     use rand::{rngs::ThreadRng, Rng};
 
-    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
-        let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
+        let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
@@ -90,7 +90,7 @@ mod tests {
 
         // check blob serialization
         let blob_serialized = serde_json::to_string(&blob).unwrap();
-        let blob_deserialized: Blob = serde_json::from_str(&blob_serialized).unwrap();
+        let blob_deserialized = serde_json::from_str(&blob_serialized).unwrap();
         assert_eq!(blob, blob_deserialized);
 
         // check commitment serialization

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -85,9 +85,9 @@ mod tests {
         // generate blob, commitment, proof
         let mut rng = rand::thread_rng();
         let blob = generate_random_blob(&mut rng, &kzg_settings);
-        let commitment = KZGCommitment::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap();
+        let commitment = kzg_settings.blob_to_kzg_commitment(&blob).unwrap();
         let proof =
-            KZGProof::compute_blob_kzg_proof(&blob, &commitment.to_bytes(), &kzg_settings).unwrap();
+            kzg_settings.compute_blob_kzg_proof(&blob, &commitment.to_bytes()).unwrap();
 
         // check commitment serialization
         let commitment_serialized = serde_json::to_string(&commitment.to_bytes()).unwrap();
@@ -111,7 +111,7 @@ mod tests {
         // generate blob just to calculate a commitment
         let mut rng = rand::thread_rng();
         let blob = generate_random_blob(&mut rng, &kzg_settings);
-        let commitment = KZGCommitment::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap();
+        let commitment = kzg_settings.blob_to_kzg_commitment(&blob).unwrap();
 
         // check blob serialization
         let blob_serialized = serde_json::to_string(&commitment.to_bytes()).unwrap();

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -86,8 +86,9 @@ mod tests {
         let mut rng = rand::thread_rng();
         let blob = generate_random_blob(&mut rng, &kzg_settings);
         let commitment = kzg_settings.blob_to_kzg_commitment(&blob).unwrap();
-        let proof =
-            kzg_settings.compute_blob_kzg_proof(&blob, &commitment.to_bytes()).unwrap();
+        let proof = kzg_settings
+            .compute_blob_kzg_proof(&blob, &commitment.to_bytes())
+            .unwrap();
 
         // check commitment serialization
         let commitment_serialized = serde_json::to_string(&commitment.to_bytes()).unwrap();

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use super::deserialize_blob;
+use crate::{Bytes48, Error};
+use bytes::Bytes;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, kzg_settings)
+    pub fn get_blob(&self) -> Result<Bytes, Error> {
+        deserialize_blob(self.blob)
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,8 +9,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob)
+    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, s)
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::bindings::hex_to_bytes;
+use crate::{Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::bindings::hex_to_bytes;
-use crate::{Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +9,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, kzg_settings)
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::bindings::hex_to_bytes;
+use crate::{Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use crate::bindings::hex_to_bytes;
-use crate::{Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -11,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, kzg_settings)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use super::deserialize_blob;
+use crate::{Bytes48, Error};
+use bytes::Bytes;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, kzg_settings)
+    pub fn get_blob(&self) -> Result<Bytes, Error> {
+        deserialize_blob(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob)
+    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, s)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Bytes32, Bytes48, Error};
+use crate::{Blob, Bytes32, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -11,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, kzg_settings)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes32, Bytes48, Error};
+use crate::{Blob, Bytes32, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob)
+    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, s)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes32, Bytes48, Error, KzgSettings};
+use super::deserialize_blob;
+use crate::{Bytes32, Bytes48, Error};
+use bytes::Bytes;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, kzg_settings)
+    pub fn get_blob(&self) -> Result<Bytes, Error> {
+        deserialize_blob(self.blob)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes32, Bytes48, Error, KzgSettings};
+use crate::{Bytes32, Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -10,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/mod.rs
+++ b/bindings/rust/src/bindings/test_formats/mod.rs
@@ -4,3 +4,13 @@ pub mod compute_kzg_proof;
 pub mod verify_blob_kzg_proof;
 pub mod verify_blob_kzg_proof_batch;
 pub mod verify_kzg_proof;
+
+use bytes::Bytes;
+use crate::Error;
+
+use super::hex_to_bytes;
+
+pub(crate) fn deserialize_blob(blob_str: &str) -> Result<Bytes, Error> {
+    let bytes = hex_to_bytes(blob_str)?;
+    Ok(Bytes::from(bytes))
+}

--- a/bindings/rust/src/bindings/test_formats/mod.rs
+++ b/bindings/rust/src/bindings/test_formats/mod.rs
@@ -5,8 +5,8 @@ pub mod verify_blob_kzg_proof;
 pub mod verify_blob_kzg_proof_batch;
 pub mod verify_kzg_proof;
 
-use bytes::Bytes;
 use crate::Error;
+use bytes::Bytes;
 
 use super::hex_to_bytes;
 

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::{Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -11,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -11,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob)
+    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, s)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -12,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
+        Blob::from_hex(self.blob, kzg_settings)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use super::deserialize_blob;
+use crate::{Bytes48, Error};
+use bytes::Bytes;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -11,8 +13,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, kzg_settings: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, kzg_settings)
+    pub fn get_blob(&self) -> Result<Bytes, Error> {
+        deserialize_blob(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Bytes48, Error};
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input {
@@ -12,10 +11,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let mut v: Vec<Vec<u8>> = Vec::new();
+    pub fn get_blobs(&self, kzg_settings: &KzgSettings) -> Result<Vec<Blob>, Error> {
+        let mut v: Vec<Blob> = Vec::new();
         for blob in &self.blobs {
-            v.push(hex_to_bytes(blob)?);
+            v.push(Blob::from_hex(blob, kzg_settings)?);
         }
         Ok(v)
     }

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error};
-use alloc::string::String;
-use alloc::vec::Vec;
+use crate::{Blob, Bytes48, Error, KzgSettings};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -13,11 +11,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self) -> Result<Vec<Blob>, Error> {
-        // TODO: `iter.map.collect` overflows the stack
-        let mut v = Vec::with_capacity(self.blobs.len());
+    pub fn get_blobs(&self, s: &KzgSettings) -> Result<Vec<Blob>, Error> {
+        let mut v: Vec<Blob> = Vec::new();
         for blob in &self.blobs {
-            v.push(Blob::from_hex(blob)?);
+            v.push(Blob::from_hex(blob, s)?);
         }
         Ok(v)
     }

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::{Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input {
@@ -11,10 +12,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self, s: &KzgSettings) -> Result<Vec<Blob>, Error> {
-        let mut v: Vec<Blob> = Vec::new();
+    pub fn get_blobs(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let mut v: Vec<Vec<u8>> = Vec::new();
         for blob in &self.blobs {
-            v.push(Blob::from_hex(blob, s)?);
+            v.push(hex_to_bytes(blob)?);
         }
         Ok(v)
     }

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use super::deserialize_blob;
+use crate::{Bytes48, Error};
+use bytes::Bytes;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -11,10 +13,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self, kzg_settings: &KzgSettings) -> Result<Vec<Blob>, Error> {
-        let mut v: Vec<Blob> = Vec::new();
+    pub fn get_blobs(&self) -> Result<Vec<Bytes>, Error> {
+        let mut v: Vec<Bytes> = Vec::new();
         for blob in &self.blobs {
-            v.push(Blob::from_hex(blob, kzg_settings)?);
+            v.push(deserialize_blob(blob)?);
         }
         Ok(v)
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -21,4 +21,4 @@ pub use bindings::{
     BYTES_PER_PROOF,
 };
 // Expose the remaining relevant types.
-pub use bindings::{Blob, Bytes32, Bytes48, Error};
+pub use bindings::{Bytes32, Bytes48, Error};

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -17,8 +17,8 @@ pub use bindings::{
 };
 // Expose the constants.
 pub use bindings::{
-    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT,
-    BYTES_PER_G2_POINT, BYTES_PER_PROOF, FIELD_ELEMENTS_PER_BLOB,
+    BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT, BYTES_PER_G2_POINT,
+    BYTES_PER_PROOF,
 };
 // Expose the remaining relevant types.
 pub use bindings::{Blob, Bytes32, Bytes48, Error};

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -21,4 +21,4 @@ pub use bindings::{
     BYTES_PER_PROOF,
 };
 // Expose the remaining relevant types.
-pub use bindings::{Bytes32, Bytes48, Error};
+pub use bindings::{Blob, Bytes32, Bytes48, Error};


### PR DESCRIPTION
This is a version of what Sean described in https://github.com/ethereum/c-kzg-4844/pull/363#issuecomment-1749509149

The changes are the following:
1. Make all kzg interface functions methods on the `KzgSettings` struct
2. In the public interface, the `Blob` argument is just a byte slice
3. Make `Blob` a private type which contains a byte slice. The `Blob` constructor does the length check and returns an error if it doesn't equal `self.bytes_per_blob()`
4. Have internal functions which accept a length validated`Blob` call the underlying FFI functions.

Some advantages to this approach:
1. No generics
2. `Blob` being just a byte slice in the public interface means that users of the library can store the Blobs in whatever container they want and don't have to do conversions before passing it to the library
3. All kzg functions being methods on `KzgSettings` is advantageous because we do the blob length validations w.r.t a given trusted setup
4. A `Blob` passed to the internal functions would be valid w.r.t the passed `KzgSettings` so there's less scope of shooting ourselves in the foot for any future changes.

Curious to see what you guys think @Rjected @asn-d6 @jtraglia 
cc @realbigsean

