### PR TITLE
chore: npm publish 2.1.2

### DIFF
--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",


### PR DESCRIPTION
update the c-kzg on npm
(2.1.1 publish had an issue while publishing so had to publish 2.1.2)