### PR TITLE
ci: ensure setuptools are installed

### DIFF
--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{matrix.node}}
+      - name: Install setuptools
+        run: python3 -m pip install setuptools
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
         working-directory: bindings/node.js


### PR DESCRIPTION
distutils is deprecated with python 3.12 and no longer included.
should fix Nodejs CI

ref https://github.com/ethereum/c-kzg-4844/pull/380
 