### PR TITLE
Fixed x86_64-pc-windows-gcc build for rust bindings

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
     let mut cc = cc::Build::new();
 
-    #[cfg(windows)]
+    #[cfg(all(windows, target_env = "msvc"))]
     {
         cc.flag("-D_CRT_SECURE_NO_WARNINGS");
 


### PR DESCRIPTION
Fixed rust bindings build from windows-gcc toolchain

https://github.com/ethereum/c-kzg-4844/pull/354#issuecomment-1856355981

cc @jtraglia @asn-d6 