### PR TITLE
feat: add pub methods for cell and export das items

### DIFF
--- a/bindings/rust/rust-toolchain
+++ b/bindings/rust/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(new_uninit)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
@@ -19,7 +18,8 @@ pub use bindings::{
 // Expose the constants.
 pub use bindings::{
     BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT,
-    BYTES_PER_G2_POINT, BYTES_PER_PROOF, FIELD_ELEMENTS_PER_BLOB,
+    BYTES_PER_G2_POINT, BYTES_PER_PROOF, CELLS_PER_BLOB, DATA_POINTS_PER_BLOB,
+    FIELD_ELEMENTS_PER_BLOB, FIELD_ELEMENTS_PER_CELL,
 };
 // Expose the remaining relevant types.
-pub use bindings::{Blob, Bytes32, Bytes48, Error};
+pub use bindings::{Blob, Bytes32, Bytes48, Cell, Error};


### PR DESCRIPTION
add `pub` methods to `Cell` to retrieve inner data and KZG proof and to construct `Cell`.

export the following DAS items:

* `CELLS_PER_BLOB`
* `DATA_POINTS_PER_BLOB`
* `FIELD_ELEMENTS_PER_CELL`
* `Cell`

modify construction of boxed `Cell` array to not rely on `nightly` channel.