### PR TITLE
feat: add more targets to ci

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dan/multi-arch-ci
   pull_request:
     branches:
       - main
@@ -23,22 +24,42 @@ jobs:
         run: cargo hack check --feature-powerset --depth 2
 
   tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+          - host: macos-14
+            target: aarch64-apple-darwin
+          - host: macos-latest
+            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./bindings/rust"
+          cache-on-failure: true
+
       - name: Build and Test
         working-directory: bindings/rust
-        run: cargo test
+        run: cargo test --target ${{ matrix.target }}
       - name: Benchmark
         working-directory: bindings/rust
-        run: cargo bench
+        run: cargo bench --target ${{ matrix.target }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./bindings/rust"
       - name: cargo hack
         working-directory: bindings/rust
         run: cargo hack check --feature-powerset --depth 2

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -31,8 +31,6 @@ jobs:
       matrix:
         include:
           - host: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - host: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - dan/multi-arch-ci
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Adds `aarch64` targets to the rust CI alongside `x86_86`, including for macOS, using the new M1 runner. Also fixes an issue where `rust-cache` would not find `bindings/rust/Cargo.toml` due to the `workspace` field being unset.