### PR TITLE
chore: make standalone portable feature, enabled by default

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -8,10 +8,14 @@ links = "ckzg"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "blst/portable"]
+default = ["std", "portable"]
 std = ["hex/std", "libc/std", "serde?/std"]
 serde = ["dep:serde"]
 generate-bindings = ["dep:bindgen"]
+
+# This is a standalone feature so that crates that disable default features can
+# enable blst/portable without having to add it as a dependency
+portable = ["blst/portable"]
 
 # BLST Compilation:
 # Suppress multi-threading.


### PR DESCRIPTION
This way crates can do:
```toml
c-kzg = { version = "0.4.x", default-features = false }

[features]
default = ["portable"]
std = ["c-kzg/std"] # common pattern w/ std
portable = ["c-kzg/portable"]
```
instead of
```toml
c-kzg = { version = "0.4.1", default-features = false }
blst = { version = "0.3.11", default-features = false, optional = true }

[features]
default = ["portable"]
std = ["c-kzg/std"] # common pattern w/ std
portable = ["dep:blst", "blst?/portable"]
```