### PR TITLE
go-bindings: pass large arrays by ref instead of value

### DIFF
--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -49,14 +49,14 @@ var (
 // will return nil.
 func makeErrorFromRet(ret C.C_KZG_RET) error {
 	switch ret {
+	case C.C_KZG_OK:
+		return nil
 	case C.C_KZG_BADARGS:
 		return ErrBadArgs
 	case C.C_KZG_ERROR:
 		return ErrError
 	case C.C_KZG_MALLOC:
 		return ErrMalloc
-	case C.C_KZG_OK:
-		return nil
 	}
 	return fmt.Errorf("unexpected return value from c-library %v", ret)
 }

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -200,14 +200,14 @@ BlobToKZGCommitment is the binding for:
 	    const Blob *blob,
 	    const KZGSettings *s);
 */
-func BlobToKZGCommitment(blob Blob) (KZGCommitment, error) {
+func BlobToKZGCommitment(blob *Blob) (KZGCommitment, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
 	}
 	commitment := KZGCommitment{}
 	ret := C.blob_to_kzg_commitment(
 		(*C.KZGCommitment)(unsafe.Pointer(&commitment)),
-		(*C.Blob)(unsafe.Pointer(&blob)),
+		(*C.Blob)(unsafe.Pointer(blob)),
 		&settings)
 	return commitment, makeErrorFromRet(ret)
 }
@@ -222,7 +222,7 @@ ComputeKZGProof is the binding for:
 	    const Bytes32 *z_bytes,
 	    const KZGSettings *s);
 */
-func ComputeKZGProof(blob Blob, zBytes Bytes32) (KZGProof, Bytes32, error) {
+func ComputeKZGProof(blob *Blob, zBytes Bytes32) (KZGProof, Bytes32, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
 	}
@@ -231,7 +231,7 @@ func ComputeKZGProof(blob Blob, zBytes Bytes32) (KZGProof, Bytes32, error) {
 	ret := C.compute_kzg_proof(
 		(*C.KZGProof)(unsafe.Pointer(&proof)),
 		(*C.Bytes32)(unsafe.Pointer(&y)),
-		(*C.Blob)(unsafe.Pointer(&blob)),
+		(*C.Blob)(unsafe.Pointer(blob)),
 		(*C.Bytes32)(unsafe.Pointer(&zBytes)),
 		&settings)
 	return proof, y, makeErrorFromRet(ret)
@@ -246,14 +246,14 @@ ComputeBlobKZGProof is the binding for:
 	    const Bytes48 *commitment_bytes,
 	    const KZGSettings *s);
 */
-func ComputeBlobKZGProof(blob Blob, commitmentBytes Bytes48) (KZGProof, error) {
+func ComputeBlobKZGProof(blob *Blob, commitmentBytes Bytes48) (KZGProof, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
 	}
 	proof := KZGProof{}
 	ret := C.compute_blob_kzg_proof(
 		(*C.KZGProof)(unsafe.Pointer(&proof)),
-		(*C.Blob)(unsafe.Pointer(&blob)),
+		(*C.Blob)(unsafe.Pointer(blob)),
 		(*C.Bytes48)(unsafe.Pointer(&commitmentBytes)),
 		&settings)
 	return proof, makeErrorFromRet(ret)
@@ -295,14 +295,14 @@ VerifyBlobKZGProof is the binding for:
 	    const Bytes48 *proof_bytes,
 	    const KZGSettings *s);
 */
-func VerifyBlobKZGProof(blob Blob, commitmentBytes, proofBytes Bytes48) (bool, error) {
+func VerifyBlobKZGProof(blob *Blob, commitmentBytes, proofBytes Bytes48) (bool, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
 	}
 	var result C.bool
 	ret := C.verify_blob_kzg_proof(
 		&result,
-		(*C.Blob)(unsafe.Pointer(&blob)),
+		(*C.Blob)(unsafe.Pointer(blob)),
 		(*C.Bytes48)(unsafe.Pointer(&commitmentBytes)),
 		(*C.Bytes48)(unsafe.Pointer(&proofBytes)),
 		&settings)

--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -45,12 +45,10 @@ var (
 ///////////////////////////////////////////////////////////////////////////////
 
 // makeErrorFromRet translates an (integral) return value, as reported
-// by the C library, into a proper Go error. If there is no error, this
-// will return nil.
+// by the C library, into a proper Go error. This function should only be
+// called when there is an error, not with C_KZG_OK.
 func makeErrorFromRet(ret C.C_KZG_RET) error {
 	switch ret {
-	case C.C_KZG_OK:
-		return nil
 	case C.C_KZG_BADARGS:
 		return ErrBadArgs
 	case C.C_KZG_ERROR:
@@ -58,7 +56,7 @@ func makeErrorFromRet(ret C.C_KZG_RET) error {
 	case C.C_KZG_MALLOC:
 		return ErrMalloc
 	}
-	return fmt.Errorf("unexpected return value from c-library %v", ret)
+	return fmt.Errorf("unexpected error from c-library: %v", ret)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -91,7 +91,7 @@ func TestBlobToKZGCommitment(t *testing.T) {
 				return
 			}
 
-			commitment, err := BlobToKZGCommitment(blob)
+			commitment, err := BlobToKZGCommitment(&blob)
 			if err == nil {
 				require.NotNil(t, test.Output)
 				require.Equal(t, test.Output[:], commitment[:])
@@ -138,7 +138,7 @@ func TestComputeKZGProof(t *testing.T) {
 				return
 			}
 
-			proof, y, err := ComputeKZGProof(blob, z)
+			proof, y, err := ComputeKZGProof(&blob, z)
 			if err == nil {
 				require.NotNil(t, test.Output)
 				var expectedProof Bytes48
@@ -192,7 +192,7 @@ func TestComputeBlobKZGProof(t *testing.T) {
 				return
 			}
 
-			proof, err := ComputeBlobKZGProof(blob, commitment)
+			proof, err := ComputeBlobKZGProof(&blob, commitment)
 			if err == nil {
 				require.NotNil(t, test.Output)
 				require.Equal(t, test.Output[:], proof[:])
@@ -310,7 +310,7 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 				return
 			}
 
-			valid, err := VerifyBlobKZGProof(blob, commitment, proof)
+			valid, err := VerifyBlobKZGProof(&blob, commitment, proof)
 			if err == nil {
 				require.NotNil(t, test.Output)
 				require.Equal(t, *test.Output, valid)
@@ -400,9 +400,9 @@ func Benchmark(b *testing.B) {
 	fields := [length]Bytes32{}
 	for i := 0; i < length; i++ {
 		blob := getRandBlob(int64(i))
-		commitment, err := BlobToKZGCommitment(blob)
+		commitment, err := BlobToKZGCommitment(&blob)
 		require.NoError(b, err)
-		proof, err := ComputeBlobKZGProof(blob, Bytes48(commitment))
+		proof, err := ComputeBlobKZGProof(&blob, Bytes48(commitment))
 		require.NoError(b, err)
 
 		blobs[i] = blob
@@ -413,19 +413,19 @@ func Benchmark(b *testing.B) {
 
 	b.Run("BlobToKZGCommitment", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			BlobToKZGCommitment(blobs[0])
+			BlobToKZGCommitment(&blobs[0])
 		}
 	})
 
 	b.Run("ComputeKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			ComputeKZGProof(blobs[0], fields[0])
+			ComputeKZGProof(&blobs[0], fields[0])
 		}
 	})
 
 	b.Run("ComputeBlobKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			ComputeBlobKZGProof(blobs[0], commitments[0])
+			ComputeBlobKZGProof(&blobs[0], commitments[0])
 		}
 	})
 
@@ -437,7 +437,7 @@ func Benchmark(b *testing.B) {
 
 	b.Run("VerifyBlobKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			VerifyBlobKZGProof(blobs[0], commitments[0], proofs[0])
+			VerifyBlobKZGProof(&blobs[0], commitments[0], proofs[0])
 		}
 	})
 

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -129,7 +129,7 @@ func TestComputeKZGProof(t *testing.T) {
 				return
 			}
 
-			var z = new(Bytes32)
+			var z Bytes32
 			err = z.UnmarshalText([]byte(test.Input.Z))
 			if err != nil {
 				require.Nil(t, test.Output)
@@ -183,7 +183,7 @@ func TestComputeBlobKZGProof(t *testing.T) {
 				return
 			}
 
-			var commitment = new(Bytes48)
+			var commitment Bytes48
 			err = commitment.UnmarshalText([]byte(test.Input.Commitment))
 			if err != nil {
 				require.Nil(t, test.Output)
@@ -225,28 +225,28 @@ func TestVerifyKZGProof(t *testing.T) {
 			require.NoError(t, testFile.Close())
 			require.NoError(t, err)
 
-			var commitment = new(Bytes48)
+			var commitment Bytes48
 			err = commitment.UnmarshalText([]byte(test.Input.Commitment))
 			if err != nil {
 				require.Nil(t, test.Output)
 				return
 			}
 
-			var z = new(Bytes32)
+			var z Bytes32
 			err = z.UnmarshalText([]byte(test.Input.Z))
 			if err != nil {
 				require.Nil(t, test.Output)
 				return
 			}
 
-			var y = new(Bytes32)
+			var y Bytes32
 			err = y.UnmarshalText([]byte(test.Input.Y))
 			if err != nil {
 				require.Nil(t, test.Output)
 				return
 			}
 
-			var proof = new(Bytes48)
+			var proof Bytes48
 			err = proof.UnmarshalText([]byte(test.Input.Proof))
 			if err != nil {
 				require.Nil(t, test.Output)
@@ -294,14 +294,14 @@ func TestVerifyBlobKZGProof(t *testing.T) {
 				return
 			}
 
-			var commitment = new(Bytes48)
+			var commitment Bytes48
 			err = commitment.UnmarshalText([]byte(test.Input.Commitment))
 			if err != nil {
 				require.Nil(t, test.Output)
 				return
 			}
 
-			var proof = new(Bytes48)
+			var proof Bytes48
 			err = proof.UnmarshalText([]byte(test.Input.Proof))
 			if err != nil {
 				require.Nil(t, test.Output)
@@ -401,12 +401,12 @@ func Benchmark(b *testing.B) {
 		fillBlobRandom(&blob, int64(i))
 		commitment, err := BlobToKZGCommitment(&blob)
 		require.NoError(b, err)
-		proof, err := ComputeBlobKZGProof(&blob, (*Bytes48)(commitment))
+		proof, err := ComputeBlobKZGProof(&blob, Bytes48(commitment))
 		require.NoError(b, err)
 
 		blobs[i] = blob
-		commitments[i] = Bytes48(*commitment)
-		proofs[i] = Bytes48(*proof)
+		commitments[i] = Bytes48(commitment)
+		proofs[i] = Bytes48(proof)
 		fields[i] = getRandFieldElement(int64(i))
 	}
 
@@ -418,25 +418,25 @@ func Benchmark(b *testing.B) {
 
 	b.Run("ComputeKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			ComputeKZGProof(&blobs[0], &fields[0])
+			ComputeKZGProof(&blobs[0], fields[0])
 		}
 	})
 
 	b.Run("ComputeBlobKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			ComputeBlobKZGProof(&blobs[0], &commitments[0])
+			ComputeBlobKZGProof(&blobs[0], commitments[0])
 		}
 	})
 
 	b.Run("VerifyKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			VerifyKZGProof(&commitments[0], &fields[0], &fields[1], &proofs[0])
+			VerifyKZGProof(commitments[0], fields[0], fields[1], proofs[0])
 		}
 	})
 
 	b.Run("VerifyBlobKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			VerifyBlobKZGProof(&blobs[0], &commitments[0], &proofs[0])
+			VerifyBlobKZGProof(&blobs[0], commitments[0], proofs[0])
 		}
 	})
 

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -395,7 +395,7 @@ func Benchmark(b *testing.B) {
 	blobs := [length]Blob{}
 	commitments := [length]Bytes48{}
 	proofs := [length]Bytes48{}
-	fields := [length]*Bytes32{}
+	fields := [length]Bytes32{}
 	for i := 0; i < length; i++ {
 		var blob Blob
 		fillBlobRandom(&blob, int64(i))
@@ -407,8 +407,7 @@ func Benchmark(b *testing.B) {
 		blobs[i] = blob
 		commitments[i] = Bytes48(*commitment)
 		proofs[i] = Bytes48(*proof)
-		field := getRandFieldElement(int64(i))
-		fields[i] = &field
+		fields[i] = getRandFieldElement(int64(i))
 	}
 
 	b.Run("BlobToKZGCommitment", func(b *testing.B) {
@@ -419,7 +418,7 @@ func Benchmark(b *testing.B) {
 
 	b.Run("ComputeKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			ComputeKZGProof(&blobs[0], fields[0])
+			ComputeKZGProof(&blobs[0], &fields[0])
 		}
 	})
 
@@ -431,7 +430,7 @@ func Benchmark(b *testing.B) {
 
 	b.Run("VerifyKZGProof", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			VerifyKZGProof(&commitments[0], fields[0], fields[1], &proofs[0])
+			VerifyKZGProof(&commitments[0], &fields[0], &fields[1], &proofs[0])
 		}
 	})
 


### PR DESCRIPTION
This PR 

- changes the public interface methods that currently pass `Blob`  by value, to instead pass `*Blob`, that is , by  reference. 
- ~~It also changes the returns to also be mainly pointer-based. In this change, it also returns `nil` in case there is an error, which is go-idiomatic~~
- Slightly improved text unmarshalling. Those methods are probably only used by tests, but they're part of the exported API, so why not make them as fast as possible. 

**NOTE**: This means that this PR creates a breaking change, which requires a major version-upgrade of this library, strictly speaking. :warning: 

The `Blob` type is an `array`, of 130K bytes. As opposed to a slice of similar size, when an array is passed by value, every byte is passed over the heap. 

This is the old API:
```golang
func BlobToKZGCommitment(blob Blob) (KZGCommitment, error)
func ComputeKZGProof(blob Blob, zBytes Bytes32) (KZGProof, Bytes32, error)
func ComputeBlobKZGProof(blob Blob, commitmentBytes Bytes48) (KZGProof, error)
func VerifyKZGProof(commitmentBytes Bytes48, zBytes, yBytes Bytes32, proofBytes Bytes48) (bool, error)
func VerifyBlobKZGProof(blob Blob, commitmentBytes, proofBytes Bytes48) (bool, error)
```
Changed API in this PR: 
```golang
func BlobToKZGCommitment(blob *Blob) (KZGCommitment, error)
func ComputeKZGProof(blob *Blob, zBytes Bytes32) (KZGProof, Bytes32, error)
func ComputeBlobKZGProof(blob *Blob, commitmentBytes Bytes48) (KZGProof, error)
func VerifyBlobKZGProof(blob *Blob, commitmentBytes, proofBytes Bytes48) (bool, error)
```
Untouched: 

```golang
func LoadTrustedSetup(g1Bytes, g2Bytes []byte) error
func LoadTrustedSetupFile(trustedSetupFile string) error
func FreeTrustedSetup()
func VerifyBlobKZGProofBatch(blobs []Blob, commitmentsBytes, proofsBytes []Bytes48) (bool, error)
func VerifyKZGProof(commitmentBytes Bytes48, zBytes, yBytes Bytes32, proofBytes Bytes48) (bool, error)
```

Corresponding go-kzg PR: https://github.com/crate-crypto/go-kzg-4844/pull/63 


```
name                                  old time/op    new time/op    delta
/BlobToKZGCommitment-8                   172ms ±45%     171ms ±50%      ~     (p=1.000 n=5+5)
/ComputeKZGProof-8                       174ms ±41%     139ms ±56%      ~     (p=0.421 n=5+5)
/ComputeBlobKZGProof-8                   205ms ±13%     192ms ±38%      ~     (p=0.548 n=5+5)
/VerifyKZGProof-8                       3.29ms ±58%    3.84ms ±50%      ~     (p=0.548 n=5+5)
/VerifyBlobKZGProof-8                   5.72ms ±46%    6.24ms ±39%      ~     (p=0.690 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8     8.47ms ± 0%    7.20ms ±49%      ~     (p=0.063 n=4+5)
/VerifyBlobKZGProofBatch(count=2)-8     13.9ms ± 1%    13.9ms ± 1%      ~     (p=0.905 n=5+4)
/VerifyBlobKZGProofBatch(count=4)-8     18.4ms ±34%    20.1ms ±51%      ~     (p=1.000 n=5+5)
/VerifyBlobKZGProofBatch(count=8)-8     29.6ms ±51%    31.6ms ±41%      ~     (p=0.690 n=5+5)
/VerifyBlobKZGProofBatch(count=16)-8    73.6ms ±49%    65.0ms ±26%      ~     (p=0.222 n=5+5)
/VerifyBlobKZGProofBatch(count=32)-8     126ms ±43%     133ms ±26%      ~     (p=1.000 n=5+5)
/VerifyBlobKZGProofBatch(count=64)-8     284ms ±36%     218ms ±52%      ~     (p=0.222 n=5+5)

name                                  old alloc/op   new alloc/op   delta
/BlobToKZGCommitment-8                   131kB ± 0%       0kB ± 0%   -99.96%  (p=0.008 n=5+5)
/ComputeKZGProof-8                       131kB ± 0%       0kB ± 0%   -99.94%  (p=0.008 n=5+5)
/ComputeBlobKZGProof-8                   131kB ± 0%       0kB ± 0%   -99.96%  (p=0.008 n=5+5)
/VerifyKZGProof-8                         161B ± 0%        1B ± 0%   -99.38%  (p=0.008 n=5+5)
/VerifyBlobKZGProof-8                    131kB ± 0%       0kB ± 0%  -100.00%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8      1.00B ± 0%     1.00B ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=2)-8      1.00B ± 0%     1.00B ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=4)-8      1.00B ± 0%     1.00B ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=8)-8      1.00B ± 0%     1.00B ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=16)-8     1.00B ± 0%     1.00B ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=32)-8     1.40B ±43%     1.00B ± 0%      ~     (p=0.444 n=5+5)
/VerifyBlobKZGProofBatch(count=64)-8     2.00B ± 0%     2.00B ± 0%      ~     (all equal)

name                                  old allocs/op  new allocs/op  delta
/BlobToKZGCommitment-8                    2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
/ComputeKZGProof-8                        4.00 ± 0%      2.00 ± 0%   -50.00%  (p=0.008 n=5+5)
/ComputeBlobKZGProof-8                    3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.008 n=5+5)
/VerifyKZGProof-8                         5.00 ± 0%      1.00 ± 0%   -80.00%  (p=0.008 n=5+5)
/VerifyBlobKZGProof-8                     4.00 ± 0%      1.00 ± 0%   -75.00%  (p=0.008 n=5+5)
/VerifyBlobKZGProofBatch(count=1)-8       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=2)-8       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=4)-8       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=8)-8       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=16)-8      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=32)-8      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
/VerifyBlobKZGProofBatch(count=64)-8      1.00 ± 0%      1.00 ± 0%      ~     (all equal)

```