### PR TITLE
Define __BLST_NO_ASM__ for other ISAs

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -28,6 +28,12 @@ fn main() {
         cc.flag("/std:c11");
     }
 
+    // Enable __BLST_NO_ASM__ if not x86_64 or aarch64.
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    if !["x86_64", "aarch64"].contains(&target_arch.as_str()) {
+        cc.flag("-D__BLST_NO_ASM__");
+    }
+
     cc.include(blst_headers_dir.clone());
     cc.warnings(false);
     cc.file(c_src_dir.join("c_kzg_4844.c"));


### PR DESCRIPTION
I have no way of testing this, but I believe this is what we need to do in order to support other architectures.

Does anyone have a system they could verify this works?

Might fix #398.