### PR TITLE
python: check file pointer when loading trusted setup

### DIFF
--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -24,13 +24,14 @@ static PyObject* load_trusted_setup_wrap(PyObject *self, PyObject *args) {
     return PyErr_Format(PyExc_RuntimeError, "error reading trusted setup");
   }
 
-  if (load_trusted_setup_file(s, fp) != C_KZG_OK) {
+  C_KZG_RET ret = load_trusted_setup_file(s, fp);
+  fclose(fp);
+
+  if (ret != C_KZG_OK) {
     free(s);
-    fclose(fp);
     return PyErr_Format(PyExc_RuntimeError, "error loading trusted setup");
   }
 
-  fclose(fp);
   return PyCapsule_New(s, "KZGSettings", free_KZGSettings);
 }
 

--- a/bindings/python/ckzg.c
+++ b/bindings/python/ckzg.c
@@ -10,19 +10,27 @@ static void free_KZGSettings(PyObject *c) {
 
 static PyObject* load_trusted_setup_wrap(PyObject *self, PyObject *args) {
   PyObject *f;
+  FILE *fp;
 
   if (!PyArg_ParseTuple(args, "U", &f))
     return PyErr_Format(PyExc_ValueError, "expected a string");
 
   KZGSettings *s = (KZGSettings*)malloc(sizeof(KZGSettings));
-
   if (s == NULL) return PyErr_NoMemory();
 
-  if (load_trusted_setup_file(s, fopen(PyUnicode_AsUTF8(f), "r")) != C_KZG_OK) {
+  fp = fopen(PyUnicode_AsUTF8(f), "r");
+  if (fp == NULL) {
     free(s);
+    return PyErr_Format(PyExc_RuntimeError, "error reading trusted setup");
+  }
+
+  if (load_trusted_setup_file(s, fp) != C_KZG_OK) {
+    free(s);
+    fclose(fp);
     return PyErr_Format(PyExc_RuntimeError, "error loading trusted setup");
   }
 
+  fclose(fp);
   return PyCapsule_New(s, "KZGSettings", free_KZGSettings);
 }
 


### PR DESCRIPTION
Fixes: #400

Before:
```
>>> import ckzg
>>> ckzg.load_trusted_setup("sfsfdsfdsfdsf.json")
[1]    60039 segmentation fault  python
```

After:
```
>>> import ckzg
>>> ckzg.load_trusted_setup("sfsfdsfdsfdsf.json")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: error reading trusted setup
```

