### PR TITLE
Update versions in preparation of release

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 env:
-  binding_build_number_based_version: 0.4.0.${{ github.run_number }}
+  binding_build_number_based_version: 0.4.3.${{ github.run_number }}
 
 jobs:
   build-ckzg:

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "2.1.2",
+  "version": "2.4.3",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, Extension
 def main():
     setup(
         name="ckzg",
-        version="0.4.2",
+        version="0.4.3",
         author="Ethereum Foundation",
         description="Python bindings for C-KZG-4844",
         ext_modules=[

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-kzg"
-version = "0.1.0"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 links = "ckzg"


### PR DESCRIPTION
This PR updates the versions to 0.4.3 before the new release, so it's correct.

I'm only uncertain about the nodejs version. Don't think I can go from v2 to v0. So just change the minor/patch numbers.