### PR TITLE
Upload python wheels on Linux runner

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -81,4 +81,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload bindings/python/wheelhouse/*
+        run: twine upload wheelhouse/*

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,6 +6,9 @@ on:
       - published
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-wheels:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -73,12 +73,24 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: |
             make -C src blst
 
-      - name: Install twine
-        run: python -m pip install twine
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse/*
 
-      # Cannot use gh-action-pypi-publish as it only works on Linux.
+  publish:
+    needs: [build-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse
+
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload wheelhouse/*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: wheelhouse

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -2,6 +2,8 @@ name: Python Package
 
 on:
   release:
+    types:
+      - published
     branches:
       - main
 
@@ -34,7 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      
+
       # Need this to get cl.exe on the path.
       - name: Set up Visual Studio shell
         if: runner.os == 'Windows'
@@ -68,8 +70,12 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: |
             make -C src blst
 
+      - name: Install twine
+        run: python -m pip install twine
+
+      # Cannot use gh-action-pypi-publish as it only works on Linux.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}
-          packages-dir: bindings/python/wheelhouse
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload bindings/python/wheelhouse/*

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,9 +6,6 @@ on:
       - published
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build-wheels:


### PR DESCRIPTION
So I made a mistake. `gh-action-pypi-publish` only works on Linux. So when this action ran, it failed when trying to publish the macOS packages and cancelled the other platform workflows.

Also, I didn't realize there were multiple types of "releases" like "created", "published", etc. This PR adds a line which should cause this to only run once when a release is made.

<img width="754" alt="image" src="https://github.com/ethereum/c-kzg-4844/assets/95511699/fc2f3bc8-6b3f-4925-8f12-e32fff208910">
