### PR TITLE
Add workflow_dispatch to python release action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,6 +6,8 @@ on:
       - published
     branches:
       - main
+  # Allows us run the action manually.
+  workflow_dispatch:
 
 jobs:
   build-wheels:


### PR DESCRIPTION
I'm trying to run this action manually. It needs the `workflow_dispatch` flag.