### PR TITLE
Add more information in setuptools.setup()

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup, Extension
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 
 def main():
@@ -6,7 +10,12 @@ def main():
         name="ckzg",
         version="0.4.3",
         author="Ethereum Foundation",
+        author_email="security@ethereum.org",
+        url="https://github.com/ethereum/c-kzg-4844",
         description="Python bindings for C-KZG-4844",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        license="Apache-2.0",
         ext_modules=[
             Extension(
                 "ckzg",


### PR DESCRIPTION
For some reason the Python package publishing is failing because of the long description. Hopefully this fixes it.

There are a bunch of errors like this:
```
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.                                   
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.  
```