### PR TITLE
feat: derive hash for generated types

### DIFF
--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "c-kzg"
-version = "0.1.0"
+version = "0.4.3"
 dependencies = [
  "bindgen",
  "blst",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -103,6 +103,8 @@ fn make_bindings(header_path: &str, blst_headers_dir: &str, bindings_out_path: &
         .parse_callbacks(Box::new(Callbacks))
         // Add PartialEq and Eq impls to types.
         .derive_eq(true)
+        // All types are hashable.
+        .derive_hash(true)
         // Blobs are big, we don't want rust to liberally copy them around.
         .no_copy("Blob")
         // Do not make fields public. If we want to modify them we can create setters/mutable

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -9,29 +9,29 @@ pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 pub const BYTES_PER_BLOB: usize = 131072;
 pub type limb_t = u64;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct blst_fr {
     l: [limb_t; 4usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct blst_fp {
     l: [limb_t; 6usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct blst_fp2 {
     fp: [blst_fp; 2usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct blst_p1 {
     x: blst_fp,
     y: blst_fp,
     z: blst_fp,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct blst_p2 {
     x: blst_fp2,
     y: blst_fp2,
@@ -42,19 +42,19 @@ pub type g2_t = blst_p2;
 pub type fr_t = blst_fr;
 #[doc = " An array of 32 bytes. Represents an untrusted\n (potentially invalid) field element."]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Bytes32 {
     bytes: [u8; 32usize],
 }
 #[doc = " An array of 48 bytes. Represents an untrusted\n (potentially invalid) commitment/proof."]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Bytes48 {
     bytes: [u8; 48usize],
 }
 #[doc = " A basic blob data."]
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct Blob {
     bytes: [u8; 131072usize],
 }
@@ -73,7 +73,7 @@ pub enum C_KZG_RET {
 }
 #[doc = " Stores the setup and parameters needed for computing KZG proofs."]
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct KZGSettings {
     #[doc = " The length of `roots_of_unity`, a power of 2."]
     max_width: u64,


### PR DESCRIPTION
This makes it lot easier to use the type in other structs that require hash.