### PR TITLE
Update versions in preparation for release

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 env:
-  binding_build_number_based_version: 0.4.3.${{ github.run_number }}
+  binding_build_number_based_version: 1.0.0.${{ github.run_number }}
 
 jobs:
   build-ckzg:

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "2.4.3",
+  "version": "3.0.0",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 def main():
     setup(
         name="ckzg",
-        version="0.4.3",
+        version="1.0.0",
         author="Ethereum Foundation",
         author_email="security@ethereum.org",
         url="https://github.com/ethereum/c-kzg-4844",

--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "c-kzg"
-version = "0.4.3"
+version = "1.0.0"
 dependencies = [
  "bindgen",
  "blst",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-kzg"
-version = "0.4.3"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 links = "ckzg"


### PR DESCRIPTION
This PR updates the c-kzg-4844 version to v1.0.0, except for the Node.js bindings which will be v3.0.0.