### PR TITLE
Fix the Python release CI action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -48,7 +48,7 @@ jobs:
         run: python -m pip install cibuildwheel==2.16.5
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse bindings/python
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
 
           # We have QEMU setup and can build everything.
@@ -92,7 +92,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-    
+
       - name: Build source distribution
         run: python setup.py sdist
 


### PR DESCRIPTION
This PR removes the directory argument from cibuildwheel which tells it to look in the current directory for `setup.py`.