### PR TITLE
When building Python bindings, only build blst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class CustomBuild(build_ext):
                 check_call([f("blst\\build.bat")])
             except Exception:
                 pass
-        check_call(["make", "-C", f("src"), "c_kzg_4844.o"])
+        check_call(["make", "-C", f("src"), "blst"])
         super().run()
 
 


### PR DESCRIPTION
This was my mistake. We only need to build blst here. When building with an older version of clang, this would complain about missing braces in c-kzg code and would cause the Python bindings build to fail.