### PR TITLE
In Python setup file, change directory instead of using absolute paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,27 @@
+from os import chdir
 from pathlib import Path
 from platform import system
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from subprocess import check_call
 
-this_dir = Path(__file__).parent
-long_description = (this_dir / "bindings/python/README.md").read_text()
-
-
-def r(path_str):
-    """
-    For a given path, get the relative path the current working directory.
-    The result will be a string, rather than a Path object.
-    """
-    absolute_path = this_dir / path_str
-    relative_path = absolute_path.relative_to(Path.cwd())
-    return str(relative_path)
-
 
 class CustomBuild(build_ext):
     def run(self):
         if system() == "Windows":
             try:
-                check_call([r("blst\\build.bat")])
+                check_call(["blst\\build.bat"])
             except Exception:
                 pass
-        check_call(["make", "-C", r("src"), "blst"])
+        check_call(["make", "-C", "src", "blst"])
         super().run()
 
 
 def main():
+    # Change directory so we don't have to deal with paths.
+    setup_dir = Path(__file__).parent.resolve()
+    chdir(setup_dir)
+
     setup(
         name="ckzg",
         version="1.0.1",
@@ -37,15 +29,15 @@ def main():
         author_email="security@ethereum.org",
         url="https://github.com/ethereum/c-kzg-4844",
         description="Python bindings for C-KZG-4844",
-        long_description=long_description,
+        long_description=Path("bindings/python/README.md").read_text(),
         long_description_content_type="text/markdown",
         license="Apache-2.0",
         ext_modules=[
             Extension(
                 "ckzg",
-                sources=[r("bindings/python/ckzg.c"), r("src/c_kzg_4844.c")],
-                include_dirs=[r("inc"), r("src")],
-                library_dirs=[r("lib")],
+                sources=["bindings/python/ckzg.c", "src/c_kzg_4844.c"],
+                include_dirs=["inc", "src"],
+                library_dirs=["lib"],
                 libraries=["blst"]
             )
         ],

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,24 @@ this_dir = Path(__file__).parent
 long_description = (this_dir / "bindings/python/README.md").read_text()
 
 
-def f(path_str):
-    return str(this_dir / path_str)
+def r(path_str):
+    """
+    For a given path, get the relative path the current working directory.
+    The result will be a string, rather than a Path object.
+    """
+    absolute_path = this_dir / path_str
+    relative_path = absolute_path.relative_to(Path.cwd())
+    return str(relative_path)
 
 
 class CustomBuild(build_ext):
     def run(self):
         if system() == "Windows":
             try:
-                check_call([f("blst\\build.bat")])
+                check_call([r("blst\\build.bat")])
             except Exception:
                 pass
-        check_call(["make", "-C", f("src"), "blst"])
+        check_call(["make", "-C", r("src"), "blst"])
         super().run()
 
 
@@ -37,9 +43,9 @@ def main():
         ext_modules=[
             Extension(
                 "ckzg",
-                sources=[f("bindings/python/ckzg.c"), f("src/c_kzg_4844.c")],
-                include_dirs=[f("inc"), f("src")],
-                library_dirs=[f("lib")],
+                sources=[r("bindings/python/ckzg.c"), r("src/c_kzg_4844.c")],
+                include_dirs=[r("inc"), r("src")],
+                library_dirs=[r("lib")],
                 libraries=["blst"]
             )
         ],


### PR DESCRIPTION
This PR should fix a Windows issue associated with #415.