### PR TITLE
Fix broken nodejs/csharp CI tests

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -87,9 +87,7 @@ jobs:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
     - name: Test
-      run: |
-        find bindings/csharp/Ckzg.Bindings/runtimes
-        dotnet test -c release bindings/csharp/Ckzg.sln
+      run: dotnet test -c release bindings/csharp/Ckzg.sln
 
   build-ckzg-dotnet:
     name: Build .NET wrapper

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -71,7 +71,7 @@ jobs:
           - host: ubuntu-22.04
             location: linux-x64
           - host: macos-latest
-            location: osx-x64
+            location: osx-arm64
           - host: windows-latest
             location: win-x64
     steps:

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -118,7 +118,9 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
     - name: Install dependencies
-      run: cd bindings/csharp && dotnet restore
+      run: |
+        cd bindings/csharp && dotnet restore
+        find Ckzg.Bindings/runtimes
     - name: Build
       run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -87,7 +87,9 @@ jobs:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
     - name: Test
-      run: dotnet test -c release bindings/csharp/Ckzg.sln
+      run: |
+        find bindings/csharp/Ckzg.Bindings/runtimes
+        dotnet test -c release bindings/csharp/Ckzg.sln
 
   build-ckzg-dotnet:
     name: Build .NET wrapper
@@ -118,9 +120,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
     - name: Install dependencies
-      run: |
-        cd bindings/csharp && dotnet restore
-        find Ckzg.Bindings/runtimes
+      run: cd bindings/csharp && dotnet restore
     - name: Build
       run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{matrix.node}}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Install setuptools
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - name: Install setuptools
-        run: python3 -m pip install setuptools
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
         working-directory: bindings/node.js


### PR DESCRIPTION
Noticed some issues with macOS on these tests. This PR investigates & fixes these issues.

* For the nodejs tests, Python wasn't properly setup first.
  * This prevented `setuptools` from being installed. 
* For csharp, `macos-latest` now defaults to an arm64 runner.
  *  We were attempting to use the x86_64 library, which failed to load.