### PR TITLE
feat: bundle and auto-load trusted setup

### DIFF
--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -33,6 +33,7 @@ build: install clean
 	@cp -r ../../blst deps
 	@cp ../../src/c_kzg_4844.c deps/c-kzg
 	@cp ../../src/c_kzg_4844.h deps/c-kzg
+	@cp ../../src/trusted_setup.txt deps/c-kzg
 	@# Build the bindings
 	@$(YARN) node-gyp --loglevel=warn configure
 	@$(YARN) node-gyp --loglevel=warn build

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -7,7 +7,7 @@ API. The core functionality was originally a stripped-down copy of
 since then. This package wraps that native `c-kzg` C code in C/C++ NAPI
 bindings for use in node.js applications.
 
-Spec: <https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md>
+Spec: <https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md>
 
 ## Prerequisites
 
@@ -64,11 +64,11 @@ const isValid = verifyBlobKzgProofBatch(blobs, commitments, proofs);
  * ".txt" extension.
  *
  * Uses user provided location first. If one is not provided then defaults to
- * the official Ethereum mainnet setup from the kzg ceremony. Should only be
- * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ * the official Ethereum mainnet setup from the KZG ceremony. Should only be
+ * used for cases where the Ethereum official mainnet KZG setup is acceptable.
  *
  * @param {string | undefined} filePath - .txt/.json file with setup configuration
- * @default - If no string is passed the default trusted setup from the Ethereum kzg ceremony is used
+ * @default - If no string is passed the default trusted setup from the Ethereum KZG ceremony is used
  *
  * @throws {TypeError} - Non-String input
  * @throws {Error} - For all other errors. See error message for more info

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -7,7 +7,7 @@ API. The core functionality was originally a stripped-down copy of
 since then. This package wraps that native `c-kzg` C code in C/C++ NAPI
 bindings for use in node.js applications.
 
-Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md
+Spec: <https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md>
 
 ## Prerequisites
 
@@ -56,14 +56,22 @@ const isValid = verifyBlobKzgProofBatch(blobs, commitments, proofs);
 
 ```ts
 /**
- * Sets up the c-kzg library. Pass in a properly formatted trusted setup file
- * to configure the library.  File must be in json format, see TrustedSetupJson
- * interface for more details, or as a properly formatted utf-8 encoded file.
+ * Initialize the library with a trusted setup file.
  *
- * @remark This function must be run before any other functions in this
- *         library can be run.
+ * Can pass either a .txt or a .json file with setup configuration. Converts
+ * JSON formatted trusted setup into the native format that the base library
+ * requires. The created file will be in the same as the origin file but with a
+ * ".txt" extension.
  *
- * @param {string} filePath - The absolute path of the trusted setup
+ * Uses user provided location first. If one is not provided then defaults to
+ * the official Ethereum mainnet setup from the kzg ceremony. Should only be
+ * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ *
+ * @param {string | undefined} filePath - .txt/.json file with setup configuration
+ * @default - If no string is passed the default trusted setup from the Ethereum kzg ceremony is used
+ *
+ * @throws {TypeError} - Non-String input
+ * @throws {Error} - For all other errors. See error message for more info
  */
 loadTrustedSetup(filePath: string): void;
 ```

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -33,7 +33,7 @@
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": "/EHsc",
+              "ExceptionHandling": "Sync",
               "AdditionalOptions": ["/std:c++17"]
             }
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -14,12 +14,13 @@
       ],
       "defines": [
         "__BLST_PORTABLE__",
-        "NAPI_DISABLE_CPP_EXCEPTIONS"
+        "NAPI_CPP_EXCEPTIONS"
       ],
       "conditions": [
         ["OS!='win'", {
           "sources": ["deps/blst/build/assembly.S"],
           "cflags_cc": [
+            "-fexceptions",
             "-std=c++17",
             "-fPIC"
           ]
@@ -28,15 +29,18 @@
           "sources": ["deps/blst/build/win64/*-x86_64.asm"],
           "defines": [
             "_CRT_SECURE_NO_WARNINGS",
+            "_HAS_EXCEPTIONS=1"
           ],
           "msbuild_settings": {
             "ClCompile": {
+              "ExceptionHandling": 1,
               "AdditionalOptions": ["/std:c++17"]
             }
           }
         }],
         ["OS=='mac'", {
           "xcode_settings": {
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
             "CLANG_CXX_LIBRARY": "libc++",
             "MACOSX_DEPLOYMENT_TARGET": "13.0"
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -33,7 +33,7 @@
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": "/EHsc",
+              "ExceptionHandling": 1,
               "AdditionalOptions": ["/std:c++17"]
             }
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -14,13 +14,12 @@
       ],
       "defines": [
         "__BLST_PORTABLE__",
-        "NAPI_CPP_EXCEPTIONS"
+        "NAPI_DISABLE_CPP_EXCEPTIONS"
       ],
       "conditions": [
         ["OS!='win'", {
           "sources": ["deps/blst/build/assembly.S"],
           "cflags_cc": [
-            "-fexceptions",
             "-std=c++17",
             "-fPIC"
           ]
@@ -29,18 +28,15 @@
           "sources": ["deps/blst/build/win64/*-x86_64.asm"],
           "defines": [
             "_CRT_SECURE_NO_WARNINGS",
-            "_HAS_EXCEPTIONS=1"
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": 1,
               "AdditionalOptions": ["/std:c++17"]
             }
           }
         }],
         ["OS=='mac'", {
           "xcode_settings": {
-            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
             "CLANG_CXX_LIBRARY": "libc++",
             "MACOSX_DEPLOYMENT_TARGET": "13.0"
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -33,7 +33,7 @@
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": "Sync",
+              "ExceptionHandling": "/EHsc",
               "AdditionalOptions": ["/std:c++17"]
             }
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -33,7 +33,7 @@
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": 1,
+              "ExceptionHandling": "/EHsc",
               "AdditionalOptions": ["/std:c++17"]
             }
           }

--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -22,14 +22,24 @@ export const BYTES_PER_PROOF: number;
 export const FIELD_ELEMENTS_PER_BLOB: number;
 
 /**
- * Factory function that passes trusted setup to the bindings
+ * Initialize the library with a trusted setup file.
  *
- * @param {string} filePath
+ * Can pass either a .txt or a .json file with setup configuration. Converts
+ * JSON formatted trusted setup into the native format that the base library
+ * requires. The created file will be in the same as the origin file but with a
+ * ".txt" extension.
+ *
+ * Uses user provided location first. If one is not provided then defaults to
+ * the official Ethereum mainnet setup from the kzg ceremony. Should only be
+ * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ *
+ * @param {string | undefined} filePath
+ * @default - If no string is passed the default trusted setup from the Ethereum kzg ceremony is used
  *
  * @throws {TypeError} - Non-String input
  * @throws {Error} - For all other errors. See error message for more info
  */
-export function loadTrustedSetup(filePath: string): void;
+export function loadTrustedSetup(filePath?: string): void;
 
 /**
  * Convert a blob to a KZG commitment.

--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -30,11 +30,11 @@ export const FIELD_ELEMENTS_PER_BLOB: number;
  * ".txt" extension.
  *
  * Uses user provided location first. If one is not provided then defaults to
- * the official Ethereum mainnet setup from the kzg ceremony. Should only be
- * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ * the official Ethereum mainnet setup from the KZG ceremony. Should only be
+ * used for cases where the Ethereum official mainnet KZG setup is acceptable.
  *
  * @param {string | undefined} filePath
- * @default - If no string is passed the default trusted setup from the Ethereum kzg ceremony is used
+ * @default - If no string is passed the default trusted setup from the Ethereum KZG ceremony is used
  *
  * @throws {TypeError} - Non-String input
  * @throws {Error} - For all other errors. See error message for more info

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -7,6 +7,28 @@ const path = require("path");
 const bindings = require("bindings")("kzg");
 
 /**
+ * NOTE: These two paths are only exported for testing purposes. They are not
+ * announced in the type file.
+ * 
+ * It is critical that these paths are kept in sync with where the trusted setup
+ * files will be found. The root setup is in the base src directory with the
+ * primary library code. The dist version is dictated by the `build` command in
+ * the Makefile in the bindings/node.js folder.
+ */
+/**
+ * Check the production bundle case first.
+ * - this file in BUNDLE_ROOT/dist/lib/kzg.js
+ * - trusted_setup in BUNDLE_ROOT/dist/deps/c-kzg/trusted_setup.txt
+ */
+bindings.TRUSTED_SETUP_PATH_IN_DIST = path.resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt");
+/**
+ * Check the development case second.
+ * - this file in REPO_ROOT/bindings/node.js/lib/kzg.js
+ * - trusted_setup in REPO_ROOT/src/trusted_setup.txt
+ */
+bindings.TRUSTED_SETUP_PATH_IN_SRC = path.resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt");
+
+/**
  * Looks in the default locations for the trusted setup file.  This is for cases
  * where the library is loaded without passing a trusted setup.  Should only be
  * used for cases where the Ethereum official mainnet kzg setup is acceptable.
@@ -15,10 +37,10 @@ const bindings = require("bindings")("kzg");
  */
 function getDefaultTrustedSetupFilepath() {
   const locationsToSearch = [
-    // check the production bundle case first (this file in lib)
-    path.resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt"),
-    // check the development in-repo case second (this file in bindings/node.js/lib)
-    path.resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt"),
+    // check the production case first
+    bindings.TRUSTED_SETUP_PATH_IN_DIST,
+    // check the development in-repo case second
+    bindings.TRUSTED_SETUP_PATH_IN_SRC,    
   ];
 
   for (const filepath of locationsToSearch) {

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -66,7 +66,7 @@ function transformTrustedSetupJson(filePath) {
  * @throws {TypeError} - Invalid file type
  * @throws {Error} - Invalid location or no default trusted setup found
  *
- * @remarks - This function is only exported for testing purposes.  It should
+ * @remarks - This function is only exported for testing purposes. It should
  *            not be used directly. Not included in the kzg.d.ts types for that
  *            reason.
  */

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -31,7 +31,7 @@ bindings.TRUSTED_SETUP_PATH_IN_SRC = path.resolve(__dirname, "..", "..", "..", "
 /**
  * Looks in the default locations for the trusted setup file.  This is for cases
  * where the library is loaded without passing a trusted setup.  Should only be
- * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ * used for cases where the Ethereum official mainnet KZG setup is acceptable.
  *
  * @returns {string | undefined} - Filepath for trusted_setup.txt if found
  */
@@ -78,7 +78,7 @@ function transformTrustedSetupJson(filePath) {
 /**
  * Gets location for trusted setup file. Uses user provided location first. If
  * one is not provided then defaults to the official Ethereum mainnet setup from
- * the kzg ceremony.
+ * the KZG ceremony.
  *
  * @param {string} filePath - User provided filePath to check for trusted setup
  *

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -7,6 +7,28 @@ const path = require("path");
 const bindings = require("bindings")("kzg");
 
 /**
+ * Looks in the default locations for the trusted setup file.  This is for cases
+ * where the library is loaded without passing a trusted setup.  Should only be
+ * used for cases where the Ethereum official mainnet kzg setup is acceptable.
+ *
+ * @returns {string | undefined} - Filepath for trusted_setup.txt if found
+ */
+function getDefaultTrustedSetupFilepath() {
+  const locationsToSearch = [
+    // check the production bundle case first (this file in lib)
+    path.resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt"),
+    // check the development in-repo case second (this file in bindings/node.js/lib)
+    path.resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt"),
+  ];
+
+  for (const filepath of locationsToSearch) {
+    if (fs.existsSync(filepath)) {
+      return filepath;
+    }
+  }
+}
+
+/**
  * Converts JSON formatted trusted setup into the native format that
  * the native library requires.  Returns the absolute file path to
  * the formatted file.  The path will be the same as the origin
@@ -31,19 +53,49 @@ function transformTrustedSetupJson(filePath) {
   return outputPath;
 }
 
-const originalLoadTrustedSetup = bindings.loadTrustedSetup;
-// docstring in ./kzg.d.ts with exported definition
-bindings.loadTrustedSetup = function loadTrustedSetup(filePath) {
-  if (!(filePath && typeof filePath === "string")) {
-    throw new TypeError("must initialize kzg with the filePath to a txt/json trusted setup");
+/**
+ * Gets location for trusted setup file. Uses user provided location first. If
+ * one is not provided then defaults to the official Ethereum mainnet setup from
+ * the kzg ceremony.
+ *
+ * @param {string} filePath - User provided filePath to check for trusted setup
+ *
+ * @returns {string} - Location of a trusted setup file. Validity is checked by
+ *                     the native bindings.loadTrustedSetup
+ *
+ * @throws {TypeError} - Invalid file type
+ * @throws {Error} - Invalid location or no default trusted setup found
+ *
+ * @remarks - This function is only exported for testing purposes.  It should
+ *            not be used directly. Not included in the kzg.d.ts types for that
+ *            reason.
+ */
+bindings.getTrustedSetupFilepath = function getTrustedSetupFilepath(filePath) {
+  if (filePath) {
+    if (typeof filePath !== "string") {
+      throw new TypeError("Must initialize kzg with the filePath to a txt/json trusted setup");
+    }
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`No trusted setup found: ${filePath}`);
+    }
+  } else {
+    filePath = getDefaultTrustedSetupFilepath();
+    if (!filePath) {
+      throw new Error("Default trusted setup not found. Must pass a valid filepath to load c-kzg library");
+    }
   }
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`no trusted setup found: ${filePath}`);
-  }
+
   if (path.parse(filePath).ext === ".json") {
     filePath = transformTrustedSetupJson(filePath);
   }
-  originalLoadTrustedSetup(filePath);
+
+  return filePath;
+};
+
+const originalLoadTrustedSetup = bindings.loadTrustedSetup;
+// docstring in ./kzg.d.ts with exported definition
+bindings.loadTrustedSetup = function loadTrustedSetup(filePath) {
+  originalLoadTrustedSetup(bindings.getTrustedSetupFilepath(filePath));
 };
 
 module.exports = exports = bindings;

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -27,12 +27,11 @@ const {
 } = kzg;
 // not exported by types, only exported for testing purposes
 const getTrustedSetupFilepath = (kzg as any).getTrustedSetupFilepath as (filePath?: string) => string;
+const TRUSTED_SETUP_PATH_IN_DIST = (kzg as any).TRUSTED_SETUP_PATH_IN_DIST as string;
+const TRUSTED_SETUP_PATH_IN_SRC = (kzg as any).TRUSTED_SETUP_PATH_IN_SRC as string;
 
 const JSON_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.json");
 const TXT_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.txt");
-// this is the path as seen from the dist kzg.js. its actually inside the "dist folder though"
-const DIST_SETUP_FILE_PATH = resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt");
-const SRC_SETUP_FILE_PATH = resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt");
 
 const MAX_TOP_BYTE = 114;
 
@@ -190,19 +189,19 @@ describe("C-KZG", () => {
     });
     describe("default setups", () => {
       beforeEach(() => {
-        if (!existsSync(DIST_SETUP_FILE_PATH)) {
-          cpSync(SRC_SETUP_FILE_PATH, DIST_SETUP_FILE_PATH);
+        if (!existsSync(TRUSTED_SETUP_PATH_IN_DIST)) {
+          cpSync(TRUSTED_SETUP_PATH_IN_SRC, TRUSTED_SETUP_PATH_IN_DIST);
         }
       });
       it("should return dist setup first", () => {
         // both files should be preset right now
-        expect(getTrustedSetupFilepath()).toEqual(DIST_SETUP_FILE_PATH);
+        expect(getTrustedSetupFilepath()).toEqual(TRUSTED_SETUP_PATH_IN_DIST);
       });
       it("should return src setup if dist is missing", () => {
         // both files should be preset right now
-        rmSync(DIST_SETUP_FILE_PATH);
-        expect(getTrustedSetupFilepath()).toEqual(SRC_SETUP_FILE_PATH);
-        cpSync(SRC_SETUP_FILE_PATH, DIST_SETUP_FILE_PATH);
+        rmSync(TRUSTED_SETUP_PATH_IN_DIST);
+        expect(getTrustedSetupFilepath()).toEqual(TRUSTED_SETUP_PATH_IN_SRC);
+        cpSync(TRUSTED_SETUP_PATH_IN_SRC, TRUSTED_SETUP_PATH_IN_DIST);
       });
     });
   });

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -1,5 +1,5 @@
 import {randomBytes} from "crypto";
-import {readFileSync} from "fs";
+import {readFileSync, existsSync, cpSync, rmSync} from "fs";
 import {resolve} from "path";
 import {globSync} from "glob";
 
@@ -10,7 +10,9 @@ interface TestMeta<I extends Record<string, any>, O extends boolean | string | s
   output: O;
 }
 
-import {
+import kzg from "../lib/kzg";
+import type {ProofResult} from "../lib/kzg";
+const {
   loadTrustedSetup,
   blobToKzgCommitment,
   computeKzgProof,
@@ -22,10 +24,15 @@ import {
   BYTES_PER_COMMITMENT,
   BYTES_PER_PROOF,
   BYTES_PER_FIELD_ELEMENT,
-  ProofResult,
-} from "../lib/kzg";
+} = kzg;
+// not exported by types, only exported for testing purposes
+const getTrustedSetupFilepath = (kzg as any).getTrustedSetupFilepath as (filePath?: string) => string;
 
-const SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.json");
+const JSON_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.json");
+const TXT_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.txt");
+// this is the path as seen from the dist kzg.js. its actually inside the "dist folder though"
+const DIST_SETUP_FILE_PATH = resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt");
+const SRC_SETUP_FILE_PATH = resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt");
 
 const MAX_TOP_BYTE = 114;
 
@@ -166,7 +173,38 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
 
 describe("C-KZG", () => {
   beforeAll(async () => {
-    loadTrustedSetup(SETUP_FILE_PATH);
+    loadTrustedSetup(JSON_SETUP_FILE_PATH);
+  });
+
+  describe("locating trusted setup file", () => {
+    it("should return a txt path if a json file is provided and exists", () => {
+      expect(getTrustedSetupFilepath(JSON_SETUP_FILE_PATH)).toEqual(TXT_SETUP_FILE_PATH);
+    });
+    /**
+     * No guarantee that the test above runs first, however the json file should
+     * have already been loaded by the beforeAll so a valid .txt test setup
+     * should be available to expect
+     */
+    it("should return the same txt path if provided and exists", () => {
+      expect(getTrustedSetupFilepath(TXT_SETUP_FILE_PATH)).toEqual(TXT_SETUP_FILE_PATH);
+    });
+    describe("default setups", () => {
+      beforeEach(() => {
+        if (!existsSync(DIST_SETUP_FILE_PATH)) {
+          cpSync(SRC_SETUP_FILE_PATH, DIST_SETUP_FILE_PATH);
+        }
+      });
+      it("should return dist setup first", () => {
+        // both files should be preset right now
+        expect(getTrustedSetupFilepath()).toEqual(DIST_SETUP_FILE_PATH);
+      });
+      it("should return src setup if dist is missing", () => {
+        // both files should be preset right now
+        rmSync(DIST_SETUP_FILE_PATH);
+        expect(getTrustedSetupFilepath()).toEqual(SRC_SETUP_FILE_PATH);
+        cpSync(SRC_SETUP_FILE_PATH, DIST_SETUP_FILE_PATH);
+      });
+    });
   });
 
   describe("reference tests should pass", () => {

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -30,8 +30,8 @@ const getTrustedSetupFilepath = (kzg as any).getTrustedSetupFilepath as (filePat
 const TRUSTED_SETUP_PATH_IN_DIST = (kzg as any).TRUSTED_SETUP_PATH_IN_DIST as string;
 const TRUSTED_SETUP_PATH_IN_SRC = (kzg as any).TRUSTED_SETUP_PATH_IN_SRC as string;
 
-const JSON_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.json");
-const TXT_SETUP_FILE_PATH = resolve(__dirname, "__fixtures__", "trusted_setup.txt");
+const TEST_SETUP_FILE_PATH_JSON = resolve(__dirname, "__fixtures__", "trusted_setup.json");
+const TEST_SETUP_FILE_PATH_TXT = resolve(__dirname, "__fixtures__", "trusted_setup.txt");
 
 const MAX_TOP_BYTE = 114;
 
@@ -172,12 +172,12 @@ function testArgCount(fn: (...args: any[]) => any, validArgs: any[]): void {
 
 describe("C-KZG", () => {
   beforeAll(async () => {
-    loadTrustedSetup(JSON_SETUP_FILE_PATH);
+    loadTrustedSetup(TEST_SETUP_FILE_PATH_JSON);
   });
 
   describe("locating trusted setup file", () => {
     it("should return a txt path if a json file is provided and exists", () => {
-      expect(getTrustedSetupFilepath(JSON_SETUP_FILE_PATH)).toEqual(TXT_SETUP_FILE_PATH);
+      expect(getTrustedSetupFilepath(TEST_SETUP_FILE_PATH_JSON)).toEqual(TEST_SETUP_FILE_PATH_TXT);
     });
     /**
      * No guarantee that the test above runs first, however the json file should
@@ -185,7 +185,7 @@ describe("C-KZG", () => {
      * should be available to expect
      */
     it("should return the same txt path if provided and exists", () => {
-      expect(getTrustedSetupFilepath(TXT_SETUP_FILE_PATH)).toEqual(TXT_SETUP_FILE_PATH);
+      expect(getTrustedSetupFilepath(TEST_SETUP_FILE_PATH_TXT)).toEqual(TEST_SETUP_FILE_PATH_TXT);
     });
     describe("default setups", () => {
       beforeEach(() => {


### PR DESCRIPTION
**Motivation**

Allows for easier initialization of library for Ethereum use cases.  Also bundles the trusted setup so that it does not need to be manually downloaded by consumers and stored separately.  Will simplify the `lodestar` use case.  Defaults to using the file passed by the user first.  If none is passed use the one found in the dist bundle (checks here for the prod case first).  If one is not found in the prod location fall back to the src location (for development purposes).  Still throws error if none is sourced (invalid bundle/build).

**Description of Changes**
- Bundle `trusted_setup.txt` with the c-kzg deps for node.js bindings
- Update `kzg.js` to functions to allow for passing a trusted setup or for loading the default setup from either the bundle or the repo src
- Export `getTrustedSetupFilepath` for testing purposes but do not announce via types file.
- Unit test `getTrustedSetupFilepath` to ensure proper loading.
