### PR TITLE
feat: turn on exceptions

### DIFF
--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -33,7 +33,7 @@
           ],
           "msbuild_settings": {
             "ClCompile": {
-              "ExceptionHandling": 1,
+              "ExceptionHandling": "Sync",
               "AdditionalOptions": ["/std:c++17"]
             }
           }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -14,12 +14,13 @@
       ],
       "defines": [
         "__BLST_PORTABLE__",
-        "NAPI_DISABLE_CPP_EXCEPTIONS"
+        "NAPI_CPP_EXCEPTIONS"
       ],
       "conditions": [
         ["OS!='win'", {
           "sources": ["deps/blst/build/assembly.S"],
           "cflags_cc": [
+            "-fexceptions",
             "-std=c++17",
             "-fPIC"
           ]
@@ -28,15 +29,18 @@
           "sources": ["deps/blst/build/win64/*-x86_64.asm"],
           "defines": [
             "_CRT_SECURE_NO_WARNINGS",
+            "_HAS_EXCEPTIONS=1"
           ],
           "msbuild_settings": {
             "ClCompile": {
+              "ExceptionHandling": 1,
               "AdditionalOptions": ["/std:c++17"]
             }
           }
         }],
         ["OS=='mac'", {
           "xcode_settings": {
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
             "CLANG_CXX_LIBRARY": "libc++",
             "MACOSX_DEPLOYMENT_TARGET": "13.0"
           }


### PR DESCRIPTION
A JavaScript `Value` is a `Reference` that contains an `Address` to a value (little "v" actual data) that is stored either on the stack or in the heap.  A large part of what the `Isolate` (instance of a JS virtual machine) does is manage memory and garbage collection of the values (little "v", think data, and big "V" think reference to the `Address` that points to the data).

These two layers of indirection allow for the data to be tracked/moved/managed/deleted etc by the runtime.

When a `v8::Value` is requested by a function call the `Isolate` does a lookup and dereferences the value (little "v") and then returns a `Reference` to for the value (little v) as a `v8::Value` (big V).  It does so for ref counting which informs the garbage collection system of when a value (both big and little v) can be deleted.

The sticky wicket comes in that if exceptions are turned on, requesting a `v8::Value` will throw an error if the value (little v) does not exist.  With exceptions off it essentially returns a `std::optional` which in JS world is called a `v8::Maybe`.  The extra steps required without exceptions is a `Maybe` needs to be checked if it has a value (little v) associated or if it is `Empty` which is sort of like a `nullptr`.  If an attempt is made to use an `Empty` value there will be undefined behavior or worse a segfault.

Generally this does not happen because there are several checks that occur in the workflow under the hood.  However the one that is most critical is if memory is not allocated correctly for the value (little v) the system will think it is a valid `v8::Value` but it will be `Empty` which is.... not... ideal...

There are other considerations as well with regards to errors in JS propagating back into native code, however our codebase does not enter this territory so I will not elaborate.

Turning on exceptions is the preferred way of handling this and is something the docs advocate for.  This was something that slipped by me when we worked on this before and I only caught it recently.  If we do not want to turn on exceptions there will need to be code added to check and unwrap the `Maybe` values to turn them in to proper `Value`s.

It will not affect the c-kzg code, its strictly to protect from `v8` engine issues.

Here is the doc about exception handling:
https://github.com/nodejs/node-addon-api/blob/main/doc/error_handling.md

And the subsection about code compliance with exceptions turned off:
https://github.com/nodejs/node-addon-api/blob/main/doc/error_handling.md#handling-errors-with-maybe-type-and-c-exceptions-disabled