### PR TITLE
fix: simplify how default setup is found

### DIFF
--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -7,48 +7,23 @@ const path = require("path");
 const bindings = require("bindings")("kzg");
 
 /**
- * NOTE: These two paths are only exported for testing purposes. They are not
- * announced in the type file.
+ * NOTE: This path is only exported for testing purposes. It is not announced in
+ * the type file.
  * 
- * It is critical that these paths are kept in sync with where the trusted setup
- * files will be found. The root setup is in the base src directory with the
- * primary library code. The dist version is dictated by the `build` command in
- * the Makefile in the bindings/node.js folder.
- */
-/**
- * Check the production bundle case first.
+ * It is critical that this path is kept in sync with where the trusted setup
+ * file will be found. The path is dictated by the `build` command in the
+ * Makefile in the bindings/node.js folder.
+ * 
+ * This path works for two situations:
+ * 1) Production case
  * - this file in BUNDLE_ROOT/dist/lib/kzg.js
  * - trusted_setup in BUNDLE_ROOT/dist/deps/c-kzg/trusted_setup.txt
+ * 
+ *  2) Post `build` state before `bundle` command works
+ * - this file in bindings/node.js/lib/kzg.js
+ * - trusted_setup in bindings/node.js/deps/c-kzg/trusted_setup.txt
  */
-bindings.TRUSTED_SETUP_PATH_IN_DIST = path.resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt");
-/**
- * Check the development case second.
- * - this file in REPO_ROOT/bindings/node.js/lib/kzg.js
- * - trusted_setup in REPO_ROOT/src/trusted_setup.txt
- */
-bindings.TRUSTED_SETUP_PATH_IN_SRC = path.resolve(__dirname, "..", "..", "..", "src", "trusted_setup.txt");
-
-/**
- * Looks in the default locations for the trusted setup file.  This is for cases
- * where the library is loaded without passing a trusted setup.  Should only be
- * used for cases where the Ethereum official mainnet KZG setup is acceptable.
- *
- * @returns {string | undefined} - Filepath for trusted_setup.txt if found
- */
-function getDefaultTrustedSetupFilepath() {
-  const locationsToSearch = [
-    // check the production case first
-    bindings.TRUSTED_SETUP_PATH_IN_DIST,
-    // check the development in-repo case second
-    bindings.TRUSTED_SETUP_PATH_IN_SRC,    
-  ];
-
-  for (const filepath of locationsToSearch) {
-    if (fs.existsSync(filepath)) {
-      return filepath;
-    }
-  }
-}
+bindings.DEFAULT_TRUSTED_SETUP_PATH = path.resolve(__dirname, "..", "deps", "c-kzg", "trusted_setup.txt");
 
 /**
  * Converts JSON formatted trusted setup into the native format that
@@ -101,8 +76,8 @@ bindings.getTrustedSetupFilepath = function getTrustedSetupFilepath(filePath) {
       throw new Error(`No trusted setup found: ${filePath}`);
     }
   } else {
-    filePath = getDefaultTrustedSetupFilepath();
-    if (!filePath) {
+    filePath = bindings.DEFAULT_TRUSTED_SETUP_PATH;
+    if (!fs.existsSync(filePath)) {
       throw new Error("Default trusted setup not found. Must pass a valid filepath to load c-kzg library");
     }
   }

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -1,5 +1,5 @@
 import {randomBytes} from "crypto";
-import {readFileSync, existsSync, cpSync, rmSync} from "fs";
+import {readFileSync, existsSync} from "fs";
 import {resolve} from "path";
 import {globSync} from "glob";
 
@@ -27,8 +27,7 @@ const {
 } = kzg;
 // not exported by types, only exported for testing purposes
 const getTrustedSetupFilepath = (kzg as any).getTrustedSetupFilepath as (filePath?: string) => string;
-const TRUSTED_SETUP_PATH_IN_DIST = (kzg as any).TRUSTED_SETUP_PATH_IN_DIST as string;
-const TRUSTED_SETUP_PATH_IN_SRC = (kzg as any).TRUSTED_SETUP_PATH_IN_SRC as string;
+const DEFAULT_TRUSTED_SETUP_PATH = (kzg as any).DEFAULT_TRUSTED_SETUP_PATH as string;
 
 const TEST_SETUP_FILE_PATH_JSON = resolve(__dirname, "__fixtures__", "trusted_setup.json");
 const TEST_SETUP_FILE_PATH_TXT = resolve(__dirname, "__fixtures__", "trusted_setup.txt");
@@ -188,20 +187,13 @@ describe("C-KZG", () => {
       expect(getTrustedSetupFilepath(TEST_SETUP_FILE_PATH_TXT)).toEqual(TEST_SETUP_FILE_PATH_TXT);
     });
     describe("default setups", () => {
-      beforeEach(() => {
-        if (!existsSync(TRUSTED_SETUP_PATH_IN_DIST)) {
-          cpSync(TRUSTED_SETUP_PATH_IN_SRC, TRUSTED_SETUP_PATH_IN_DIST);
+      beforeAll(() => {
+        if (!existsSync(DEFAULT_TRUSTED_SETUP_PATH)) {
+          throw new Error("Default deps/c-kzg/trusted_setup.txt not found for testing");
         }
       });
-      it("should return dist setup first", () => {
-        // both files should be preset right now
-        expect(getTrustedSetupFilepath()).toEqual(TRUSTED_SETUP_PATH_IN_DIST);
-      });
-      it("should return src setup if dist is missing", () => {
-        // both files should be preset right now
-        rmSync(TRUSTED_SETUP_PATH_IN_DIST);
-        expect(getTrustedSetupFilepath()).toEqual(TRUSTED_SETUP_PATH_IN_SRC);
-        cpSync(TRUSTED_SETUP_PATH_IN_SRC, TRUSTED_SETUP_PATH_IN_DIST);
+      it("should return default trusted_setup filepath", () => {
+        expect(getTrustedSetupFilepath()).toEqual(DEFAULT_TRUSTED_SETUP_PATH);
       });
     });
   });


### PR DESCRIPTION
Simplifies the logic for importing the default `trusted_setup.txt` in the node.js bindings.