### PR TITLE
fix: version and readme alpha note

### DIFF
--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -1,7 +1,5 @@
 # C-KZG-4844
 
-**Note: This is an alpha release with peerDas functionality.  For the current stable release use v3**
-
 This is a TypeScript library for EIP-4844 that implements the [Polynomial
 Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md)
 API. The core functionality was originally a stripped-down copy of

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",


### PR DESCRIPTION
Small update so the version is correct when the das branch gets merged to main.  Don't want to accidentally publish to the wrong version.  Also removed the note about alpha versions.  Wont get published until that is no longer true