### PR TITLE
Update versions in preparation for release

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 env:
-  binding_build_number_based_version: 1.0.0.${{ github.run_number }}
+  binding_build_number_based_version: 1.0.2.${{ github.run_number }}
 
 jobs:
   build-ckzg:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "c-kzg"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "bindgen",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-kzg"
-version = "1.0.0"
+version = "1.0.2"
 edition = "2021"
 license = "Apache-2.0"
 links = "ckzg"

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -23,7 +23,7 @@
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Version>0.1.0.0</Version>
+		<Version>0.1.0.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -32,7 +32,7 @@
 
 	<ItemGroup>
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
-		
+
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
 

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
     "Dan Coffman <dgcoffman@gmail.com>",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def main():
 
     setup(
         name="ckzg",
-        version="1.0.1",
+        version="1.0.2",
         author="Ethereum Foundation",
         author_email="security@ethereum.org",
         url="https://github.com/ethereum/c-kzg-4844",


### PR DESCRIPTION
This PR updates versions in the bindings.

PS: We forgot to do this for v1.0.1, so for most bindings we jump from v1.0.0 to v1.0.2.