### PR TITLE
fix: add crate description to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "c-kzg"
 version = "1.0.2"
 edition = "2021"
 license = "Apache-2.0"
+description = "A minimal implementation of the Polynomial Commitments API for EIP-4844, written in C."
 links = "ckzg"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Publishing to crates requires a description field for `Cargo.toml`