### PR TITLE
upstream: computeCells

### DIFF
--- a/bindings/nim/kzg_ex.nim
+++ b/bindings/nim/kzg_ex.nim
@@ -187,6 +187,9 @@ template verifyBlobKzgProofBatch*(blobs: openArray[KzgBlob],
                    proofs: openArray[KzgBytes48]): untyped =
   verifyProofs(blobs, commitments, proofs)
 
+template computeCells*(blob: KzgBlob): untyped =
+  computeCells(blob)
+
 template computeCellsAndKzgProofs*(blob: KzgBlob): untyped =
   computeCellsAndProofs(blob)
 


### PR DESCRIPTION
`computeCells( )` hadn't been upstreamed earlier, this fixes that.