### PR TITLE
[nim] Add completeStruct pragma which workarounds Nim compiler's issue with C codegen.

### DIFF
--- a/bindings/nim/kzg_abi.nim
+++ b/bindings/nim/kzg_abi.nim
@@ -58,19 +58,19 @@ type
 
   # A basic blob data.
   KzgBlob* {.importc: "Blob",
-    header: "c_kzg_4844.h".} = object
+    header: "c_kzg_4844.h", completeStruct.} = object
     bytes*: array[KzgBlobSize, uint8]
 
   # An array of 48 bytes. Represents an untrusted
   # (potentially invalid) commitment/proof.
   KzgBytes48* {.importc: "Bytes48",
-    header: "c_kzg_4844.h".} = object
+    header: "c_kzg_4844.h", completeStruct.} = object
     bytes*: array[48, uint8]
 
   # An array of 32 bytes. Represents an untrusted
   # (potentially invalid) field element.
   KzgBytes32* {.importc: "Bytes32",
-    header: "c_kzg_4844.h".} = object
+    header: "c_kzg_4844.h", completeStruct.} = object
     bytes*: array[32, uint8]
 
   # A trusted (valid) KZG commitment.


### PR DESCRIPTION
This helps to avoid Nim codegen issues when KZG types become parts of pure Nim objects.
PR works for both `pre-gcc-14` and `gcc-14`.