### PR TITLE
Upgrade blst to v0.3.12

### DIFF
--- a/bindings/go/blst_headers/blst.h
+++ b/bindings/go/blst_headers/blst.h
@@ -25,10 +25,13 @@ typedef __UINT64_TYPE__ uint64_t;
 extern "C" {
 #elif defined(__BLST_CGO__)
 typedef _Bool bool; /* it's assumed that cgo calls modern enough compiler */
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901
-# define bool _Bool
-#else
-# define bool int
+#elif !defined(bool)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__>=199901
+#  define bool _Bool
+# else
+#  define bool int
+# endif
+# define __blst_h_bool__
 #endif
 
 #ifdef SWIG
@@ -478,5 +481,8 @@ extern const blst_p2_affine BLS12_381_NEG_G2;
 
 #ifdef __cplusplus
 }
+#elif defined(__blst_h_bool__)
+# undef __blst_h_bool__
+# undef bool
 #endif
 #endif


### PR DESCRIPTION
This PR upgrades blst to the latest version ([v0.3.12](https://github.com/supranational/blst/releases/tag/v0.3.12)) that was released last month.