### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ systems.
 
 When processing multiple blobs, `verify_blob_kzg_proof_batch` is more efficient
 than calling `verify_blob_kzg_proof` individually. In CI tests, verifying 64
-blobs in batch is 53% faster per blob than verifying them individually. For a
+blobs in batch are 53% faster per blob than verifying them individually. For a
 single blob, `verify_blob_kzg_proof_batch` calls `verify_blob_kzg_proof`, and
 the overhead is negligible.
 

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -9,7 +9,7 @@ public static partial class Ckzg
     public const int BytesPerProof = 48;
 
     /// <summary>
-    ///     Loads trusted setup settings from file.
+    ///     Loads trusted setup settings from the file.
     /// </summary>
     /// <param name="filename">Settings file path</param>
     /// <exception cref="ArgumentException">Thrown when the file path is not correct</exception>

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -5,7 +5,7 @@ This directory contains C# bindings for the C-KZG-4844 library.
 ## Prerequisites
 
 Build requires:
-- `clang` as a preferred build tool for the native wrapper of ckzg. On Windows, it's tested with clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
+- `clang` as a preferred build tool for the native wrapper of ckzg. On Windows, it's tested with a clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
 - [.NET SDK](https://dotnet.microsoft.com/en-us/download) to build the bindings.
 
 ## Build & test

--- a/bindings/go/blst_headers/blst_aux.h
+++ b/bindings/go/blst_headers/blst_aux.h
@@ -32,7 +32,7 @@ void blst_p2_from_jacobian(blst_p2 *out, const blst_p2 *in);
  * Below functions produce both point and deserialized outcome of
  * SkToPk and Sign. However, deserialized outputs are pre-decorated
  * with sign and infinity bits. This means that you have to bring the
- * output into compliance prior returning to application. If you want
+ * output into compliance prior to returning to the application. If you want
  * compressed point value, then do [equivalent of]
  *
  *  byte temp[96];

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -14,7 +14,7 @@ make build
 ```
 
 This will install the shared library in `src/main/resources/ethereum/ckzg4844/lib` with a folder
-structure and name according your OS.
+structure and name according to your OS.
 
 All variables which could be passed to the `make` command and the defaults can be found in
 the [Makefile](./Makefile).

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -90,7 +90,7 @@ public class CKZG4844JNI {
   /**
    * An alternative to {@link #loadTrustedSetup(String)}. Loads the trusted setup from a resource.
    *
-   * @param resource the resource name that contains the trusted setup
+   * @param resource is the resource name that contains the trusted setup
    * @param clazz the class to use to get the resource
    * @param <T> the type of the class
    * @throws CKZGException if there is a crypto error

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -1,7 +1,7 @@
 # Profiling
 
 We use [`gperftools`](https://github.com/gperftools/gperftools) (Google
-Performance Tools) for profiling. Note, we also considered using
+Performance Tools) for profiling. Note, that we also considered using
 [`llvm-xray`](https://llvm.org/docs/XRay.html) but found it lacking in
 comparison. This will not tell you how long (wall clock time) each function
 took, but it will help you determine which functions are the most expensive.


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.