### PR TITLE
DAS: Implement coset FFT and use it around the codebase

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2830,8 +2830,8 @@ out:
  * @param[in]   n   Length of the arrays
  * @param[in]   s   The trusted setup
  *
- * @remark The coset shift factor is RECOVERY_SHIFT_FACTOR.
- * In this function we use its inverse to implement the IFFT.
+ * @remark The coset shift factor is RECOVERY_SHIFT_FACTOR. In this function we
+ *         use its inverse to implement the IFFT.
  */
 static C_KZG_RET coset_ifft_fr(
     fr_t *out, const fr_t *in, size_t n, const KZGSettings *s

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2810,7 +2810,7 @@ static C_KZG_RET coset_fft_fr(
     if (ret != C_KZG_OK) goto out;
 
     /* Shift the poly */
-    memcpy(in_shifted, in, n*sizeof(fr_t));
+    memcpy(in_shifted, in, n * sizeof(fr_t));
     shift_poly(in_shifted, n, &SCALE_FACTOR);
 
     ret = fft_fr(out, in_shifted, n, s);
@@ -2821,7 +2821,6 @@ out:
 
     return ret;
 }
-
 
 /** Do an inverse FFT over a coset of the roots of unity.
  *
@@ -2851,7 +2850,8 @@ out:
  * reconstructed original. Assumes that the inverse FFT of the original data
  * has the upper half of its values equal to zero.
  *
- * @param[out]  reconstructed_data_out   A preallocated array for recovered cells
+ * @param[out]  reconstructed_data_out   A preallocated array for recovered
+ *                                       cells
  * @param[in]   cells                    The cells that you have
  * @param[in]   s                        The trusted setup
  *
@@ -2926,15 +2926,21 @@ static C_KZG_RET recover_cells_impl(
             extended_evaluation_times_zero[i] = FR_ZERO;
         } else {
             blst_fr_mul(
-                &extended_evaluation_times_zero[i], &cells_brp[i], &zero_poly_eval[i]
+                &extended_evaluation_times_zero[i],
+                &cells_brp[i],
+                &zero_poly_eval[i]
             );
         }
     }
 
     /* Convert (E*Z)(x) to monomial form  */
-    ret = ifft_fr(extended_evaluation_times_zero_coeffs, extended_evaluation_times_zero, s->max_width, s);
+    ret = ifft_fr(
+        extended_evaluation_times_zero_coeffs,
+        extended_evaluation_times_zero,
+        s->max_width,
+        s
+    );
     if (ret != C_KZG_OK) goto out;
-
 
     /*
      * Polynomial division by convolution: Q3 = Q1 / Q2 where
@@ -2942,7 +2948,12 @@ static C_KZG_RET recover_cells_impl(
      *   Q2 = Z_r,I(k * x)
      *   Q3 = D(k * x)
      */
-    ret = coset_fft_fr(extended_evaluations_over_coset, extended_evaluation_times_zero_coeffs, s->max_width, s);
+    ret = coset_fft_fr(
+        extended_evaluations_over_coset,
+        extended_evaluation_times_zero_coeffs,
+        s->max_width,
+        s
+    );
     if (ret != C_KZG_OK) goto out;
 
     /* We use max_width here (not zero_poly_len) intentionally */
@@ -2952,14 +2963,21 @@ static C_KZG_RET recover_cells_impl(
     /* The result of the division is Q3 */
     for (size_t i = 0; i < s->max_width; i++) {
         fr_div(
-            &extended_evaluations_over_coset[i], &extended_evaluations_over_coset[i], &zero_poly_over_coset[i]
+            &extended_evaluations_over_coset[i],
+            &extended_evaluations_over_coset[i],
+            &zero_poly_over_coset[i]
         );
     }
 
     /* reconstructed_poly_over_coset is now extended_evaluations_over_coset */
 
     /* Convert the evaluations back to coefficents */
-    ret = coset_ifft_fr(reconstructed_poly_coeff, extended_evaluations_over_coset, s->max_width, s);
+    ret = coset_ifft_fr(
+        reconstructed_poly_coeff,
+        extended_evaluations_over_coset,
+        s->max_width,
+        s
+    );
     if (ret != C_KZG_OK) goto out;
 
     /*
@@ -2967,11 +2985,15 @@ static C_KZG_RET recover_cells_impl(
      * evaluates to our original data at the roots of unity. Next, we evaluate
      * the polynomial to get the original data.
      */
-    ret = fft_fr(reconstructed_data_out, reconstructed_poly_coeff, s->max_width, s);
+    ret = fft_fr(
+        reconstructed_data_out, reconstructed_poly_coeff, s->max_width, s
+    );
     if (ret != C_KZG_OK) goto out;
 
     /* Bit-reverse the recovered data points */
-    ret = bit_reversal_permutation(reconstructed_data_out, sizeof(fr_t), s->max_width);
+    ret = bit_reversal_permutation(
+        reconstructed_data_out, sizeof(fr_t), s->max_width
+    );
     if (ret != C_KZG_OK) goto out;
 
 out:
@@ -3967,8 +3989,14 @@ C_KZG_RET verify_cell_kzg_proof_batch(
          */
         uint32_t pos = reverse_bits_limited(CELLS_PER_EXT_BLOB, i);
         fr_t inv_coset_factor;
-        blst_fr_eucl_inverse(&inv_coset_factor, &s->expanded_roots_of_unity[pos]);
-        shift_poly(column_interpolation_poly, FIELD_ELEMENTS_PER_CELL, &inv_coset_factor);
+        blst_fr_eucl_inverse(
+            &inv_coset_factor, &s->expanded_roots_of_unity[pos]
+        );
+        shift_poly(
+            column_interpolation_poly,
+            FIELD_ELEMENTS_PER_CELL,
+            &inv_coset_factor
+        );
 
         /* Update the aggregated poly */
         for (size_t k = 0; k < FIELD_ELEMENTS_PER_CELL; k++) {

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2790,8 +2790,7 @@ static void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
     }
 }
 
-/** Do an FFT over a coset of the roots of unity. The function mutates the
- *  input array `in`
+/** Do an FFT over a coset of the roots of unity.
  *
  * @param[out]  out The results (array of length n)
  * @param[in]   in  The input data (array of length n)
@@ -2801,17 +2800,25 @@ static void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
  * @remark The coset shift factor is SCALE_FACTOR
  */
 static C_KZG_RET coset_fft_fr(
-    fr_t *out, fr_t *in, size_t n, const KZGSettings *s
+    fr_t *out, const fr_t *in, size_t n, const KZGSettings *s
 ) {
     C_KZG_RET ret;
+    fr_t *in_shifted = NULL;
 
-    shift_poly(in, n, &SCALE_FACTOR);
+    /* Create some room to shift the polynomial */
+    ret = new_fr_array(&in_shifted, n);
+    if (ret != C_KZG_OK) goto out;
 
-    /* Compute the FFT */
-    ret = fft_fr(out, in, n, s);
+    /* Shift the poly */
+    memcpy(in_shifted, in, n * sizeof(fr_t));
+    shift_poly(in_shifted, n, &SCALE_FACTOR);
+
+    ret = fft_fr(out, in_shifted, n, s);
     if (ret != C_KZG_OK) goto out;
 
 out:
+    c_kzg_free(in_shifted);
+
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2792,7 +2792,6 @@ static void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
 
 /**
  * Do an FFT over a coset of the roots of unity.
- * The function mutates the input array `in`.
  *
  * @param[out]  out The results (array of length n)
  * @param[in]   in  The input data (array of length n)

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2790,7 +2790,8 @@ static void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
     }
 }
 
-/** Do an FFT over a coset of the roots of unity.
+/** Do an FFT over a coset of the roots of unity. The function mutates the
+ *  input array `in`
  *
  * @param[out]  out The results (array of length n)
  * @param[in]   in  The input data (array of length n)
@@ -2800,25 +2801,17 @@ static void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
  * @remark The coset shift factor is SCALE_FACTOR
  */
 static C_KZG_RET coset_fft_fr(
-    fr_t *out, const fr_t *in, size_t n, const KZGSettings *s
+    fr_t *out, fr_t *in, size_t n, const KZGSettings *s
 ) {
     C_KZG_RET ret;
-    fr_t *in_shifted = NULL;
 
-    /* Create some room to shift the polynomial */
-    ret = new_fr_array(&in_shifted, n);
-    if (ret != C_KZG_OK) goto out;
+    shift_poly(in, n, &SCALE_FACTOR);
 
-    /* Shift the poly */
-    memcpy(in_shifted, in, n * sizeof(fr_t));
-    shift_poly(in_shifted, n, &SCALE_FACTOR);
-
-    ret = fft_fr(out, in_shifted, n, s);
+    /* Compute the FFT */
+    ret = fft_fr(out, in, n, s);
     if (ret != C_KZG_OK) goto out;
 
 out:
-    c_kzg_free(in_shifted);
-
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2820,7 +2820,6 @@ static C_KZG_RET coset_fft_fr(
 
 out:
     c_kzg_free(in_shifted);
-
     return ret;
 }
 

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -2970,7 +2970,8 @@ static C_KZG_RET recover_cells_impl(
         );
     }
 
-    /* reconstructed_poly_over_coset is now extended_evaluations_over_coset */
+    /* After the above polynomial division, extended_evaluations_over_coset is
+     * the same polynomial as reconstructed_poly_over_coset in the spec */
 
     /* Convert the evaluations back to coefficents */
     ret = coset_ifft_fr(

--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -3965,19 +3965,10 @@ C_KZG_RET verify_cell_kzg_proof_batch(
          * To unscale, divide by the coset. It's faster to multiply with the
          * inverse. We can skip the first iteration because its dividing by one.
          */
-        fr_t inv_x, inv_x_pow;
         uint32_t pos = reverse_bits_limited(CELLS_PER_EXT_BLOB, i);
-        fr_t coset_factor = s->expanded_roots_of_unity[pos];
-        blst_fr_eucl_inverse(&inv_x, &coset_factor);
-        inv_x_pow = inv_x;
-        for (uint64_t i = 1; i < FIELD_ELEMENTS_PER_CELL; i++) {
-            blst_fr_mul(
-                &column_interpolation_poly[i],
-                &column_interpolation_poly[i],
-                &inv_x_pow
-            );
-            blst_fr_mul(&inv_x_pow, &inv_x_pow, &inv_x);
-        }
+        fr_t inv_coset_factor;
+        blst_fr_eucl_inverse(&inv_coset_factor, &s->expanded_roots_of_unity[pos]);
+        shift_poly(column_interpolation_poly, FIELD_ELEMENTS_PER_CELL, &inv_coset_factor);
 
         /* Update the aggregated poly */
         for (size_t k = 0; k < FIELD_ELEMENTS_PER_CELL; k++) {

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1802,12 +1802,17 @@ static void test_coset_fft(void) {
     const size_t N = 8192;
     fr_t poly_eval[N];
     fr_t poly_coeff[N];
+    fr_t poly_coeff_backup[N];
     fr_t recovered_poly_coeff[N];
 
     // Generate poly in coeff form
     for (size_t i = 0; i < N; i++) {
         get_rand_fr(&poly_coeff[i]);
     }
+
+    /* Keep a backup of the coefficients becasue the coset_fft_fr() is gonna
+     * mutate them */
+    memcpy(poly_coeff_backup, poly_coeff, N * sizeof(fr_t));
 
     /* Evaluate poly using coset FFT */
     coset_fft_fr(poly_eval, poly_coeff, N, &s);
@@ -1819,7 +1824,9 @@ static void test_coset_fft(void) {
 
         blst_fr_mul(&shifted_w, &s.expanded_roots_of_unity[i], &SCALE_FACTOR);
 
-        eval_extended_poly(&individual_evaluation, poly_coeff, &shifted_w);
+        eval_extended_poly(
+            &individual_evaluation, poly_coeff_backup, &shifted_w
+        );
 
         bool ok = fr_equal(&individual_evaluation, &poly_eval[i]);
         ASSERT_EQUALS(ok, true);
@@ -1830,7 +1837,7 @@ static void test_coset_fft(void) {
 
     /* Check the end-to-end journey */
     for (size_t i = 0; i < N; i++) {
-        bool ok = fr_equal(&poly_coeff[i], &recovered_poly_coeff[i]);
+        bool ok = fr_equal(&poly_coeff_backup[i], &recovered_poly_coeff[i]);
         ASSERT_EQUALS(ok, true);
     }
 }

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1812,12 +1812,12 @@ static void test_coset_fft(void) {
     /* Evaluate poly using coset FFT */
     coset_fft_fr(poly_eval, poly_coeff, N, &s);
 
-    // check: result of coset FFT are really the evaluations over the coset
+    /* check: result of coset FFT are really the evaluations over the coset */
     for (size_t i = 0; i < N; i++) {
         fr_t shifted_w;
         fr_t individual_evaluation;
 
-        blst_fr_mul(&shifted_w, &s.expanded_roots_of_unity[i], &SCALE_FACTOR);
+        blst_fr_mul(&shifted_w, &s.expanded_roots_of_unity[i], &RECOVERY_SHIFT_FACTOR);
 
         eval_extended_poly(&individual_evaluation, poly_coeff, &shifted_w);
 
@@ -2221,8 +2221,6 @@ static void teardown(void) {
 
 int main(void) {
     setup();
-    RUN(test_fft);
-    RUN(test_coset_fft);
     RUN(test_c_kzg_malloc__succeeds_size_greater_than_zero);
     RUN(test_c_kzg_malloc__fails_size_equal_to_zero);
     RUN(test_c_kzg_malloc__fails_too_big);
@@ -2306,6 +2304,8 @@ int main(void) {
     RUN(test_expand_root_of_unity__succeeds_with_root);
     RUN(test_expand_root_of_unity__fails_not_root_of_unity);
     RUN(test_expand_root_of_unity__fails_wrong_root_of_unity);
+    RUN(test_fft);
+    RUN(test_coset_fft);
     RUN(test_reconstruct__succeeds_random_blob);
     RUN(test_verify_cell_kzg_proof__succeeds_random_blob);
 

--- a/src/test_c_kzg_4844.c
+++ b/src/test_c_kzg_4844.c
@@ -1802,17 +1802,12 @@ static void test_coset_fft(void) {
     const size_t N = 8192;
     fr_t poly_eval[N];
     fr_t poly_coeff[N];
-    fr_t poly_coeff_backup[N];
     fr_t recovered_poly_coeff[N];
 
     // Generate poly in coeff form
     for (size_t i = 0; i < N; i++) {
         get_rand_fr(&poly_coeff[i]);
     }
-
-    /* Keep a backup of the coefficients becasue the coset_fft_fr() is gonna
-     * mutate them */
-    memcpy(poly_coeff_backup, poly_coeff, N * sizeof(fr_t));
 
     /* Evaluate poly using coset FFT */
     coset_fft_fr(poly_eval, poly_coeff, N, &s);
@@ -1824,9 +1819,7 @@ static void test_coset_fft(void) {
 
         blst_fr_mul(&shifted_w, &s.expanded_roots_of_unity[i], &SCALE_FACTOR);
 
-        eval_extended_poly(
-            &individual_evaluation, poly_coeff_backup, &shifted_w
-        );
+        eval_extended_poly(&individual_evaluation, poly_coeff, &shifted_w);
 
         bool ok = fr_equal(&individual_evaluation, &poly_eval[i]);
         ASSERT_EQUALS(ok, true);
@@ -1837,7 +1830,7 @@ static void test_coset_fft(void) {
 
     /* Check the end-to-end journey */
     for (size_t i = 0; i < N; i++) {
-        bool ok = fr_equal(&poly_coeff_backup[i], &recovered_poly_coeff[i]);
+        bool ok = fr_equal(&poly_coeff[i], &recovered_poly_coeff[i]);
         ASSERT_EQUALS(ok, true);
     }
 }


### PR DESCRIPTION
This commit implements https://github.com/ethereum/consensus-specs/pull/3781 in c-kzg.

Some notes:
- Commit 7856f4dc is just comments and renames to bring the function closer to the spec (more work can be done)
- The last commit (a79cf966) is optional. We can keep it or discard it.
- I decided to discard `scale_poly()` and `unscale_poly()` and instead use a single function `shift_poly()` that can be reused in other situations as well.

The PR can be reviewed either commit-by-commit or in its entirety.