### PR TITLE
fix(rust): define NDEBUG when debug assertions are off

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -25,20 +25,19 @@ fn main() {
     cc.include(blst_headers_dir.clone());
     cc.warnings(false);
     cc.file(c_src_dir.join("c_kzg_4844.c"));
+    #[cfg(not(debug_assertions))]
+    cc.define("NDEBUG", None);
 
     cc.try_compile("ckzg").expect("Failed to compile ckzg");
 
     #[cfg(feature = "generate-bindings")]
     {
         let header_path = c_src_dir.join("c_kzg_4844.h");
-        let bindings_out_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/bindings/rust/src/bindings/generated.rs"
-        );
+        let bindings_out_path = root_dir.join("bindings/rust/src/bindings/generated.rs");
         make_bindings(
             header_path.to_str().expect("valid header path"),
             blst_headers_dir.to_str().expect("valid blst header path"),
-            bindings_out_path.as_ref(),
+            &bindings_out_path,
         );
     }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -19,8 +19,8 @@ pub use bindings::{
     C_KZG_RET as CkzgError,
 };
 
-#[cfg(feature = "ethereum_kzg_settings")]
 // Expose the default settings.
+#[cfg(feature = "ethereum_kzg_settings")]
 pub use ethereum_kzg_settings::{ethereum_kzg_settings, ethereum_kzg_settings_arc};
 
 // Expose the constants.


### PR DESCRIPTION
`cc-rs` does not define `NDEBUG` by default in release builds.