### PR TITLE
Add central Makefile which builds/tests everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ go:
 
 .PHONY: java
 java:
-	@make -C bindings/java
+	@make -C bindings/java build test
 
 .PHONY: nim
 nim:

--- a/Makefile
+++ b/Makefile
@@ -3,42 +3,34 @@ all: c csharp go java nim nodejs python rust
 
 .PHONY: c
 c:
-	@echo "[+] Building and testing $@"
 	@make -C src
 
 .PHONY: csharp
 csharp:
-	@echo "[+] Building and testing $@"
 	@make -C bindings/csharp
 
 .PHONY: go
 go:
-	@echo "[+] Building and testing $@"
 	@cd bindings/go && go clean -cache && go test
 
 .PHONY: java
 java:
-	@echo "[+] Building and testing $@"
 	@make -C bindings/java
 
 .PHONY: nim
 nim:
-	@echo "[+] Building and testing $@"
 	@cd bindings/nim && nim test
 
 .PHONY: nodejs
 nodejs:
-	@echo "[+] Building and testing $@"
 	@make -C bindings/node.js
 
 .PHONY: python
 python:
-	@echo "[+] Building and testing $@"
 	@make -C bindings/python
 
 .PHONY: rust
 rust:
-	@echo "[+] Building and testing $@"
 	@cargo test --features generate-bindings
 	@cargo bench --no-run
 	@cd fuzz && cargo build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+.PHONY: all
+all: c csharp go java nim nodejs python rust
+
+.PHONY: c
+c:
+	@echo "[+] Building and testing $@"
+	@make -C src
+
+.PHONY: csharp
+csharp:
+	@echo "[+] Building and testing $@"
+	@make -C bindings/csharp
+
+.PHONY: go
+go:
+	@echo "[+] Building and testing $@"
+	@cd bindings/go && go clean -cache && go test
+
+.PHONY: java
+java:
+	@echo "[+] Building and testing $@"
+	@make -C bindings/java
+
+.PHONY: nim
+nim:
+	@echo "[+] Building and testing $@"
+	@cd bindings/nim && nim test
+
+.PHONY: nodejs
+nodejs:
+	@echo "[+] Building and testing $@"
+	@make -C bindings/node.js
+
+.PHONY: python
+python:
+	@echo "[+] Building and testing $@"
+	@make -C bindings/python
+
+.PHONY: rust
+rust:
+	@echo "[+] Building and testing $@"
+	@cargo test --features generate-bindings
+	@cargo bench --no-run
+	@cd fuzz && cargo build


### PR DESCRIPTION
While working on EIP-7594 support, it was pretty annoying building/testing each of the bindings individually. I would have to cd bindings/<lang> && <some command> && cd ../bindings/<lang> a bunch of times. This PR adds a Makefile to the repository root which will build and test everything.