### PR TITLE
Improve python bindings build/install flow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML
+          pip install build PyYAML
       - name: Build BLST
         run: |
           cd src
@@ -60,9 +60,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML
+          pip install build PyYAML
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
       - name: Set up Visual Studio shell
         if: runner.os == 'Windows'
         uses: egor-tensin/vs-shell@v2

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ analysis-report/
 __pycache__
 .DS_Store
 
+# python build
+*dist/
+*ckzg.egg-info/
+
 # nimble build dir
 build/
 

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -2,9 +2,10 @@
 all: install test
 
 .PHONY: install
-install: ../../setup.py ckzg.c
-	python3 ../../setup.py install --force
+install: $(CURDIR)/../../setup.py $(CURDIR)/ckzg.c
+	python3 -m build --skip-dependency-check --outdir $(CURDIR)/dist $(CURDIR)/../../
+	python3 -m pip install $(CURDIR)/dist/*.whl --force-reinstall
 
 .PHONY: test
-test: tests.py
+test: $(CURDIR)/tests.py
 	python3 $<


### PR DESCRIPTION
This PR updates the Python build/install flow to use `python -m build` and `pip` instead of setuptools.