### PR TITLE
chore(rust): move Rust bindings to KZGSettings

### DIFF
--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -36,7 +36,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let commitments: Vec<Bytes48> = blobs
         .iter()
         .map(|blob| {
-            KzgCommitment::blob_to_kzg_commitment(blob, &kzg_settings)
+            kzg_settings
+                .blob_to_kzg_commitment(blob)
                 .unwrap()
                 .to_bytes()
         })
@@ -45,7 +46,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .iter()
         .zip(commitments.iter())
         .map(|(blob, commitment)| {
-            KzgProof::compute_blob_kzg_proof(blob, commitment, &kzg_settings)
+            kzg_settings
+                .compute_blob_kzg_proof(blob, commitment)
                 .unwrap()
                 .to_bytes()
         })
@@ -55,33 +57,25 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .collect();
 
     c.bench_function("blob_to_kzg_commitment", |b| {
-        b.iter(|| KzgCommitment::blob_to_kzg_commitment(&blobs[0], &kzg_settings))
+        b.iter(|| kzg_settings.blob_to_kzg_commitment(&blobs[0]))
     });
 
     c.bench_function("compute_kzg_proof", |b| {
-        b.iter(|| KzgProof::compute_kzg_proof(&blobs[0], &fields[0], &kzg_settings))
+        b.iter(|| kzg_settings.compute_kzg_proof(&blobs[0], &fields[0]))
     });
 
     c.bench_function("compute_blob_kzg_proof", |b| {
-        b.iter(|| KzgProof::compute_blob_kzg_proof(&blobs[0], &commitments[0], &kzg_settings))
+        b.iter(|| kzg_settings.compute_blob_kzg_proof(&blobs[0], &commitments[0]))
     });
 
     c.bench_function("verify_kzg_proof", |b| {
         b.iter(|| {
-            KzgProof::verify_kzg_proof(
-                &commitments[0],
-                &fields[0],
-                &fields[0],
-                &proofs[0],
-                &kzg_settings,
-            )
+            kzg_settings.verify_kzg_proof(&commitments[0], &fields[0], &fields[0], &proofs[0])
         })
     });
 
     c.bench_function("verify_blob_kzg_proof", |b| {
-        b.iter(|| {
-            KzgProof::verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0], &kzg_settings)
-        })
+        b.iter(|| kzg_settings.verify_blob_kzg_proof(&blobs[0], &commitments[0], &proofs[0]))
     });
 
     let mut group = c.benchmark_group("verify_blob_kzg_proof_batch");
@@ -97,13 +91,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     (blobs_subset, commitments_subset, proofs_subset)
                 },
                 |(blobs_subset, commitments_subset, proofs_subset)| {
-                    KzgProof::verify_blob_kzg_proof_batch(
-                        blobs_subset,
-                        commitments_subset,
-                        proofs_subset,
-                        &kzg_settings,
-                    )
-                    .unwrap();
+                    kzg_settings
+                        .verify_blob_kzg_proof_batch(
+                            blobs_subset,
+                            commitments_subset,
+                            proofs_subset,
+                        )
+                        .unwrap();
                 },
                 BatchSize::LargeInput,
             );

--- a/bindings/rust/src/ethereum_kzg_settings/mod.rs
+++ b/bindings/rust/src/ethereum_kzg_settings/mod.rs
@@ -40,7 +40,7 @@ fn ethereum_kzg_settings_inner(precompute: usize) -> &'static Arc<KzgSettings> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bindings::BYTES_PER_BLOB, Blob, KzgCommitment, KzgProof, KzgSettings};
+    use crate::{bindings::BYTES_PER_BLOB, Blob, KzgSettings};
     use std::path::Path;
 
     #[test]
@@ -53,19 +53,23 @@ mod tests {
         let blob = Blob::new([1u8; BYTES_PER_BLOB]);
 
         // generate commitment
-        let ts_commitment = KzgCommitment::blob_to_kzg_commitment(&blob, &ts_settings)
+        let ts_commitment = ts_settings
+            .blob_to_kzg_commitment(&blob)
             .unwrap()
             .to_bytes();
-        let eth_commitment = KzgCommitment::blob_to_kzg_commitment(&blob, &eth_settings)
+        let eth_commitment = eth_settings
+            .blob_to_kzg_commitment(&blob)
             .unwrap()
             .to_bytes();
         assert_eq!(ts_commitment, eth_commitment);
 
         // generate proof
-        let ts_proof = KzgProof::compute_blob_kzg_proof(&blob, &ts_commitment, &ts_settings)
+        let ts_proof = ts_settings
+            .compute_blob_kzg_proof(&blob, &ts_commitment)
             .unwrap()
             .to_bytes();
-        let eth_proof = KzgProof::compute_blob_kzg_proof(&blob, &eth_commitment, &eth_settings)
+        let eth_proof = eth_settings
+            .compute_blob_kzg_proof(&blob, &eth_commitment)
             .unwrap()
             .to_bytes();
         assert_eq!(ts_proof, eth_proof);


### PR DESCRIPTION
This moves the public functions to KZGSettings. And we no longer need to pass `&kzg_settings` as an argument.

Associated with #413.