### PR TITLE
fix: poly_lagrange_to_monomial

### DIFF
--- a/src/c_kzg_4844.c
+++ b/src/c_kzg_4844.c
@@ -3000,7 +3000,7 @@ out:
  * polynomial, by inverse FFTing the bit-reverse-permuted lagrange polynomial.
  */
 static C_KZG_RET poly_lagrange_to_monomial(
-    fr_t *monomial, const fr_t *lagrange, size_t len, const KZGSettings *s
+    fr_t *monomial_out, const fr_t *lagrange, size_t len, const KZGSettings *s
 ) {
     C_KZG_RET ret;
     fr_t *lagrange_brp = NULL;
@@ -3015,7 +3015,7 @@ static C_KZG_RET poly_lagrange_to_monomial(
     if (ret != C_KZG_OK) goto out;
 
     /* Perform an inverse FFT on the BRP'd polynomial */
-    ret = ifft_fr(monomial, lagrange_brp, len, s);
+    ret = ifft_fr(monomial_out, lagrange_brp, len, s);
     if (ret != C_KZG_OK) goto out;
 
 out:


### PR DESCRIPTION
This function had the parameters in the wrong order. It did not break because it was internally computing the monomial form but naming it the lagrange form. I've also modified the description, the previous wording made it seem like you needed to do bit reversal to convert a polynomial from lagrange to monomial form.