### PR TITLE
Cleanup roots of unity in KZGSettings

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -19,3 +19,9 @@ cargo test --release
 ```
 cargo bench
 ```
+
+## Update `generated.rs`
+
+```
+cargo build --features generate-bindings
+```

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -82,6 +82,7 @@ fn make_bindings(header_path: &str, blst_headers_dir: &str, bindings_out_path: &
         .allowlist_type("C_KZG_RET")
         .allowlist_var("BYTES_PER_.*")
         .allowlist_var("FIELD_ELEMENTS_PER_BLOB")
+        .allowlist_var("FIELD_ELEMENTS_PER_EXT_BLOB")
         .allowlist_file(".*eip.*.h")
         .allowlist_file(".*setup.h")
         /*

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -87,11 +87,11 @@ pub struct Blob {
 pub struct KZGSettings {
     #[doc = " The size of our multiplicative subgroup (the roots of unity). This is the size of\n  the extended domain (after the RS encoding has been applied), so the size of\n  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB."]
     domain_size: u64,
-    #[doc = " Roots of unity in bit-reversal permutation order.\n  The array contains `domain_size` elements."]
-    brp_roots_of_unity: *mut fr_t,
     #[doc = " Roots of unity for the subgroup of size `domain_size`.\n  The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     expanded_roots_of_unity: *mut fr_t,
-    #[doc = " Roots of unity for the subgroup of size `domain_size` reversed. Only used in FFTs.\n  The array contains `domain_size + 1` elements: it starts and ends with Fr::one()."]
+    #[doc = " Roots of unity in bit-reversed order.\n\n  This array is derived by applying a bit-reversal permutation\n  to `expanded_roots_of_unity` excluding the last element.\n  Essentially:\n  `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`\n\n  The array contains `domain_size` elements."]
+    brp_roots_of_unity: *mut fr_t,
+    #[doc = " Roots of unity for the subgroup of size `domain_size` in reversed order.\n\n  It is simply the reversed version of `expanded_roots_of_unity`.\n  Essentially:\n  `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`.\n\n  This array is primarily used in FFTs.\n  The array contains `domain_size + 1` elements: it starts and ends with Fr::one()."]
     reverse_roots_of_unity: *mut fr_t,
     #[doc = " G1 group elements from the trusted setup in monomial form."]
     g1_values_monomial: *mut g1_t,

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -87,7 +87,7 @@ pub struct Blob {
 pub struct KZGSettings {
     #[doc = " Roots of unity for the subgroup of size `domain_size`.\n\n The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     roots_of_unity: *mut fr_t,
-    #[doc = " Roots of unity in bit-reversed order.\n\n This array is derived by applying a bit-reversal permutation to `roots_of_unity`\n excluding the last element. Essentially:\n   `brp_roots_of_unity = bit_reversal_permutation(roots_of_unity[:-1])`\n\n The array contains `domain_size` elements."]
+    #[doc = " Roots of unity for the subgroup of size `domain_size` in bit-reversed order.\n\n This array is derived by applying a bit-reversal permutation to `roots_of_unity`\n excluding the last element. Essentially:\n   `brp_roots_of_unity = bit_reversal_permutation(roots_of_unity[:-1])`\n\n The array contains `domain_size` elements."]
     brp_roots_of_unity: *mut fr_t,
     #[doc = " Roots of unity for the subgroup of size `domain_size` in reversed order.\n\n It is the reversed version of `roots_of_unity`. Essentially:\n    `reverse_roots_of_unity = reverse(roots_of_unity)`\n\n This array is primarily used in FFTs.\n The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     reverse_roots_of_unity: *mut fr_t,

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -6,8 +6,8 @@ pub const BYTES_PER_COMMITMENT: usize = 48;
 pub const BYTES_PER_PROOF: usize = 48;
 pub const BYTES_PER_FIELD_ELEMENT: usize = 32;
 pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
-pub const BYTES_PER_BLOB: usize = 131072;
 pub const FIELD_ELEMENTS_PER_EXT_BLOB: usize = 8192;
+pub const BYTES_PER_BLOB: usize = 131072;
 pub const FIELD_ELEMENTS_PER_CELL: usize = 64;
 pub const CELLS_PER_EXT_BLOB: usize = 128;
 pub const BYTES_PER_CELL: usize = 2048;
@@ -85,8 +85,6 @@ pub struct Blob {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct KZGSettings {
-    #[doc = " The size of our multiplicative subgroup (the roots of unity). This is the size of the\n extended domain (after the RS encoding has been applied), so the size of the subgroup is\n FIELD_ELEMENTS_PER_EXT_BLOB."]
-    domain_size: u64,
     #[doc = " Roots of unity for the subgroup of size `domain_size`.\n\n The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     roots_of_unity: *mut fr_t,
     #[doc = " Roots of unity in bit-reversed order.\n\n This array is derived by applying a bit-reversal permutation to `roots_of_unity`\n excluding the last element. Essentially:\n   `brp_roots_of_unity = bit_reversal_permutation(roots_of_unity[:-1])`\n\n The array contains `domain_size` elements."]

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -85,13 +85,13 @@ pub struct Blob {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct KZGSettings {
-    #[doc = " The size of our multiplicative subgroup (the roots of unity). This is the size of\n  the extended domain (after the RS encoding has been applied), so the size of\n  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB."]
+    #[doc = " The size of our multiplicative subgroup (the roots of unity). This is the size of the\n extended domain (after the RS encoding has been applied), so the size of the subgroup is\n FIELD_ELEMENTS_PER_EXT_BLOB."]
     domain_size: u64,
-    #[doc = " Roots of unity for the subgroup of size `domain_size`.\n  The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
-    expanded_roots_of_unity: *mut fr_t,
-    #[doc = " Roots of unity in bit-reversed order.\n\n  This array is derived by applying a bit-reversal permutation\n  to `expanded_roots_of_unity` excluding the last element.\n  Essentially:\n  `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`\n\n  The array contains `domain_size` elements."]
+    #[doc = " Roots of unity for the subgroup of size `domain_size`.\n\n The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
+    roots_of_unity: *mut fr_t,
+    #[doc = " Roots of unity in bit-reversed order.\n\n This array is derived by applying a bit-reversal permutation to `roots_of_unity`\n excluding the last element. Essentially:\n   `brp_roots_of_unity = bit_reversal_permutation(roots_of_unity[:-1])`\n\n The array contains `domain_size` elements."]
     brp_roots_of_unity: *mut fr_t,
-    #[doc = " Roots of unity for the subgroup of size `domain_size` in reversed order.\n\n  It is simply the reversed version of `expanded_roots_of_unity`.\n  Essentially:\n  `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`.\n\n  This array is primarily used in FFTs.\n  The array contains `domain_size + 1` elements: it starts and ends with Fr::one()."]
+    #[doc = " Roots of unity for the subgroup of size `domain_size` in reversed order.\n\n It is the reversed version of `roots_of_unity`. Essentially:\n    `reverse_roots_of_unity = reverse(roots_of_unity)`\n\n This array is primarily used in FFTs.\n The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     reverse_roots_of_unity: *mut fr_t,
     #[doc = " G1 group elements from the trusted setup in monomial form."]
     g1_values_monomial: *mut g1_t,

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -85,13 +85,13 @@ pub struct Blob {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct KZGSettings {
-    #[doc = " The length of `roots_of_unity`, a power of 2."]
-    max_width: u64,
-    #[doc = " Powers of the primitive root of unity determined by `SCALE2_ROOT_OF_UNITY` in bit-reversal\n permutation order, length `max_width`."]
-    roots_of_unity: *mut fr_t,
-    #[doc = " The expanded roots of unity."]
+    #[doc = " The size of our multiplicative subgroup (the roots of unity). This is the size of\n  the extended domain (after the RS encoding has been applied), so the size of\n  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB."]
+    domain_size: u64,
+    #[doc = " Roots of unity in bit-reversal permutation order.\n  The array contains `domain_size` elements."]
+    brp_roots_of_unity: *mut fr_t,
+    #[doc = " Roots of unity for the subgroup of size `domain_size`.\n  The array contains `domain_size + 1` elements, it starts and ends with Fr::one()."]
     expanded_roots_of_unity: *mut fr_t,
-    #[doc = " The bit-reversal permuted roots of unity."]
+    #[doc = " Roots of unity for the subgroup of size `domain_size` reversed. Only used in FFTs.\n  The array contains `domain_size + 1` elements: it starts and ends with Fr::one()."]
     reverse_roots_of_unity: *mut fr_t,
     #[doc = " G1 group elements from the trusted setup in monomial form."]
     g1_values_monomial: *mut g1_t,

--- a/src/common.c
+++ b/src/common.c
@@ -662,11 +662,11 @@ static void g1_fft_fast(
  */
 C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->domain_size || !is_power_of_two(n)) {
+    if (n > FIELD_ELEMENTS_PER_EXT_BLOB || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t stride = s->domain_size / n;
+    uint64_t stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
     g1_fft_fast(out, in, 1, s->roots_of_unity, stride, n);
 
     return C_KZG_OK;
@@ -685,11 +685,11 @@ C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
  */
 C_KZG_RET g1_ifft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->domain_size || !is_power_of_two(n)) {
+    if (n > FIELD_ELEMENTS_PER_EXT_BLOB || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t stride = s->domain_size / n;
+    uint64_t stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
     g1_fft_fast(out, in, 1, s->reverse_roots_of_unity, stride, n);
 
     fr_t inv_len;

--- a/src/common.c
+++ b/src/common.c
@@ -662,11 +662,11 @@ static void g1_fft_fast(
  */
 C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->max_width || !is_power_of_two(n)) {
+    if (n > s->domain_size || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t stride = s->max_width / n;
+    uint64_t stride = s->domain_size / n;
     g1_fft_fast(out, in, 1, s->expanded_roots_of_unity, stride, n);
 
     return C_KZG_OK;
@@ -685,11 +685,11 @@ C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
  */
 C_KZG_RET g1_ifft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->max_width || !is_power_of_two(n)) {
+    if (n > s->domain_size || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t stride = s->max_width / n;
+    uint64_t stride = s->domain_size / n;
     g1_fft_fast(out, in, 1, s->reverse_roots_of_unity, stride, n);
 
     fr_t inv_len;

--- a/src/common.c
+++ b/src/common.c
@@ -667,7 +667,7 @@ C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
     }
 
     uint64_t stride = s->domain_size / n;
-    g1_fft_fast(out, in, 1, s->expanded_roots_of_unity, stride, n);
+    g1_fft_fast(out, in, 1, s->roots_of_unity, stride, n);
 
     return C_KZG_OK;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -100,14 +100,18 @@ typedef Bytes48 KZGProof;
 
 /** Stores the setup and parameters needed for computing KZG proofs. */
 typedef struct {
-    /** The length of `roots_of_unity`, a power of 2. */
+    /** The size of our multiplicative subgroup (the roots of unity). This is the size of
+     *  the extended domain (after the RS encoding has been applied), so the size of
+     *  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB. */
     uint64_t max_width;
-    /** Powers of the primitive root of unity determined by `SCALE2_ROOT_OF_UNITY` in bit-reversal
-     * permutation order, length `max_width`. */
+    /** Roots of unity in bit-reversal permutation order.
+     *  The array contains `domain_size` elements. */
     fr_t *roots_of_unity;
-    /** The expanded roots of unity. */
+    /** Roots of unity for the subgroup of size `domain_size`.
+     *  The array contains `domain_size + 1` elements, it starts and ends with Fr::one(). */
     fr_t *expanded_roots_of_unity;
-    /** The bit-reversal permuted roots of unity. */
+    /** Roots of unity for the subgroup of size `domain_size` reversed. Only used in FFTs.
+     *  The array contains `domain_size + 1` elements: it starts and ends with Fr::one(). */
     fr_t *reverse_roots_of_unity;
     /** G1 group elements from the trusted setup in monomial form. */
     g1_t *g1_values_monomial;

--- a/src/common.h
+++ b/src/common.h
@@ -111,13 +111,13 @@ typedef struct {
      *
      * The array contains `domain_size + 1` elements, it starts and ends with Fr::one().
      */
-    fr_t *expanded_roots_of_unity;
+    fr_t *roots_of_unity;
     /**
      * Roots of unity in bit-reversed order.
      *
-     * This array is derived by applying a bit-reversal permutation to `expanded_roots_of_unity`
+     * This array is derived by applying a bit-reversal permutation to `roots_of_unity`
      * excluding the last element. Essentially:
-     *   `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`
+     *   `brp_roots_of_unity = bit_reversal_permutation(roots_of_unity[:-1])`
      *
      * The array contains `domain_size` elements.
      */
@@ -125,8 +125,8 @@ typedef struct {
     /**
      * Roots of unity for the subgroup of size `domain_size` in reversed order.
      *
-     * It is the reversed version of `expanded_roots_of_unity`. Essentially:
-     *    `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`
+     * It is the reversed version of `roots_of_unity`. Essentially:
+     *    `reverse_roots_of_unity = reverse(roots_of_unity)`
      *
      * This array is primarily used in FFTs.
      * The array contains `domain_size + 1` elements, it starts and ends with Fr::one().

--- a/src/common.h
+++ b/src/common.h
@@ -104,13 +104,25 @@ typedef struct {
      *  the extended domain (after the RS encoding has been applied), so the size of
      *  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB. */
     uint64_t domain_size;
-    /** Roots of unity in bit-reversal permutation order.
-     *  The array contains `domain_size` elements. */
-    fr_t *brp_roots_of_unity;
     /** Roots of unity for the subgroup of size `domain_size`.
      *  The array contains `domain_size + 1` elements, it starts and ends with Fr::one(). */
     fr_t *expanded_roots_of_unity;
-    /** Roots of unity for the subgroup of size `domain_size` reversed. Only used in FFTs.
+    /** Roots of unity in bit-reversed order.
+     *
+     *  This array is derived by applying a bit-reversal permutation
+     *  to `expanded_roots_of_unity` excluding the last element.
+     *  Essentially:
+     *  `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`
+     *
+     *  The array contains `domain_size` elements. */
+    fr_t *brp_roots_of_unity;
+    /** Roots of unity for the subgroup of size `domain_size` in reversed order.
+     *
+     *  It is simply the reversed version of `expanded_roots_of_unity`.
+     *  Essentially:
+     *  `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`.
+     *
+     *  This array is primarily used in FFTs.
      *  The array contains `domain_size + 1` elements: it starts and ends with Fr::one(). */
     fr_t *reverse_roots_of_unity;
     /** G1 group elements from the trusted setup in monomial form. */

--- a/src/common.h
+++ b/src/common.h
@@ -103,7 +103,7 @@ typedef struct {
     /** The size of our multiplicative subgroup (the roots of unity). This is the size of
      *  the extended domain (after the RS encoding has been applied), so the size of
      *  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB. */
-    uint64_t max_width;
+    uint64_t domain_size;
     /** Roots of unity in bit-reversal permutation order.
      *  The array contains `domain_size` elements. */
     fr_t *brp_roots_of_unity;

--- a/src/common.h
+++ b/src/common.h
@@ -39,6 +39,9 @@ extern "C" {
 /** The number of field elements in a blob. */
 #define FIELD_ELEMENTS_PER_BLOB 4096
 
+/** The number of field elements in an extended blob */
+#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB * 2)
+
 /** The number of bytes in a blob. */
 #define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
 
@@ -100,12 +103,6 @@ typedef Bytes48 KZGProof;
 
 /** Stores the setup and parameters needed for computing KZG proofs. */
 typedef struct {
-    /**
-     * The size of our multiplicative subgroup (the roots of unity). This is the size of the
-     * extended domain (after the RS encoding has been applied), so the size of the subgroup is
-     * FIELD_ELEMENTS_PER_EXT_BLOB.
-     */
-    uint64_t domain_size;
     /**
      * Roots of unity for the subgroup of size `domain_size`.
      *

--- a/src/common.h
+++ b/src/common.h
@@ -106,7 +106,7 @@ typedef struct {
     uint64_t max_width;
     /** Roots of unity in bit-reversal permutation order.
      *  The array contains `domain_size` elements. */
-    fr_t *roots_of_unity;
+    fr_t *brp_roots_of_unity;
     /** Roots of unity for the subgroup of size `domain_size`.
      *  The array contains `domain_size + 1` elements, it starts and ends with Fr::one(). */
     fr_t *expanded_roots_of_unity;

--- a/src/common.h
+++ b/src/common.h
@@ -100,30 +100,37 @@ typedef Bytes48 KZGProof;
 
 /** Stores the setup and parameters needed for computing KZG proofs. */
 typedef struct {
-    /** The size of our multiplicative subgroup (the roots of unity). This is the size of
-     *  the extended domain (after the RS encoding has been applied), so the size of
-     *  the subgroup is FIELD_ELEMENTS_PER_EXT_BLOB. */
+    /**
+     * The size of our multiplicative subgroup (the roots of unity). This is the size of the
+     * extended domain (after the RS encoding has been applied), so the size of the subgroup is
+     * FIELD_ELEMENTS_PER_EXT_BLOB.
+     */
     uint64_t domain_size;
-    /** Roots of unity for the subgroup of size `domain_size`.
-     *  The array contains `domain_size + 1` elements, it starts and ends with Fr::one(). */
+    /**
+     * Roots of unity for the subgroup of size `domain_size`.
+     *
+     * The array contains `domain_size + 1` elements, it starts and ends with Fr::one().
+     */
     fr_t *expanded_roots_of_unity;
-    /** Roots of unity in bit-reversed order.
+    /**
+     * Roots of unity in bit-reversed order.
      *
-     *  This array is derived by applying a bit-reversal permutation
-     *  to `expanded_roots_of_unity` excluding the last element.
-     *  Essentially:
-     *  `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`
+     * This array is derived by applying a bit-reversal permutation to `expanded_roots_of_unity`
+     * excluding the last element. Essentially:
+     *   `brp_roots_of_unity = bit_reversal_permutation(expanded_roots_of_unity[:-1])`
      *
-     *  The array contains `domain_size` elements. */
+     * The array contains `domain_size` elements.
+     */
     fr_t *brp_roots_of_unity;
-    /** Roots of unity for the subgroup of size `domain_size` in reversed order.
+    /**
+     * Roots of unity for the subgroup of size `domain_size` in reversed order.
      *
-     *  It is simply the reversed version of `expanded_roots_of_unity`.
-     *  Essentially:
-     *  `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`.
+     * It is the reversed version of `expanded_roots_of_unity`. Essentially:
+     *    `reverse_roots_of_unity = reverse(expanded_roots_of_unity)`
      *
-     *  This array is primarily used in FFTs.
-     *  The array contains `domain_size + 1` elements: it starts and ends with Fr::one(). */
+     * This array is primarily used in FFTs.
+     * The array contains `domain_size + 1` elements, it starts and ends with Fr::one().
+     */
     fr_t *reverse_roots_of_unity;
     /** G1 group elements from the trusted setup in monomial form. */
     g1_t *g1_values_monomial;

--- a/src/common.h
+++ b/src/common.h
@@ -110,7 +110,7 @@ typedef struct {
      */
     fr_t *roots_of_unity;
     /**
-     * Roots of unity in bit-reversed order.
+     * Roots of unity for the subgroup of size `domain_size` in bit-reversed order.
      *
      * This array is derived by applying a bit-reversal permutation to `roots_of_unity`
      * excluding the last element. Essentially:

--- a/src/eip7594.c
+++ b/src/eip7594.c
@@ -159,7 +159,7 @@ static C_KZG_RET fr_fft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *
     }
 
     size_t stride = s->domain_size / n;
-    fr_fft_fast(out, in, 1, s->expanded_roots_of_unity, stride, n);
+    fr_fft_fast(out, in, 1, s->roots_of_unity, stride, n);
 
     return C_KZG_OK;
 }
@@ -248,7 +248,7 @@ static C_KZG_RET compute_vanishing_polynomial_from_roots(
  * the domain of size `FIELD_ELEMENTS_PER_BLOB`.
  *
  * The roots of unity are chosen based on the missing cell indices. If the i'th cell is missing,
- * then the i'th root of unity from `expanded_roots_of_unity` will be zero on the polynomial
+ * then the i'th root of unity from `roots_of_unity` will be zero on the polynomial
  * computed, along with every `CELLS_PER_EXT_BLOB` spaced root of unity in the domain.
  *
  * @param[in,out]   vanishing_poly          The vanishing polynomial
@@ -297,7 +297,7 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
      */
     size_t stride = s->domain_size / CELLS_PER_EXT_BLOB;
     for (size_t i = 0; i < len_missing_cells; i++) {
-        roots[i] = s->expanded_roots_of_unity[missing_cell_indices[i] * stride];
+        roots[i] = s->roots_of_unity[missing_cell_indices[i] * stride];
     }
 
     /* Compute the polynomial that evaluates to zero on the roots */
@@ -1415,7 +1415,7 @@ C_KZG_RET verify_cell_kzg_proof_batch(
          */
         uint32_t pos = reverse_bits_limited(CELLS_PER_EXT_BLOB, i);
         fr_t inv_coset_factor;
-        blst_fr_eucl_inverse(&inv_coset_factor, &s->expanded_roots_of_unity[pos]);
+        blst_fr_eucl_inverse(&inv_coset_factor, &s->roots_of_unity[pos]);
         shift_poly(column_interpolation_poly, FIELD_ELEMENTS_PER_CELL, &inv_coset_factor);
 
         /* Update the aggregated poly */
@@ -1443,7 +1443,7 @@ C_KZG_RET verify_cell_kzg_proof_batch(
 
     for (size_t i = 0; i < num_cells; i++) {
         uint32_t pos = reverse_bits_limited(CELLS_PER_EXT_BLOB, cell_indices[i]);
-        fr_t coset_factor = s->expanded_roots_of_unity[pos];
+        fr_t coset_factor = s->roots_of_unity[pos];
         fr_pow(&weights[i], &coset_factor, FIELD_ELEMENTS_PER_CELL);
         blst_fr_mul(&weighted_powers_of_r[i], &r_powers[i], &weights[i]);
     }

--- a/src/eip7594.c
+++ b/src/eip7594.c
@@ -154,11 +154,11 @@ static void fr_fft_fast(
  */
 static C_KZG_RET fr_fft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->max_width || !is_power_of_two(n)) {
+    if (n > s->domain_size || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    size_t stride = s->max_width / n;
+    size_t stride = s->domain_size / n;
     fr_fft_fast(out, in, 1, s->expanded_roots_of_unity, stride, n);
 
     return C_KZG_OK;
@@ -177,11 +177,11 @@ static C_KZG_RET fr_fft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *
  */
 static C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
     /* Ensure the length is valid */
-    if (n > s->max_width || !is_power_of_two(n)) {
+    if (n > s->domain_size || !is_power_of_two(n)) {
         return C_KZG_BADARGS;
     }
 
-    size_t stride = s->max_width / n;
+    size_t stride = s->domain_size / n;
     fr_fft_fast(out, in, 1, s->reverse_roots_of_unity, stride, n);
 
     fr_t inv_len;
@@ -285,8 +285,8 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
     ret = new_fr_array(&short_vanishing_poly, (len_missing_cells + 1));
     if (ret != C_KZG_OK) goto out;
 
-    /* Check if max_width is divisible by CELLS_PER_EXT_BLOB */
-    assert(s->max_width % CELLS_PER_EXT_BLOB == 0);
+    /* Check if domain_size is divisible by CELLS_PER_EXT_BLOB */
+    assert(s->domain_size % CELLS_PER_EXT_BLOB == 0);
 
     /*
      * For each missing cell index, choose the corresponding root of unity from the subgroup of
@@ -295,7 +295,7 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
      * In other words, if the missing index is `i`, then we add \omega^i to the roots array, where
      * \omega is a primitive `CELLS_PER_EXT_BLOB` root of unity.
      */
-    size_t stride = s->max_width / CELLS_PER_EXT_BLOB;
+    size_t stride = s->domain_size / CELLS_PER_EXT_BLOB;
     for (size_t i = 0; i < len_missing_cells; i++) {
         roots[i] = s->expanded_roots_of_unity[missing_cell_indices[i] * stride];
     }
@@ -457,28 +457,28 @@ static C_KZG_RET recover_cells_impl(
     fr_t *cells_brp = NULL;
 
     /* Allocate space for arrays */
-    ret = c_kzg_calloc((void **)&missing_cell_indices, s->max_width, sizeof(uint64_t));
+    ret = c_kzg_calloc((void **)&missing_cell_indices, s->domain_size, sizeof(uint64_t));
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_eval, s->max_width);
+    ret = new_fr_array(&vanishing_poly_eval, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_coeff, s->max_width);
+    ret = new_fr_array(&vanishing_poly_coeff, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&extended_evaluation_times_zero, s->max_width);
+    ret = new_fr_array(&extended_evaluation_times_zero, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&extended_evaluation_times_zero_coeffs, s->max_width);
+    ret = new_fr_array(&extended_evaluation_times_zero_coeffs, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&extended_evaluations_over_coset, s->max_width);
+    ret = new_fr_array(&extended_evaluations_over_coset, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_over_coset, s->max_width);
+    ret = new_fr_array(&vanishing_poly_over_coset, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&reconstructed_poly_coeff, s->max_width);
+    ret = new_fr_array(&reconstructed_poly_coeff, s->domain_size);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&cells_brp, s->max_width);
+    ret = new_fr_array(&cells_brp, s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Bit-reverse the data points, stored in new array */
-    memcpy(cells_brp, cells, s->max_width * sizeof(fr_t));
-    ret = bit_reversal_permutation(cells_brp, sizeof(fr_t), s->max_width);
+    memcpy(cells_brp, cells, s->domain_size * sizeof(fr_t));
+    ret = bit_reversal_permutation(cells_brp, sizeof(fr_t), s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Identify missing cells */
@@ -505,11 +505,11 @@ static C_KZG_RET recover_cells_impl(
     if (ret != C_KZG_OK) goto out;
 
     /* Convert Z(x) to evaluation form */
-    ret = fr_fft(vanishing_poly_eval, vanishing_poly_coeff, s->max_width, s);
+    ret = fr_fft(vanishing_poly_eval, vanishing_poly_coeff, s->domain_size, s);
     if (ret != C_KZG_OK) goto out;
 
     /* Compute (E*Z)(x) = E(x) * Z(x) in evaluation form over the FFT domain */
-    for (size_t i = 0; i < s->max_width; i++) {
+    for (size_t i = 0; i < s->domain_size; i++) {
         if (fr_is_null(&cells_brp[i])) {
             extended_evaluation_times_zero[i] = FR_ZERO;
         } else {
@@ -519,7 +519,7 @@ static C_KZG_RET recover_cells_impl(
 
     /* Convert (E*Z)(x) to monomial form  */
     ret = fr_ifft(
-        extended_evaluation_times_zero_coeffs, extended_evaluation_times_zero, s->max_width, s
+        extended_evaluation_times_zero_coeffs, extended_evaluation_times_zero, s->domain_size, s
     );
     if (ret != C_KZG_OK) goto out;
 
@@ -530,15 +530,15 @@ static C_KZG_RET recover_cells_impl(
      *   Q3 = D(k * x)
      */
     ret = coset_fft(
-        extended_evaluations_over_coset, extended_evaluation_times_zero_coeffs, s->max_width, s
+        extended_evaluations_over_coset, extended_evaluation_times_zero_coeffs, s->domain_size, s
     );
     if (ret != C_KZG_OK) goto out;
 
-    ret = coset_fft(vanishing_poly_over_coset, vanishing_poly_coeff, s->max_width, s);
+    ret = coset_fft(vanishing_poly_over_coset, vanishing_poly_coeff, s->domain_size, s);
     if (ret != C_KZG_OK) goto out;
 
     /* The result of the division is Q3 */
-    for (size_t i = 0; i < s->max_width; i++) {
+    for (size_t i = 0; i < s->domain_size; i++) {
         fr_div(
             &extended_evaluations_over_coset[i],
             &extended_evaluations_over_coset[i],
@@ -552,18 +552,18 @@ static C_KZG_RET recover_cells_impl(
      */
 
     /* Convert the evaluations back to coefficents */
-    ret = coset_ifft(reconstructed_poly_coeff, extended_evaluations_over_coset, s->max_width, s);
+    ret = coset_ifft(reconstructed_poly_coeff, extended_evaluations_over_coset, s->domain_size, s);
     if (ret != C_KZG_OK) goto out;
 
     /*
      * After unscaling the reconstructed polynomial, we have D(x) which evaluates to our original
      * data at the roots of unity. Next, we evaluate the polynomial to get the original data.
      */
-    ret = fr_fft(reconstructed_data_out, reconstructed_poly_coeff, s->max_width, s);
+    ret = fr_fft(reconstructed_data_out, reconstructed_poly_coeff, s->domain_size, s);
     if (ret != C_KZG_OK) goto out;
 
     /* Bit-reverse the recovered data points */
-    ret = bit_reversal_permutation(reconstructed_data_out, sizeof(fr_t), s->max_width);
+    ret = bit_reversal_permutation(reconstructed_data_out, sizeof(fr_t), s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
 out:
@@ -1097,7 +1097,7 @@ C_KZG_RET recover_cells_and_kzg_proofs(
     }
 
     /* Do allocations */
-    ret = new_fr_array(&recovered_cells_fr, s->max_width);
+    ret = new_fr_array(&recovered_cells_fr, s->domain_size);
     if (ret != C_KZG_OK) goto out;
     ret = new_g1_array(&recovered_proofs_g1, CELLS_PER_EXT_BLOB);
     if (ret != C_KZG_OK) goto out;
@@ -1105,7 +1105,7 @@ C_KZG_RET recover_cells_and_kzg_proofs(
     if (ret != C_KZG_OK) goto out;
 
     /* Initialize all cells as missing */
-    for (size_t i = 0; i < s->max_width; i++) {
+    for (size_t i = 0; i < s->domain_size; i++) {
         recovered_cells_fr[i] = FR_NULL;
     }
 

--- a/src/eip7594.h
+++ b/src/eip7594.h
@@ -28,9 +28,6 @@ extern "C" {
 // Macros
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/** The number of field elements in an extended blob */
-#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB * 2)
-
 /** The number of field elements in a cell. */
 #define FIELD_ELEMENTS_PER_CELL 64
 

--- a/src/setup.c
+++ b/src/setup.c
@@ -100,10 +100,10 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     if (ret != C_KZG_OK) goto out;
 
     /* Copy all but the last root to the roots of unity */
-    memcpy(s->roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->max_width);
+    memcpy(s->brp_roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->max_width);
 
     /* Apply the bit reversal permutation to the roots of unity */
-    ret = bit_reversal_permutation(s->roots_of_unity, sizeof(fr_t), s->max_width);
+    ret = bit_reversal_permutation(s->brp_roots_of_unity, sizeof(fr_t), s->max_width);
     if (ret != C_KZG_OK) goto out;
 
     /* Populate reverse roots of unity */
@@ -125,7 +125,7 @@ out:
 void free_trusted_setup(KZGSettings *s) {
     if (s == NULL) return;
     s->max_width = 0;
-    c_kzg_free(s->roots_of_unity);
+    c_kzg_free(s->brp_roots_of_unity);
     c_kzg_free(s->expanded_roots_of_unity);
     c_kzg_free(s->reverse_roots_of_unity);
     c_kzg_free(s->g1_values_monomial);
@@ -339,7 +339,7 @@ C_KZG_RET load_trusted_setup(
     C_KZG_RET ret;
 
     out->max_width = 0;
-    out->roots_of_unity = NULL;
+    out->brp_roots_of_unity = NULL;
     out->expanded_roots_of_unity = NULL;
     out->reverse_roots_of_unity = NULL;
     out->g1_values_monomial = NULL;
@@ -382,7 +382,7 @@ C_KZG_RET load_trusted_setup(
     out->max_width *= 2;
 
     /* Allocate all of our arrays */
-    ret = new_fr_array(&out->roots_of_unity, out->max_width);
+    ret = new_fr_array(&out->brp_roots_of_unity, out->max_width);
     if (ret != C_KZG_OK) goto out_error;
     ret = new_fr_array(&out->expanded_roots_of_unity, out->max_width + 1);
     if (ret != C_KZG_OK) goto out_error;

--- a/src/setup.c
+++ b/src/setup.c
@@ -92,7 +92,7 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
         return C_KZG_BADARGS;
     }
 
-    /* Get the root of unity */
+    /* Get the right subgroup generator */
     blst_fr_from_uint64(&root_of_unity, SCALE2_ROOT_OF_UNITY[max_scale]);
 
     /* Populate the roots of unity */
@@ -102,7 +102,7 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     /* Copy all but the last root to the roots of unity */
     memcpy(s->roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->max_width);
 
-    /* Permute the roots of unity */
+    /* Apply the bit reversal permutation to the roots of unity */
     ret = bit_reversal_permutation(s->roots_of_unity, sizeof(fr_t), s->max_width);
     if (ret != C_KZG_OK) goto out;
 

--- a/src/setup.c
+++ b/src/setup.c
@@ -84,7 +84,7 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     fr_t root_of_unity;
 
     uint32_t max_scale = 0;
-    while ((1ULL << max_scale) < s->max_width)
+    while ((1ULL << max_scale) < s->domain_size)
         max_scale++;
 
     /* Ensure this element will exist */
@@ -96,19 +96,19 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     blst_fr_from_uint64(&root_of_unity, SCALE2_ROOT_OF_UNITY[max_scale]);
 
     /* Populate the roots of unity */
-    ret = expand_root_of_unity(s->expanded_roots_of_unity, &root_of_unity, s->max_width);
+    ret = expand_root_of_unity(s->expanded_roots_of_unity, &root_of_unity, s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Copy all but the last root to the roots of unity */
-    memcpy(s->brp_roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->max_width);
+    memcpy(s->brp_roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->domain_size);
 
     /* Apply the bit reversal permutation to the roots of unity */
-    ret = bit_reversal_permutation(s->brp_roots_of_unity, sizeof(fr_t), s->max_width);
+    ret = bit_reversal_permutation(s->brp_roots_of_unity, sizeof(fr_t), s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Populate reverse roots of unity */
-    for (uint64_t i = 0; i <= s->max_width; i++) {
-        s->reverse_roots_of_unity[i] = s->expanded_roots_of_unity[s->max_width - i];
+    for (uint64_t i = 0; i <= s->domain_size; i++) {
+        s->reverse_roots_of_unity[i] = s->expanded_roots_of_unity[s->domain_size - i];
     }
 
 out:
@@ -124,7 +124,7 @@ out:
  */
 void free_trusted_setup(KZGSettings *s) {
     if (s == NULL) return;
-    s->max_width = 0;
+    s->domain_size = 0;
     c_kzg_free(s->brp_roots_of_unity);
     c_kzg_free(s->expanded_roots_of_unity);
     c_kzg_free(s->reverse_roots_of_unity);
@@ -201,7 +201,7 @@ static C_KZG_RET init_fk20_multi_settings(KZGSettings *s) {
     blst_p1_affine *p_affine = NULL;
     bool precompute = s->wbits != 0;
 
-    n = s->max_width / 2;
+    n = s->domain_size / 2;
     k = n / FIELD_ELEMENTS_PER_CELL;
     k2 = 2 * k;
 
@@ -338,7 +338,7 @@ C_KZG_RET load_trusted_setup(
 ) {
     C_KZG_RET ret;
 
-    out->max_width = 0;
+    out->domain_size = 0;
     out->brp_roots_of_unity = NULL;
     out->expanded_roots_of_unity = NULL;
     out->reverse_roots_of_unity = NULL;
@@ -375,18 +375,18 @@ C_KZG_RET load_trusted_setup(
     while ((1ULL << max_scale) < NUM_G1_POINTS)
         max_scale++;
 
-    /* Set the max_width */
-    out->max_width = 1ULL << max_scale;
+    /* Set the domain_size */
+    out->domain_size = 1ULL << max_scale;
 
     /* For DAS reconstruction */
-    out->max_width *= 2;
+    out->domain_size *= 2;
 
     /* Allocate all of our arrays */
-    ret = new_fr_array(&out->brp_roots_of_unity, out->max_width);
+    ret = new_fr_array(&out->brp_roots_of_unity, out->domain_size);
     if (ret != C_KZG_OK) goto out_error;
-    ret = new_fr_array(&out->expanded_roots_of_unity, out->max_width + 1);
+    ret = new_fr_array(&out->expanded_roots_of_unity, out->domain_size + 1);
     if (ret != C_KZG_OK) goto out_error;
-    ret = new_fr_array(&out->reverse_roots_of_unity, out->max_width + 1);
+    ret = new_fr_array(&out->reverse_roots_of_unity, out->domain_size + 1);
     if (ret != C_KZG_OK) goto out_error;
     ret = new_g1_array(&out->g1_values_monomial, NUM_G1_POINTS);
     if (ret != C_KZG_OK) goto out_error;

--- a/src/setup.c
+++ b/src/setup.c
@@ -96,11 +96,11 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     blst_fr_from_uint64(&root_of_unity, SCALE2_ROOT_OF_UNITY[max_scale]);
 
     /* Populate the roots of unity */
-    ret = expand_root_of_unity(s->expanded_roots_of_unity, &root_of_unity, s->domain_size);
+    ret = expand_root_of_unity(s->roots_of_unity, &root_of_unity, s->domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Copy all but the last root to the roots of unity */
-    memcpy(s->brp_roots_of_unity, s->expanded_roots_of_unity, sizeof(fr_t) * s->domain_size);
+    memcpy(s->brp_roots_of_unity, s->roots_of_unity, sizeof(fr_t) * s->domain_size);
 
     /* Apply the bit reversal permutation to the roots of unity */
     ret = bit_reversal_permutation(s->brp_roots_of_unity, sizeof(fr_t), s->domain_size);
@@ -108,7 +108,7 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
 
     /* Populate reverse roots of unity */
     for (uint64_t i = 0; i <= s->domain_size; i++) {
-        s->reverse_roots_of_unity[i] = s->expanded_roots_of_unity[s->domain_size - i];
+        s->reverse_roots_of_unity[i] = s->roots_of_unity[s->domain_size - i];
     }
 
 out:
@@ -126,7 +126,7 @@ void free_trusted_setup(KZGSettings *s) {
     if (s == NULL) return;
     s->domain_size = 0;
     c_kzg_free(s->brp_roots_of_unity);
-    c_kzg_free(s->expanded_roots_of_unity);
+    c_kzg_free(s->roots_of_unity);
     c_kzg_free(s->reverse_roots_of_unity);
     c_kzg_free(s->g1_values_monomial);
     c_kzg_free(s->g1_values_lagrange_brp);
@@ -340,7 +340,7 @@ C_KZG_RET load_trusted_setup(
 
     out->domain_size = 0;
     out->brp_roots_of_unity = NULL;
-    out->expanded_roots_of_unity = NULL;
+    out->roots_of_unity = NULL;
     out->reverse_roots_of_unity = NULL;
     out->g1_values_monomial = NULL;
     out->g1_values_lagrange_brp = NULL;
@@ -384,7 +384,7 @@ C_KZG_RET load_trusted_setup(
     /* Allocate all of our arrays */
     ret = new_fr_array(&out->brp_roots_of_unity, out->domain_size);
     if (ret != C_KZG_OK) goto out_error;
-    ret = new_fr_array(&out->expanded_roots_of_unity, out->domain_size + 1);
+    ret = new_fr_array(&out->roots_of_unity, out->domain_size + 1);
     if (ret != C_KZG_OK) goto out_error;
     ret = new_fr_array(&out->reverse_roots_of_unity, out->domain_size + 1);
     if (ret != C_KZG_OK) goto out_error;

--- a/src/tests.c
+++ b/src/tests.c
@@ -1684,7 +1684,7 @@ static void test_fft(void) {
     for (size_t i = 0; i < N; i++) {
         fr_t individual_evaluation;
 
-        eval_extended_poly(&individual_evaluation, poly_coeff, &s.expanded_roots_of_unity[i]);
+        eval_extended_poly(&individual_evaluation, poly_coeff, &s.roots_of_unity[i]);
 
         bool ok = fr_equal(&individual_evaluation, &poly_eval[i]);
         ASSERT_EQUALS(ok, true);
@@ -1721,7 +1721,7 @@ static void test_coset_fft(void) {
         fr_t shifted_w;
         fr_t individual_evaluation;
 
-        blst_fr_mul(&shifted_w, &s.expanded_roots_of_unity[i], &RECOVERY_SHIFT_FACTOR);
+        blst_fr_mul(&shifted_w, &s.roots_of_unity[i], &RECOVERY_SHIFT_FACTOR);
 
         eval_extended_poly(&individual_evaluation, poly_coeff, &shifted_w);
 
@@ -1934,32 +1934,32 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
      * We expect that the following roots will evaluate to zero on the vanishing polynomial we
      * computed:
      *
-     * s->expanded_roots_of_unity[0]
-     * s->expanded_roots_of_unity[128]
-     * s->expanded_roots_of_unity[256]
+     * s->roots_of_unity[0]
+     * s->roots_of_unity[128]
+     * s->roots_of_unity[256]
      * ...
-     * s->expanded_roots_of_unity[8064]
+     * s->roots_of_unity[8064]
      *
      * For every cell index, we should have `FIELD_ELEMENTS_PER_CELL` number of these roots. ie each
-     * cell index corresponds to 64 roots taken from `expanded_roots_of_unity` in the vanishing
+     * cell index corresponds to 64 roots taken from `roots_of_unity` in the vanishing
      * polynomial.
      *
-     * In general, the formula is expanded_roots_of_unity[cell_index + CELLS_PER_EXT_BLOB * k] where
+     * In general, the formula is roots_of_unity[cell_index + CELLS_PER_EXT_BLOB * k] where
      * `k` goes from 0 to FIELD_ELEMENTS_PER_CELL-1.
      *
      * For cell index 1, we would therefore expect the polynomial to vanish at points:
      *
-     * s->expanded_roots_of_unity[1]
-     * s->expanded_roots_of_unity[129]
-     * s->expanded_roots_of_unity[257]
+     * s->roots_of_unity[1]
+     * s->roots_of_unity[129]
+     * s->roots_of_unity[257]
      * ...
-     * s->expanded_roots_of_unity[8065]
+     * s->roots_of_unity[8065]
      *
      * Sanity check:
      * The largest cell index we can have is 127 since there are 128 cells.
      *
      * The last element for that cell index would have array index `127 + 128*63 = 8191`. This is
-     * correct since `expanded_roots_of_unity` has 8192 elements.
+     * correct since `roots_of_unity` has 8192 elements.
      */
     for (size_t i = 0; i < s.domain_size; i++) {
         if (i % CELLS_PER_EXT_BLOB == 1 || i % CELLS_PER_EXT_BLOB == 0) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -1904,11 +1904,11 @@ static void test_compute_vanishing_polynomial_from_roots(void) {
 static void test_vanishing_polynomial_for_missing_cells(void) {
 
     fr_t *vanishing_poly = NULL;
-    C_KZG_RET ret = new_fr_array(&vanishing_poly, s.domain_size);
+    C_KZG_RET ret = new_fr_array(&vanishing_poly, FIELD_ELEMENTS_PER_EXT_BLOB);
     ASSERT("vanishing poly alloc", ret == C_KZG_OK);
 
     fr_t *fft_result = NULL;
-    ret = new_fr_array(&fft_result, s.domain_size);
+    ret = new_fr_array(&fft_result, FIELD_ELEMENTS_PER_EXT_BLOB);
     ASSERT("fft_result alloc", ret == C_KZG_OK);
 
     /* Test case: the 0th and 1st cell are missing */
@@ -1923,7 +1923,7 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
     ASSERT("compute vanishing poly from cells", ret == C_KZG_OK);
 
     /* Compute FFT of vanishing_poly */
-    fr_fft(fft_result, vanishing_poly, s.domain_size, &s);
+    fr_fft(fft_result, vanishing_poly, FIELD_ELEMENTS_PER_EXT_BLOB, &s);
 
     /*
      * Check FFT results
@@ -1961,7 +1961,7 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
      * The last element for that cell index would have array index `127 + 128*63 = 8191`. This is
      * correct since `roots_of_unity` has 8192 elements.
      */
-    for (size_t i = 0; i < s.domain_size; i++) {
+    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
         if (i % CELLS_PER_EXT_BLOB == 1 || i % CELLS_PER_EXT_BLOB == 0) {
             /* Every CELLS_PER_EXT_BLOB-th evaluation should be zero */
             ASSERT("evaluation is zero", fr_is_zero(&fft_result[i]));

--- a/src/tests.c
+++ b/src/tests.c
@@ -1904,11 +1904,11 @@ static void test_compute_vanishing_polynomial_from_roots(void) {
 static void test_vanishing_polynomial_for_missing_cells(void) {
 
     fr_t *vanishing_poly = NULL;
-    C_KZG_RET ret = new_fr_array(&vanishing_poly, s.max_width);
+    C_KZG_RET ret = new_fr_array(&vanishing_poly, s.domain_size);
     ASSERT("vanishing poly alloc", ret == C_KZG_OK);
 
     fr_t *fft_result = NULL;
-    ret = new_fr_array(&fft_result, s.max_width);
+    ret = new_fr_array(&fft_result, s.domain_size);
     ASSERT("fft_result alloc", ret == C_KZG_OK);
 
     /* Test case: the 0th and 1st cell are missing */
@@ -1923,7 +1923,7 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
     ASSERT("compute vanishing poly from cells", ret == C_KZG_OK);
 
     /* Compute FFT of vanishing_poly */
-    fr_fft(fft_result, vanishing_poly, s.max_width, &s);
+    fr_fft(fft_result, vanishing_poly, s.domain_size, &s);
 
     /*
      * Check FFT results
@@ -1961,7 +1961,7 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
      * The last element for that cell index would have array index `127 + 128*63 = 8191`. This is
      * correct since `expanded_roots_of_unity` has 8192 elements.
      */
-    for (size_t i = 0; i < s.max_width; i++) {
+    for (size_t i = 0; i < s.domain_size; i++) {
         if (i % CELLS_PER_EXT_BLOB == 1 || i % CELLS_PER_EXT_BLOB == 0) {
             /* Every CELLS_PER_EXT_BLOB-th evaluation should be zero */
             ASSERT("evaluation is zero", fr_is_zero(&fft_result[i]));

--- a/src/tests.c
+++ b/src/tests.c
@@ -986,7 +986,7 @@ static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_
     fr_t x, y, c;
 
     get_rand_fr(&c);
-    x = s.roots_of_unity[123];
+    x = s.brp_roots_of_unity[123];
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
         p.evals[i] = c;
@@ -1009,7 +1009,7 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void)
     }
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        eval_poly(&p.evals[i], poly_coefficients, &s.roots_of_unity[i]);
+        eval_poly(&p.evals[i], poly_coefficients, &s.brp_roots_of_unity[i]);
     }
 
     get_rand_fr(&x);
@@ -1020,7 +1020,7 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void)
 
     ASSERT("evaluation methods match", fr_equal(&y, &check));
 
-    x = s.roots_of_unity[123];
+    x = s.brp_roots_of_unity[123];
 
     eval_poly(&check, poly_coefficients, &x);
 
@@ -1190,7 +1190,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         ret = blob_to_polynomial(poly.evals, &blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
-        z_fr = s.roots_of_unity[i];
+        z_fr = s.brp_roots_of_unity[i];
         bytes_from_bls_field(&z, &z_fr);
 
         /* Compute the proof */


### PR DESCRIPTION
This PR makes some steps towards https://github.com/ethereum/c-kzg-4844/issues/439

Leftover things to do:
- ~~Completely remove `max_width`. This is not a variable field so it doesn't need to be in `KZGSettings`. It's a parameter of the system, and by having it as a variable it makes things more confusing. IMO we should just use `FIELD_ELEMENTS_PER_EXT_BLOB` directly where it's appropriate, and `FIELD_ELEMENTS_PER_BLOB` in FK20.~~
- At some point we should stop this `domain_size + 1` artifact stemming from `expand_root_of_unity()` since it's needless and confusing. I decided to not do it because it would also change the 4844 code and I would ideally like it to remain as it was.