### PR TITLE
Fix profile & analyze

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -158,10 +158,13 @@ endif
 ###############################################################################
 
 .PHONY: analyze
-analyze: $(SOURCE_FILES) $(HEADER_FILES)
-	@$(CC) --analyze -Xanalyzer -analyzer-output=html \
-	    -o analysis-report $(CFLAGS) -c $<
-	@[ -d analysis-report ] && exit 1 || exit 0
+analyze: $(SOURCE_FILES)
+	@rm -rf analysis-report
+	@for src in $^; do \
+		echo "Analyzing $$src..."; \
+		$(CC) --analyze -Xanalyzer -analyzer-output=html -o analysis-report $(CFLAGS) -c $$src; \
+		[ -d analysis-report ] && exit 1; true; \
+	done
 
 ###############################################################################
 # Cleanup

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -386,7 +386,7 @@ static C_KZG_RET compute_r_powers_for_verify_cell_kzg_proof_batch(
                         + sizeof(uint64_t)                         /* FIELD_ELEMENTS_PER_CELL */
                         + sizeof(uint64_t)                         /* num_commitments */
                         + sizeof(uint64_t)                         /* num_cells */
-                        + (num_commitments * BYTES_PER_COMMITMENT) /* comms */
+                        + (num_commitments * BYTES_PER_COMMITMENT) /* commitment_bytes */
                         + (num_cells * sizeof(uint64_t))           /* commitment_indices */
                         + (num_cells * sizeof(uint64_t))           /* cell_indices */
                         + (num_cells * BYTES_PER_CELL)             /* cells */

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -135,6 +135,11 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
     );
     if (ret != C_KZG_OK) goto out;
 
+    /* Zero out all the coefficients */
+    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+        vanishing_poly[i] = FR_ZERO;
+    }
+
     /*
      * For each root \omega^i in `short_vanishing_poly`, we compute a polynomial that has roots at
      *

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -135,11 +135,6 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
     );
     if (ret != C_KZG_OK) goto out;
 
-    /* Zero out all the coefficients */
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        vanishing_poly[i] = FR_ZERO;
-    }
-
     /*
      * For each root \omega^i in `short_vanishing_poly`, we compute a polynomial that has roots at
      *

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -131,7 +131,6 @@ static void test_c_kzg_malloc__succeeds_size_greater_than_zero(void) {
     bool is_null = ptr == NULL;
     c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_OK);
-    ASSERT("valid pointer", ptr != NULL);
     ASSERT_EQUALS(is_null, false);
 }
 

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -126,68 +126,67 @@ static void eval_extended_poly(fr_t *out, fr_t *poly_coefficients, fr_t *x) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void test_c_kzg_malloc__succeeds_size_greater_than_zero(void) {
-    C_KZG_RET ret;
     void *ptr = NULL;
-
-    ret = c_kzg_malloc(&ptr, 123);
+    C_KZG_RET ret = c_kzg_malloc(&ptr, 123);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_OK);
     ASSERT("valid pointer", ptr != NULL);
-    free(ptr);
+    ASSERT_EQUALS(is_null, false);
 }
 
 static void test_c_kzg_malloc__fails_size_equal_to_zero(void) {
-    C_KZG_RET ret;
-    void *ptr = (void *)0x123;
-
-    ret = c_kzg_malloc(&ptr, 0);
+    void *ptr = NULL;
+    C_KZG_RET ret = c_kzg_malloc(&ptr, 0);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
-    ASSERT_EQUALS(ptr, NULL);
+    ASSERT_EQUALS(is_null, true);
 }
 
 static void test_c_kzg_malloc__fails_too_big(void) {
-    C_KZG_RET ret;
     void *ptr = NULL;
-
-    ret = c_kzg_malloc(&ptr, UINT64_MAX);
+    C_KZG_RET ret = c_kzg_malloc(&ptr, UINT64_MAX);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_MALLOC);
-    ASSERT_EQUALS(ptr, NULL);
+    ASSERT_EQUALS(is_null, true);
 }
 
 static void test_c_kzg_calloc__succeeds_size_greater_than_zero(void) {
-    C_KZG_RET ret;
     void *ptr = NULL;
-
-    ret = c_kzg_calloc(&ptr, 123, 456);
+    C_KZG_RET ret = c_kzg_calloc(&ptr, 123, 456);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_OK);
-    ASSERT("valid pointer", ptr != NULL);
-    free(ptr);
+    ASSERT_EQUALS(is_null, false);
 }
 
 static void test_c_kzg_calloc__fails_count_equal_to_zero(void) {
-    C_KZG_RET ret;
     void *ptr = (void *)0x123;
-
-    ret = c_kzg_calloc(&ptr, 0, 456);
+    C_KZG_RET ret = c_kzg_calloc(&ptr, 0, 456);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
-    ASSERT_EQUALS(ptr, NULL);
+    ASSERT_EQUALS(is_null, true);
 }
 
 static void test_c_kzg_calloc__fails_size_equal_to_zero(void) {
-    C_KZG_RET ret;
     void *ptr = (void *)0x123;
-
-    ret = c_kzg_calloc(&ptr, 123, 0);
+    C_KZG_RET ret = c_kzg_calloc(&ptr, 123, 0);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
-    ASSERT_EQUALS(ptr, NULL);
+    ASSERT_EQUALS(is_null, true);
 }
 
 static void test_c_kzg_calloc__fails_too_big(void) {
-    C_KZG_RET ret;
     void *ptr = NULL;
-
-    ret = c_kzg_calloc(&ptr, UINT64_MAX, UINT64_MAX);
+    C_KZG_RET ret = c_kzg_calloc(&ptr, UINT64_MAX, UINT64_MAX);
+    bool is_null = ptr == NULL;
+    c_kzg_free(ptr);
     ASSERT_EQUALS(ret, C_KZG_MALLOC);
-    ASSERT_EQUALS(ptr, NULL);
+    ASSERT_EQUALS(is_null, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1897,14 +1896,10 @@ static void test_compute_vanishing_polynomial_from_roots(void) {
 }
 
 static void test_vanishing_polynomial_for_missing_cells(void) {
+    C_KZG_RET ret;
 
-    fr_t *vanishing_poly = NULL;
-    C_KZG_RET ret = new_fr_array(&vanishing_poly, FIELD_ELEMENTS_PER_EXT_BLOB);
-    ASSERT("vanishing poly alloc", ret == C_KZG_OK);
-
-    fr_t *fft_result = NULL;
-    ret = new_fr_array(&fft_result, FIELD_ELEMENTS_PER_EXT_BLOB);
-    ASSERT("fft_result alloc", ret == C_KZG_OK);
+    fr_t vanishing_poly[FIELD_ELEMENTS_PER_EXT_BLOB];
+    fr_t fft_result[FIELD_ELEMENTS_PER_EXT_BLOB];
 
     /* Test case: the 0th and 1st cell are missing */
     uint64_t missing_cell_indices[] = {0, 1};
@@ -2106,19 +2101,12 @@ static void profile_verify_blob_kzg_proof_batch(void) {
 }
 
 static void profile_compute_cells_and_kzg_proofs(void) {
-    C_KZG_RET ret;
     Blob blob;
-    Cell *cells = NULL;
-    KZGProof *proofs = NULL;
+    Cell cells[CELLS_PER_EXT_BLOB];
+    KZGProof proofs[CELLS_PER_EXT_BLOB];
 
     /* Get a random blob */
     get_rand_blob(&blob);
-
-    /* Allocate arrays */
-    ret = c_kzg_calloc((void **)&cells, CELLS_PER_EXT_BLOB, sizeof(Cell));
-    ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = c_kzg_calloc((void **)&proofs, CELLS_PER_EXT_BLOB, sizeof(KZGProof));
-    ASSERT_EQUALS(ret, C_KZG_OK);
 
     ProfilerStart("compute_cells_and_kzg_proofs.prof");
     for (int i = 0; i < 5; i++) {
@@ -2128,10 +2116,9 @@ static void profile_compute_cells_and_kzg_proofs(void) {
 }
 
 static void profile_recover_cells_and_kzg_proofs(void) {
-    C_KZG_RET ret;
     Blob blob;
-    uint64_t *cell_indices = NULL;
-    Cell *cells = NULL;
+    uint64_t cell_indices[CELLS_PER_EXT_BLOB];
+    Cell cells[CELLS_PER_EXT_BLOB];
 
     /*
      * NOTE: this profiling function only cares about cell recovery since the proofs will always be
@@ -2141,16 +2128,10 @@ static void profile_recover_cells_and_kzg_proofs(void) {
     /* Get a random blob */
     get_rand_blob(&blob);
 
-    /* Allocate arrays */
-    ret = c_kzg_calloc((void **)&cells, CELLS_PER_EXT_BLOB, sizeof(Cell));
-    ASSERT_EQUALS(ret, C_KZG_OK);
-
     /* Compute cells */
     compute_cells_and_kzg_proofs(cells, NULL, &blob, &s);
 
     /* Initialize cell indices */
-    ret = c_kzg_calloc((void **)&cell_indices, CELLS_PER_EXT_BLOB / 2, sizeof(uint64_t));
-    ASSERT_EQUALS(ret, C_KZG_OK);
     for (size_t i = 0; i < CELLS_PER_EXT_BLOB / 2; i++) {
         cell_indices[i] = i;
     }
@@ -2166,10 +2147,11 @@ static void profile_verify_cell_kzg_proof_batch(void) {
     C_KZG_RET ret;
     bool ok;
     Blob blob;
-    uint64_t *cell_indices = NULL;
     KZGCommitment commitment;
-    Cell *cells = NULL;
-    KZGProof *proofs = NULL;
+    KZGCommitment commitments[CELLS_PER_EXT_BLOB];
+    uint64_t cell_indices[CELLS_PER_EXT_BLOB];
+    Cell cells[CELLS_PER_EXT_BLOB];
+    KZGProof proofs[CELLS_PER_EXT_BLOB];
 
     /* Get a random blob */
     get_rand_blob(&blob);
@@ -2178,20 +2160,8 @@ static void profile_verify_cell_kzg_proof_batch(void) {
     ret = blob_to_kzg_commitment(&commitment, &blob, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
-    /* Allocate arrays */
-    ret = c_kzg_calloc((void **)&cells, CELLS_PER_EXT_BLOB, sizeof(Cell));
-    ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = c_kzg_calloc((void **)&proofs, CELLS_PER_EXT_BLOB, sizeof(KZGProof));
-    ASSERT_EQUALS(ret, C_KZG_OK);
-
     /* Compute cells and proofs */
     ret = compute_cells_and_kzg_proofs(cells, proofs, &blob, &s);
-    ASSERT_EQUALS(ret, C_KZG_OK);
-
-    /* Initialize indices */
-    ret = c_kzg_calloc((void **)&commitments, CELLS_PER_EXT_BLOB, sizeof(uint64_t));
-    ASSERT_EQUALS(ret, C_KZG_OK);
-    ret = c_kzg_calloc((void **)&cell_indices, CELLS_PER_EXT_BLOB, sizeof(uint64_t));
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++) {
@@ -2202,7 +2172,7 @@ static void profile_verify_cell_kzg_proof_batch(void) {
     ProfilerStart("verify_cell_kzg_proof_batch.prof");
     for (int i = 0; i < 100; i++) {
         verify_cell_kzg_proof_batch(
-            &ok, &commitments, cell_indices, cells, proofs, CELLS_PER_EXT_BLOB, &s
+            &ok, commitments, cell_indices, cells, proofs, CELLS_PER_EXT_BLOB, &s
         );
     }
     ProfilerStop();


### PR DESCRIPTION
So `make profile` and `make analyze` have been broken since the file split. This PR makes the following changes:

* Run analyzer on each source file individually. Doesn't work when bundled together.
* Fix some allocation nits in the tests. There were some potential leaks that the analyzer pointed out.
  * I'm using more stack variables now. They are big, but not big enough to cause problems.
  * This includes storing the result & doing `c_kzg_free` before doing asserts.
* Fix `commitments` issue in one of the profiler functions.

~~To fix the broken test, please merge #474 first.~~