### PR TITLE
Do not rely on calloc zeroing out allocations

### DIFF
--- a/src/common/alloc.c
+++ b/src/common/alloc.c
@@ -21,10 +21,6 @@
 #include <stdbool.h> /* For bool */
 #include <stddef.h>  /* For size_t & NULL */
 #include <stdlib.h>  /* For malloc */
-#include <string.h>  /* For memset */
-
-/** Enable to test non-zeroized allocations. */
-#define MEMSET_TO_FF 0
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Memory Allocation
@@ -42,9 +38,6 @@ C_KZG_RET c_kzg_malloc(void **out, size_t size) {
     *out = NULL;
     if (size == 0) return C_KZG_BADARGS;
     *out = malloc(size);
-#if MEMSET_TO_FF
-    if (*out != NULL) memset(*out, 0xff, size);
-#endif /* MEMSET_TO_FF */
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;
 }
 
@@ -61,9 +54,6 @@ C_KZG_RET c_kzg_calloc(void **out, size_t count, size_t size) {
     *out = NULL;
     if (count == 0 || size == 0) return C_KZG_BADARGS;
     *out = calloc(count, size);
-#if MEMSET_TO_FF
-    if (*out != NULL) memset(*out, 0xff, count * size);
-#endif /* MEMSET_TO_FF */
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;
 }
 

--- a/src/common/alloc.c
+++ b/src/common/alloc.c
@@ -21,6 +21,10 @@
 #include <stdbool.h> /* For bool */
 #include <stddef.h>  /* For size_t & NULL */
 #include <stdlib.h>  /* For malloc */
+#include <string.h>  /* For memset */
+
+/** Enable to test non-zeroized allocations. */
+#define MEMSET_TO_FF 0
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Memory Allocation
@@ -38,6 +42,9 @@ C_KZG_RET c_kzg_malloc(void **out, size_t size) {
     *out = NULL;
     if (size == 0) return C_KZG_BADARGS;
     *out = malloc(size);
+#if MEMSET_TO_FF
+    if (*out != NULL) memset(*out, 0xff, size);
+#endif /* MEMSET_TO_FF */
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;
 }
 
@@ -54,6 +61,9 @@ C_KZG_RET c_kzg_calloc(void **out, size_t count, size_t size) {
     *out = NULL;
     if (count == 0 || size == 0) return C_KZG_BADARGS;
     *out = calloc(count, size);
+#if MEMSET_TO_FF
+    if (*out != NULL) memset(*out, 0xff, count * size);
+#endif /* MEMSET_TO_FF */
     return *out != NULL ? C_KZG_OK : C_KZG_MALLOC;
 }
 

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -91,7 +91,7 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     ret = poly_lagrange_to_monomial(poly_monomial, poly_lagrange, FIELD_ELEMENTS_PER_BLOB, s);
     if (ret != C_KZG_OK) goto out;
 
-    /* Ensure the upper half of the fields are zero */
+    /* Ensure the upper half of the field elements are zero */
     for (size_t i = FIELD_ELEMENTS_PER_BLOB; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
         poly_monomial[i] = FR_ZERO;
     }

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -91,6 +91,11 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     ret = poly_lagrange_to_monomial(poly_monomial, poly_lagrange, FIELD_ELEMENTS_PER_BLOB, s);
     if (ret != C_KZG_OK) goto out;
 
+    /* Ensure the upper half of the fields are zero */
+    for (size_t i = FIELD_ELEMENTS_PER_BLOB; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+        poly_monomial[i] = FR_ZERO;
+    }
+
     if (cells != NULL) {
         /* Allocate space for our data points */
         ret = new_fr_array(&data_fr, FIELD_ELEMENTS_PER_EXT_BLOB);

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -135,6 +135,11 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
     );
     if (ret != C_KZG_OK) goto out;
 
+    /* Zero out all the coefficients */
+    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+        vanishing_poly[i] = FR_ZERO;
+    }
+
     /*
      * For each root \omega^i in `short_vanishing_poly`, we compute a polynomial that has roots at
      *
@@ -246,10 +251,7 @@ C_KZG_RET recover_cells(
     for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++) {
         /* Iterate over each cell index and check if we have received it */
         if (!is_in_array(cell_indices, num_cells, i)) {
-            /*
-             * If the cell is missing, bit reverse the index and add it to the
-             * missing array.
-             */
+            /* If the cell is missing, bit reverse the index and add it to the missing array */
             uint32_t brp_i = reverse_bits_limited(CELLS_PER_EXT_BLOB, i);
             missing_cell_indices[len_missing++] = brp_i;
         }


### PR DESCRIPTION
There were two spots which relied on `calloc` zeroing out values. I don't like this.

I left the `MEMSET_TO_FF` macro option to test this. Could be useful in the future. Open to removing it.

And yeah, `malloc` doesn't zero out allocations, but wanted to be consistent.

Also fix a random comment's wrap that I noticed.