### PR TITLE
Improve the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src/.blst_hash
 src/tests
 src/tests_*
 coverage.html

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -52,6 +52,7 @@ all: build test
 
 .PHONY: build
 build:
+	$(MAKE) -C ../../src/ blst
 	mkdir -p ${LIBRARY_FOLDER}
 	${CLANG_EXECUTABLE} ${CC_FLAGS} ${CLANG_FLAGS} ${OPTIMIZATION_LEVEL} -Wall -Wextra -Werror -Wno-missing-braces -Wno-unused-parameter -Wno-format ${addprefix -I,${INCLUDE_DIRS}} -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/${JNI_INCLUDE_FOLDER}" -o ${LIBRARY_FOLDER}/${LIBRARY_RESOURCE} ${TARGETS}
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -125,7 +125,7 @@ $(BLST_BUILDSCRIPT):
 # This will build blst without condition.
 # It will also copy the header files to our include directory.
 .PHONY: build_blst
-build_blst:
+build_blst: $(BLST_BUILDSCRIPT)
 	@echo "[+] building blst"
 	@cd $(dir $(BLST_BUILDSCRIPT)) && \
 	./$(notdir $(BLST_BUILDSCRIPT)) $(BLST_BUILDSCRIPT_FLAGS) && \
@@ -136,7 +136,7 @@ build_blst:
 # This will build blst if the module is out of date.
 # We track this with a hidden file.
 .PHONY: blst
-blst: $(BLST_BUILDSCRIPT)
+blst:
 	@if [ ! -f $(BLST_HASH_FILE) ] || \
 		[ "$(BLST_HASH)" != "$$(cat $(BLST_HASH_FILE))" ]; then \
 			$(MAKE) build_blst; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -131,20 +131,15 @@ build_blst:
 	./$(notdir $(BLST_BUILDSCRIPT)) $(BLST_BUILDSCRIPT_FLAGS) && \
 	cp $(notdir $(BLST_LIBRARY)) ../lib && \
 	cp bindings/*.h ../inc
+	@echo $(BLST_HASH) > $(BLST_HASH_FILE)
 
 # This will build blst if the module is out of date.
 # We track this with a hidden file.
 .PHONY: blst
 blst: $(BLST_BUILDSCRIPT)
-	@if [ -f $(BLST_HASH_FILE) ]; then \
-		LAST_HASH=$$(cat $(BLST_HASH_FILE)); \
-		if [ "$(BLST_HASH)" != "$$LAST_HASH" ]; then \
+	@if [ ! -f $(BLST_HASH_FILE) ] || \
+		[ "$(BLST_HASH)" != "$$(cat $(BLST_HASH_FILE))" ]; then \
 			$(MAKE) build_blst; \
-			echo $(BLST_HASH) > $(BLST_HASH_FILE); \
-		fi \
-	else \
-		$(MAKE) build_blst; \
-		echo $(BLST_HASH) > $(BLST_HASH_FILE); \
 	fi
 
 # This compiles the tests with optimizations disabled.

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,6 +92,9 @@ else
 endif
 
 # Settings for blst.
+BLST_DIR = ../blst
+BLST_HASH := $(shell git -C $(BLST_DIR) rev-parse HEAD)
+BLST_HASH_FILE = .blst_hash
 BLST_LIBRARY = ../lib/libblst.a
 BLST_BUILDSCRIPT = ../blst/build.sh
 BLST_BUILDSCRIPT_FLAGS = -D__BLST_PORTABLE__
@@ -113,26 +116,49 @@ HEADER_FILES := $(filter-out test/tinytest.h, $(HEADER_FILES))
 # Core
 ###############################################################################
 
-all: $(OBJECT_FILES) test
+all: test
 
+# This will populate the blst directory will files.
 $(BLST_BUILDSCRIPT):
+	@echo "[+] initializing blst submodule"
 	@git submodule update --init
 
-$(BLST_LIBRARY): $(BLST_BUILDSCRIPT)
+# This will build blst without condition.
+# It will also copy the header files to our include directory.
+.PHONY: build_blst
+build_blst:
+	@echo "[+] building blst"
 	@cd $(dir $(BLST_BUILDSCRIPT)) && \
 	./$(notdir $(BLST_BUILDSCRIPT)) $(BLST_BUILDSCRIPT_FLAGS) && \
 	cp $(notdir $(BLST_LIBRARY)) ../lib && \
 	cp bindings/*.h ../inc
 
+# This will build blst if the module is out of date.
+# We track this with a hidden file.
 .PHONY: blst
-blst: $(BLST_LIBRARY)
+blst: $(BLST_BUILDSCRIPT)
+	@if [ -f $(BLST_HASH_FILE) ]; then \
+		LAST_HASH=$$(cat $(BLST_HASH_FILE)); \
+		if [ "$(BLST_HASH)" != "$$LAST_HASH" ]; then \
+			$(MAKE) build_blst; \
+			echo $(BLST_HASH) > $(BLST_HASH_FILE); \
+		fi \
+	else \
+		$(MAKE) build_blst; \
+		echo $(BLST_HASH) > $(BLST_HASH_FILE); \
+	fi
 
+# This compiles the tests with optimizations disabled.
+# It will re-build if any of our source/header files change.
 tests: CFLAGS += -O0
-tests: $(SOURCE_FILES) $(HEADER_FILES) $(BLST_LIBRARY)
+tests: blst $(SOURCE_FILES) $(HEADER_FILES)
+	@echo "[+] building tests"
 	@$(CC) $(CFLAGS) -o $@ test/tests.c $(LIBS)
 
+# This simply runs the test suite.
 .PHONY: test
 test: tests
+	@echo "[+] executing tests"
 	@./tests
 
 ###############################################################################
@@ -140,11 +166,13 @@ test: tests
 ###############################################################################
 
 tests_cov: CFLAGS += -O0 -fprofile-instr-generate -fcoverage-mapping
-tests_cov: $(SOURCE_FILES) $(HEADER_FILES) $(BLST_LIBRARY)
+tests_cov: blst $(SOURCE_FILES) $(HEADER_FILES)
+	@echo "[+] building tests with coverage"
 	@$(CC) $(CFLAGS) -o $@ test/tests.c $(LIBS)
 
 .PHONY: coverage
 coverage: tests_cov
+	@echo "[+] executing tests with coverage"
 	@LLVM_PROFILE_FILE="ckzg.profraw" ./$<
 	@$(XCRUN) llvm-profdata merge --sparse ckzg.profraw -o ckzg.profdata
 	@$(XCRUN) llvm-cov show --instr-profile=ckzg.profdata --format=html \
@@ -162,16 +190,18 @@ ifeq ($(PLATFORM),Darwin)
 tests_prof: CFLAGS += -L$(shell brew --prefix gperftools)/lib
 tests_prof: CFLAGS += -I$(shell brew --prefix gperftools)/include
 endif
-tests_prof: $(SOURCE_FILES) $(HEADER_FILES) $(BLST_LIBRARY)
+tests_prof: blst $(SOURCE_FILES) $(HEADER_FILES)
+	@echo "[+] building tests with profiler"
 	@$(CC) $(CFLAGS) -o $@ test/tests.c $(LIBS)
 
 .PHONY: run_profiler
 run_profiler: tests_prof
+	@echo "[+] executing tests with profiler"
 	@CPUPROFILE_FREQUENCY=1000000000 ./$<
 
 .PHONY: profile_%
 profile_%: run_profiler
-	@echo Profiling $*...
+	@echo "[+] generating profiling graph for $*"
 	@pprof --pdf --nodefraction=0.00001 --edgefraction=0.00001 \
 	    ./tests_prof $*.prof > $*.pdf
 
@@ -193,9 +223,10 @@ profile: \
 
 .PHONY: sanitize_%
 sanitize_%: CFLAGS += -O0 -fsanitize=$*
-sanitize_%: $(SOURCE_FILES) $(HEADER_FILES) $(BLST_LIBRARY)
-	@echo Running sanitize=$*...
+sanitize_%: blst $(SOURCE_FILES) $(HEADER_FILES)
+	@echo "[+] building tests with $* sanitizer"
 	@$(CC) $(CFLAGS) -o $@ test/tests.c $(LIBS)
+	@echo "[+] executing tests with $* sanitizer"
 	@ASAN_OPTIONS=allocator_may_return_null=1 \
 	    LSAN_OPTIONS=allocator_may_return_null=1 \
 	    ./$@; rm $@
@@ -218,10 +249,10 @@ endif
 ###############################################################################
 
 .PHONY: analyze
-analyze: $(SOURCE_FILES)
+analyze: blst $(SOURCE_FILES)
 	@rm -rf analysis-report
-	@for src in $^; do \
-		echo "Analyzing $$src..."; \
+	@for src in $(SOURCE_FILES); do \
+		echo "[+] analyzing $$src..."; \
 		$(CC) --analyze -Xanalyzer -analyzer-output=html -o analysis-report $(CFLAGS) -c $$src; \
 		[ -d analysis-report ] && exit 1; true; \
 	done
@@ -232,10 +263,12 @@ analyze: $(SOURCE_FILES)
 
 .PHONY: format
 format:
+	@echo "[+] executing formatter"
 	@clang-format -i --sort-includes $(SOURCE_FILES) $(HEADER_FILES)
 
 .PHONY: clean
 clean:
+	@echo "[+] cleaning"
 	@rm -f *.o */*.o *.profraw *.profdata *.html xray-log.* *.prof *.pdf \
-	    tests tests_cov tests_prof
+	    tests tests_cov tests_prof .blst_hash
 	@rm -rf analysis-report

--- a/src/Makefile
+++ b/src/Makefile
@@ -93,7 +93,7 @@ endif
 
 # Settings for blst.
 BLST_DIR = ../blst
-BLST_HASH := $(shell git -C $(BLST_DIR) rev-parse HEAD)
+BLST_HASH = $(shell git -C $(BLST_DIR) rev-parse HEAD)
 BLST_HASH_FILE = .blst_hash
 BLST_LIBRARY = ../lib/libblst.a
 BLST_BUILDSCRIPT = ../blst/build.sh
@@ -105,7 +105,6 @@ LIBS = $(BLST_LIBRARY)
 # Create file lists.
 SOURCE_FILES := $(shell find . -name '*.c' | sed 's|^\./||' | sort)
 HEADER_FILES := $(shell find . -name '*.h' | sed 's|^\./||' | sort)
-OBJECT_FILES := $(patsubst %.c, %.o, $(SOURCE_FILES))
 
 # There is no tests header file.
 HEADER_FILES := $(filter-out test/tests.h, $(HEADER_FILES))

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -2069,7 +2069,7 @@ static void profile_verify_blob_kzg_proof(void) {
 }
 
 static void profile_verify_blob_kzg_proof_batch(void) {
-    const int n = 16;
+    const int n = 4;
     Blob blobs[n];
     Bytes48 commitments[n];
     Bytes48 proofs[n];


### PR DESCRIPTION
This makes a few notable improvements to the build system:

* If the blst submodule has been updated, it will re-build & copy files.
* Do not build object files individually. The build prints won't show now.
  * I kind of liked this though, because it ensured imports were correct.
* Add prints for each rule, so the developer knows what's going on.
* Also, fix build for profiler (it was using too much stack).
* Also, build blst in the Java bindings. If the library didn't exist, it would error.