### PR TITLE
Rename Kzg to KZG in bindings

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -59,7 +59,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
-        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/${{ matrix.target.location }}/native
 
   test-ckzg-dotnet:
     name: Test .NET wrapper
@@ -85,9 +85,9 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
-        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/${{ matrix.target.location }}/native
     - name: Test
-      run: dotnet test -c release bindings/csharp/Ckzg.sln
+      run: dotnet test -c release bindings/csharp/CKZG.sln
 
   build-ckzg-dotnet:
     name: Build .NET wrapper
@@ -98,23 +98,23 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-linux-x64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/linux-x64/native
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-osx-x64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/osx-x64/native
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-win-x64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/win-x64/native
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-osx-arm64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/osx-arm64/native
     - uses: actions/download-artifact@v3
       with:
         name: ckzg-library-wrapper-linux-arm64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
+        path: bindings/csharp/CKZG.Bindings/runtimes/linux-arm64/native
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
     - name: Install dependencies
@@ -124,8 +124,8 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
-        path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
+        name: CKZG.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
+        path: bindings/csharp/nupkgs/CKZG.Bindings.*.nupkg
     - name: Publish .NET package
       if: github.ref == 'refs/heads/main'
       run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg -k ${{ secrets.CSHARP_NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json

--- a/bindings/csharp/.gitignore
+++ b/bindings/csharp/.gitignore
@@ -5,7 +5,7 @@
 .vscode
 *.DotSettings.user
 
-Ckzg.Bindings/runtimes/*/native/*
+CKZG.Bindings/runtimes/*/native/*
 !**/.gitkeep
 test_ckzg*
 *.so

--- a/bindings/csharp/CKZG.Bindings/CKZG.Bindings.cs
+++ b/bindings/csharp/CKZG.Bindings/CKZG.Bindings.cs
@@ -2,11 +2,11 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
-namespace Ckzg;
+namespace CKZG;
 
-public static partial class Ckzg
+public static partial class CKZG
 {
-    static Ckzg() => AssemblyLoadContext.Default.ResolvingUnmanagedDll += LoadNativeLibrary;
+    static CKZG() => AssemblyLoadContext.Default.ResolvingUnmanagedDll += LoadNativeLibrary;
 
     private static IntPtr LoadNativeLibrary(Assembly _, string path)
     {
@@ -40,38 +40,38 @@ public static partial class Ckzg
     private static extern void InternalFreeTrustedSetup(IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "blob_to_kzg_commitment", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult BlobToKZGCommitment(byte* commitment, byte* blob, IntPtr ts);
+    private static extern unsafe KZGResult BlobToKZGCommitment(byte* commitment, byte* blob, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeKZGProof(byte* proof_out, byte* y_out, byte* blob, byte* z, IntPtr ts);
+    private static extern unsafe KZGResult ComputeKZGProof(byte* proof_out, byte* y_out, byte* blob, byte* z, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeBlobKZGProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
+    private static extern unsafe KZGResult ComputeBlobKZGProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyKZGProof(out bool result, byte* commitment, byte* z,
+    private static extern unsafe KZGResult VerifyKZGProof(out bool result, byte* commitment, byte* z,
         byte* y, byte* proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyBlobKZGProof(out bool result, byte* blob, byte* commitment,
+    private static extern unsafe KZGResult VerifyBlobKZGProof(out bool result, byte* blob, byte* commitment,
         byte* proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyBlobKZGProofBatch(out bool result, byte* blobs, byte* commitments,
+    private static extern unsafe KZGResult VerifyBlobKZGProofBatch(out bool result, byte* blobs, byte* commitments,
         byte* proofs, ulong count, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_cells_and_kzg_proofs", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeCellsAndKZGProofs(byte* cells, byte* proofs, byte* blob, IntPtr ts);
+    private static extern unsafe KZGResult ComputeCellsAndKZGProofs(byte* cells, byte* proofs, byte* blob, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "recover_cells_and_kzg_proofs", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult RecoverCellsAndKZGProofs(byte* recovered_cells, byte* recovered_proofs,
+    private static extern unsafe KZGResult RecoverCellsAndKZGProofs(byte* recovered_cells, byte* recovered_proofs,
         ulong* cell_indices, byte* cells, ulong num_cells, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_cell_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyCellKZGProofBatch(out bool result, byte* commitments,
+    private static extern unsafe KZGResult VerifyCellKZGProofBatch(out bool result, byte* commitments,
         ulong* cell_indices, byte* cells, byte* proofs, ulong num_cells, IntPtr ts);
 
-    private enum KzgResult
+    private enum KZGResult
     {
         // Success!
         Ok,

--- a/bindings/csharp/CKZG.Bindings/CKZG.Bindings.csproj
+++ b/bindings/csharp/CKZG.Bindings/CKZG.Bindings.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
-		<RootNamespace>Ckzg</RootNamespace>
+		<RootNamespace>CKZG</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
@@ -16,7 +16,7 @@
 		<Description>The C# bindings for the Polynomial Commitments API library for EIP-4844 and EIP-7594</Description>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
-		<PackageId>Ckzg.Bindings</PackageId>
+		<PackageId>CKZG.Bindings</PackageId>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>c-kzg eip-4844 eip-7594</PackageTags>

--- a/bindings/csharp/CKZG.Bindings/CKZG.cs
+++ b/bindings/csharp/CKZG.Bindings/CKZG.cs
@@ -1,6 +1,6 @@
-namespace Ckzg;
+namespace CKZG;
 
-public static partial class Ckzg
+public static partial class CKZG
 {
     public const int BytesPerBlob = FieldElementsPerBlob * BytesPerFieldElement;
     public const int BytesPerCell = FieldElementsPerCell * BytesPerFieldElement;
@@ -57,7 +57,7 @@ public static partial class Ckzg
 
         fixed (byte* commitmentPtr = commitment, blobPtr = blob)
         {
-            KzgResult result = BlobToKZGCommitment(commitmentPtr, blobPtr, ckzgSetup);
+            KZGResult result = BlobToKZGCommitment(commitmentPtr, blobPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -84,7 +84,7 @@ public static partial class Ckzg
 
         fixed (byte* proofPtr = proof, yPtr = y, blobPtr = blob, zPtr = z)
         {
-            KzgResult result = ComputeKZGProof(proofPtr, yPtr, blobPtr, zPtr, ckzgSetup);
+            KZGResult result = ComputeKZGProof(proofPtr, yPtr, blobPtr, zPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -109,7 +109,7 @@ public static partial class Ckzg
 
         fixed (byte* proofPtr = proof, blobPtr = blob, commitmentPtr = commitment)
         {
-            KzgResult result = ComputeBlobKZGProof(proofPtr, blobPtr, commitmentPtr, ckzgSetup);
+            KZGResult result = ComputeBlobKZGProof(proofPtr, blobPtr, commitmentPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -138,7 +138,7 @@ public static partial class Ckzg
 
         fixed (byte* commitmentPtr = commitment, zPtr = z, yPtr = y, proofPtr = proof)
         {
-            KzgResult kzgResult = VerifyKZGProof(out var result, commitmentPtr, zPtr, yPtr, proofPtr, ckzgSetup);
+            KZGResult kzgResult = VerifyKZGProof(out var result, commitmentPtr, zPtr, yPtr, proofPtr, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
         }
@@ -165,7 +165,7 @@ public static partial class Ckzg
 
         fixed (byte* blobPtr = blob, commitmentPtr = commitment, proofPtr = proof)
         {
-            KzgResult kzgResult = VerifyBlobKZGProof(out var result, blobPtr, commitmentPtr, proofPtr, ckzgSetup);
+            KZGResult kzgResult = VerifyBlobKZGProof(out var result, blobPtr, commitmentPtr, proofPtr, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
         }
@@ -193,7 +193,7 @@ public static partial class Ckzg
 
         fixed (byte* blobsPtr = blobs, commitmentsPtr = commitments, proofsPtr = proofs)
         {
-            KzgResult kzgResult =
+            KZGResult kzgResult =
                 VerifyBlobKZGProofBatch(out var result, blobsPtr, commitmentsPtr, proofsPtr, (ulong)count, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
@@ -220,7 +220,7 @@ public static partial class Ckzg
 
         fixed (byte* cellsPtr = cells, proofsPtr = proofs, blobPtr = blob)
         {
-            KzgResult result = ComputeCellsAndKZGProofs(cellsPtr, proofsPtr, blobPtr, ckzgSetup);
+            KZGResult result = ComputeCellsAndKZGProofs(cellsPtr, proofsPtr, blobPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -250,7 +250,7 @@ public static partial class Ckzg
         {
             fixed(ulong* cellIndicesPtr = cellIndices)
             {
-                KzgResult result = RecoverCellsAndKZGProofs(recoveredCellsPtr, recoveredProofsPtr, cellIndicesPtr,
+                KZGResult result = RecoverCellsAndKZGProofs(recoveredCellsPtr, recoveredProofsPtr, cellIndicesPtr,
                     cellsPtr, (ulong)numCells, ckzgSetup);
                 ThrowOnError(result);
             }
@@ -283,7 +283,7 @@ public static partial class Ckzg
         {
             fixed (ulong* cellIndicesPtr = cellIndices)
             {
-                KzgResult kzgResult = VerifyCellKZGProofBatch(out var result, commitmentsPtr,
+                KZGResult kzgResult = VerifyCellKZGProofBatch(out var result, commitmentsPtr,
                     cellIndicesPtr, cellsPtr, proofsPtr, (ulong)numCells, ckzgSetup);
                 ThrowOnError(kzgResult);
                 return result;
@@ -292,13 +292,13 @@ public static partial class Ckzg
     }
 
     #region Argument verification helpers
-    private static void ThrowOnError(KzgResult result)
+    private static void ThrowOnError(KZGResult result)
     {
         switch (result)
         {
-            case KzgResult.BadArgs: throw new ArgumentException();
-            case KzgResult.Malloc: throw new InsufficientMemoryException();
-            case KzgResult.Ok:
+            case KZGResult.BadArgs: throw new ArgumentException();
+            case KZGResult.Malloc: throw new InsufficientMemoryException();
+            case KZGResult.Ok:
                 return;
             default:
                 throw new ApplicationException("KZG returned unexpected result");

--- a/bindings/csharp/CKZG.Test/CKZG.Test.csproj
+++ b/bindings/csharp/CKZG.Test/CKZG.Test.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Ckzg.Bindings\Ckzg.Bindings.csproj" />
+        <ProjectReference Include="..\CKZG.Bindings\CKZG.Bindings.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/bindings/csharp/CKZG.Test/ReferenceTests.cs
+++ b/bindings/csharp/CKZG.Test/ReferenceTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace Ckzg.Test;
+namespace CKZG.Test;
 
 [TestFixture]
 public class ReferenceTests
@@ -15,13 +15,13 @@ public class ReferenceTests
     [OneTimeSetUp]
     public void Setup()
     {
-        _ts = Ckzg.LoadTrustedSetup("trusted_setup.txt", 0);
+        _ts = CKZG.LoadTrustedSetup("trusted_setup.txt", 0);
     }
 
     [OneTimeTearDown]
     public void Teardown()
     {
-        Ckzg.FreeTrustedSetup(_ts);
+        CKZG.FreeTrustedSetup(_ts);
     }
 
     [TestCase]
@@ -99,7 +99,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.BlobToKZGCommitment(commitment, blob, _ts);
+                CKZG.BlobToKZGCommitment(commitment, blob, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedCommitment = GetBytes(test.Output);
                 Assert.That(commitment, Is.EqualTo(expectedCommitment));
@@ -149,7 +149,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.ComputeKZGProof(proof, y, blob, z, _ts);
+                CKZG.ComputeKZGProof(proof, y, blob, z, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(test.Output.ElementAt(0));
                 Assert.That(proof, Is.EqualTo(expectedProof));
@@ -200,7 +200,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.ComputeBlobKZGProof(proof, blob, commitment, _ts);
+                CKZG.ComputeBlobKZGProof(proof, blob, commitment, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(test.Output);
                 Assert.That(proof, Is.EqualTo(expectedProof));
@@ -252,7 +252,7 @@ public class ReferenceTests
 
             try
             {
-                bool isCorrect = Ckzg.VerifyKZGProof(commitment, z, y, proof, _ts);
+                bool isCorrect = CKZG.VerifyKZGProof(commitment, z, y, proof, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -299,7 +299,7 @@ public class ReferenceTests
             byte[] proof = GetBytes(test.Input.Proof);
             try
             {
-                bool isCorrect = Ckzg.VerifyBlobKZGProof(blob, commitment, proof, _ts);
+                bool isCorrect = CKZG.VerifyBlobKZGProof(blob, commitment, proof, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -344,11 +344,11 @@ public class ReferenceTests
             byte[] blobs = GetFlatBytes(test.Input.Blobs);
             byte[] commitments = GetFlatBytes(test.Input.Commitments);
             byte[] proofs = GetFlatBytes(test.Input.Proofs);
-            int count = blobs.Length / Ckzg.BytesPerBlob;
+            int count = blobs.Length / CKZG.BytesPerBlob;
 
             try
             {
-                bool isCorrect = Ckzg.VerifyBlobKZGProofBatch(blobs, commitments, proofs, count, _ts);
+                bool isCorrect = CKZG.VerifyBlobKZGProofBatch(blobs, commitments, proofs, count, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -391,13 +391,13 @@ public class ReferenceTests
     [Test, TestCaseSource(nameof(GetComputeCellsAndKZGProofsTests))]
     public void TestComputeCellsAndKZGProofs(ComputeCellsAndKZGProofsTest test)
     {
-        byte[] cells = new byte[CellsPerExtBlob * Ckzg.BytesPerCell];
-        byte[] proofs = new byte[CellsPerExtBlob * Ckzg.BytesPerProof];
+        byte[] cells = new byte[CellsPerExtBlob * CKZG.BytesPerCell];
+        byte[] proofs = new byte[CellsPerExtBlob * CKZG.BytesPerProof];
         byte[] blob = GetBytes(test.Input.Blob);
 
         try
         {
-            Ckzg.ComputeCellsAndKZGProofs(cells, proofs, blob, _ts);
+            CKZG.ComputeCellsAndKZGProofs(cells, proofs, blob, _ts);
             Assert.That(test.Output, Is.Not.EqualTo(null));
             byte[] expectedCells = GetFlatBytes(test.Output.ElementAt(0));
             Assert.That(cells, Is.EqualTo(expectedCells));
@@ -443,15 +443,15 @@ public class ReferenceTests
     [Test, TestCaseSource(nameof(GetRecoverCellsAndKZGProofsTests))]
     public void TestRecoverCellsAndKZGProofs(RecoverCellsAndKZGProofsTest test)
     {
-        byte[] recoveredCells = new byte[CellsPerExtBlob * Ckzg.BytesPerCell];
-        byte[] recoveredProofs = new byte[CellsPerExtBlob * Ckzg.BytesPerProof];
+        byte[] recoveredCells = new byte[CellsPerExtBlob * CKZG.BytesPerCell];
+        byte[] recoveredProofs = new byte[CellsPerExtBlob * CKZG.BytesPerProof];
         ulong[] cellIndices = test.Input.CellIndices.ToArray();
         byte[] cells = GetFlatBytes(test.Input.Cells);
-        int numCells = cells.Length / Ckzg.BytesPerCell;
+        int numCells = cells.Length / CKZG.BytesPerCell;
 
         try
         {
-            Ckzg.RecoverCellsAndKZGProofs(recoveredCells, recoveredProofs, cellIndices, cells, numCells, _ts);
+            CKZG.RecoverCellsAndKZGProofs(recoveredCells, recoveredProofs, cellIndices, cells, numCells, _ts);
             Assert.That(test.Output, Is.Not.EqualTo(null));
             byte[] expectedCells = GetFlatBytes(test.Output.ElementAt(0));
             Assert.That(recoveredCells, Is.EqualTo(expectedCells));
@@ -503,11 +503,11 @@ public class ReferenceTests
         ulong[] cellIndices = test.Input.CellIndices.ToArray();
         byte[] cells = GetFlatBytes(test.Input.Cells);
         byte[] proofs = GetFlatBytes(test.Input.Proofs);
-        int numCells = cells.Length / Ckzg.BytesPerCell;
+        int numCells = cells.Length / CKZG.BytesPerCell;
 
         try
         {
-            bool isCorrect = Ckzg.VerifyCellKZGProofBatch(commitments, cellIndices, cells, proofs, numCells, _ts);
+            bool isCorrect = CKZG.VerifyCellKZGProofBatch(commitments, cellIndices, cells, proofs, numCells, _ts);
             Assert.That(isCorrect, Is.EqualTo(test.Output));
         }
         catch

--- a/bindings/csharp/CKZG.sln
+++ b/bindings/csharp/CKZG.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ckzg.Bindings", "Ckzg.Bindings\Ckzg.Bindings.csproj", "{4BE5C759-C998-47AB-A7F3-FA5E115A06DD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CKZG.Bindings", "CKZG.Bindings\CKZG.Bindings.csproj", "{4BE5C759-C998-47AB-A7F3-FA5E115A06DD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ckzg.Test", "Ckzg.Test\Ckzg.Test.csproj", "{B7A7291F-3DBC-4D9C-A5F1-B036C2EAA41C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CKZG.Test", "CKZG.Test\CKZG.Test.csproj", "{B7A7291F-3DBC-4D9C-A5F1-B036C2EAA41C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
@@ -40,35 +40,35 @@ public static partial class Ckzg
     private static extern void InternalFreeTrustedSetup(IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "blob_to_kzg_commitment", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult BlobToKzgCommitment(byte* commitment, byte* blob, IntPtr ts);
+    private static extern unsafe KzgResult BlobToKZGCommitment(byte* commitment, byte* blob, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeKzgProof(byte* proof_out, byte* y_out, byte* blob, byte* z, IntPtr ts);
+    private static extern unsafe KzgResult ComputeKZGProof(byte* proof_out, byte* y_out, byte* blob, byte* z, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeBlobKzgProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
+    private static extern unsafe KzgResult ComputeBlobKZGProof(byte* proof, byte* blob, byte* commitment, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyKzgProof(out bool result, byte* commitment, byte* z,
+    private static extern unsafe KzgResult VerifyKZGProof(out bool result, byte* commitment, byte* z,
         byte* y, byte* proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyBlobKzgProof(out bool result, byte* blob, byte* commitment,
+    private static extern unsafe KzgResult VerifyBlobKZGProof(out bool result, byte* blob, byte* commitment,
         byte* proof, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_blob_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyBlobKzgProofBatch(out bool result, byte* blobs, byte* commitments,
+    private static extern unsafe KzgResult VerifyBlobKZGProofBatch(out bool result, byte* blobs, byte* commitments,
         byte* proofs, ulong count, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "compute_cells_and_kzg_proofs", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult ComputeCellsAndKzgProofs(byte* cells, byte* proofs, byte* blob, IntPtr ts);
+    private static extern unsafe KzgResult ComputeCellsAndKZGProofs(byte* cells, byte* proofs, byte* blob, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "recover_cells_and_kzg_proofs", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult RecoverCellsAndKzgProofs(byte* recovered_cells, byte* recovered_proofs,
+    private static extern unsafe KzgResult RecoverCellsAndKZGProofs(byte* recovered_cells, byte* recovered_proofs,
         ulong* cell_indices, byte* cells, ulong num_cells, IntPtr ts);
 
     [DllImport("ckzg", EntryPoint = "verify_cell_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl)]
-    private static extern unsafe KzgResult VerifyCellKzgProofBatch(out bool result, byte* commitments,
+    private static extern unsafe KzgResult VerifyCellKZGProofBatch(out bool result, byte* commitments,
         ulong* cell_indices, byte* cells, byte* proofs, ulong num_cells, IntPtr ts);
 
     private enum KzgResult

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -49,7 +49,7 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void BlobToKzgCommitment(Span<byte> commitment, ReadOnlySpan<byte> blob, IntPtr ckzgSetup)
+    public static unsafe void BlobToKZGCommitment(Span<byte> commitment, ReadOnlySpan<byte> blob, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
         ThrowOnInvalidLength(commitment, nameof(commitment), BytesPerCommitment);
@@ -57,7 +57,7 @@ public static partial class Ckzg
 
         fixed (byte* commitmentPtr = commitment, blobPtr = blob)
         {
-            KzgResult result = BlobToKzgCommitment(commitmentPtr, blobPtr, ckzgSetup);
+            KzgResult result = BlobToKZGCommitment(commitmentPtr, blobPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -73,7 +73,7 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void ComputeKzgProof(Span<byte> proof, Span<byte> y, ReadOnlySpan<byte> blob,
+    public static unsafe void ComputeKZGProof(Span<byte> proof, Span<byte> y, ReadOnlySpan<byte> blob,
         ReadOnlySpan<byte> z, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -84,7 +84,7 @@ public static partial class Ckzg
 
         fixed (byte* proofPtr = proof, yPtr = y, blobPtr = blob, zPtr = z)
         {
-            KzgResult result = ComputeKzgProof(proofPtr, yPtr, blobPtr, zPtr, ckzgSetup);
+            KzgResult result = ComputeKZGProof(proofPtr, yPtr, blobPtr, zPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -99,7 +99,7 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void ComputeBlobKzgProof(Span<byte> proof, ReadOnlySpan<byte> blob,
+    public static unsafe void ComputeBlobKZGProof(Span<byte> proof, ReadOnlySpan<byte> blob,
         ReadOnlySpan<byte> commitment, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -109,7 +109,7 @@ public static partial class Ckzg
 
         fixed (byte* proofPtr = proof, blobPtr = blob, commitmentPtr = commitment)
         {
-            KzgResult result = ComputeBlobKzgProof(proofPtr, blobPtr, commitmentPtr, ckzgSetup);
+            KzgResult result = ComputeBlobKZGProof(proofPtr, blobPtr, commitmentPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -126,7 +126,7 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
-    public static unsafe bool VerifyKzgProof(ReadOnlySpan<byte> commitment, ReadOnlySpan<byte> z, ReadOnlySpan<byte> y,
+    public static unsafe bool VerifyKZGProof(ReadOnlySpan<byte> commitment, ReadOnlySpan<byte> z, ReadOnlySpan<byte> y,
         ReadOnlySpan<byte> proof, IntPtr ckzgSetup)
     {
 
@@ -138,7 +138,7 @@ public static partial class Ckzg
 
         fixed (byte* commitmentPtr = commitment, zPtr = z, yPtr = y, proofPtr = proof)
         {
-            KzgResult kzgResult = VerifyKzgProof(out var result, commitmentPtr, zPtr, yPtr, proofPtr, ckzgSetup);
+            KzgResult kzgResult = VerifyKZGProof(out var result, commitmentPtr, zPtr, yPtr, proofPtr, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
         }
@@ -155,7 +155,7 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
-    public static unsafe bool VerifyBlobKzgProof(ReadOnlySpan<byte> blob, ReadOnlySpan<byte> commitment,
+    public static unsafe bool VerifyBlobKZGProof(ReadOnlySpan<byte> blob, ReadOnlySpan<byte> commitment,
         ReadOnlySpan<byte> proof, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -165,7 +165,7 @@ public static partial class Ckzg
 
         fixed (byte* blobPtr = blob, commitmentPtr = commitment, proofPtr = proof)
         {
-            KzgResult kzgResult = VerifyBlobKzgProof(out var result, blobPtr, commitmentPtr, proofPtr, ckzgSetup);
+            KzgResult kzgResult = VerifyBlobKZGProof(out var result, blobPtr, commitmentPtr, proofPtr, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
         }
@@ -183,7 +183,7 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
-    public static unsafe bool VerifyBlobKzgProofBatch(ReadOnlySpan<byte> blobs, ReadOnlySpan<byte> commitments,
+    public static unsafe bool VerifyBlobKZGProofBatch(ReadOnlySpan<byte> blobs, ReadOnlySpan<byte> commitments,
         ReadOnlySpan<byte> proofs, int count, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -194,7 +194,7 @@ public static partial class Ckzg
         fixed (byte* blobsPtr = blobs, commitmentsPtr = commitments, proofsPtr = proofs)
         {
             KzgResult kzgResult =
-                VerifyBlobKzgProofBatch(out var result, blobsPtr, commitmentsPtr, proofsPtr, (ulong)count, ckzgSetup);
+                VerifyBlobKZGProofBatch(out var result, blobsPtr, commitmentsPtr, proofsPtr, (ulong)count, ckzgSetup);
             ThrowOnError(kzgResult);
             return result;
         }
@@ -210,7 +210,7 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void ComputeCellsAndKzgProofs(Span<byte> cells, Span<byte> proofs, ReadOnlySpan<byte> blob,
+    public static unsafe void ComputeCellsAndKZGProofs(Span<byte> cells, Span<byte> proofs, ReadOnlySpan<byte> blob,
             IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -220,7 +220,7 @@ public static partial class Ckzg
 
         fixed (byte* cellsPtr = cells, proofsPtr = proofs, blobPtr = blob)
         {
-            KzgResult result = ComputeCellsAndKzgProofs(cellsPtr, proofsPtr, blobPtr, ckzgSetup);
+            KzgResult result = ComputeCellsAndKZGProofs(cellsPtr, proofsPtr, blobPtr, ckzgSetup);
             ThrowOnError(result);
         }
     }
@@ -237,7 +237,7 @@ public static partial class Ckzg
     /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
-    public static unsafe void RecoverCellsAndKzgProofs(Span<byte> recoveredCells, Span<byte> recoveredProofs,
+    public static unsafe void RecoverCellsAndKZGProofs(Span<byte> recoveredCells, Span<byte> recoveredProofs,
             ReadOnlySpan<ulong> cellIndices, ReadOnlySpan<byte> cells, int numCells, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -250,7 +250,7 @@ public static partial class Ckzg
         {
             fixed(ulong* cellIndicesPtr = cellIndices)
             {
-                KzgResult result = RecoverCellsAndKzgProofs(recoveredCellsPtr, recoveredProofsPtr, cellIndicesPtr,
+                KzgResult result = RecoverCellsAndKZGProofs(recoveredCellsPtr, recoveredProofsPtr, cellIndicesPtr,
                     cellsPtr, (ulong)numCells, ckzgSetup);
                 ThrowOnError(result);
             }
@@ -270,7 +270,7 @@ public static partial class Ckzg
     /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
     /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
     /// <returns>Verification result</returns>
-    public static unsafe bool VerifyCellKzgProofBatch(ReadOnlySpan<byte> commitments, ReadOnlySpan<ulong> cellIndices,
+    public static unsafe bool VerifyCellKZGProofBatch(ReadOnlySpan<byte> commitments, ReadOnlySpan<ulong> cellIndices,
             ReadOnlySpan<byte> cells, ReadOnlySpan<byte> proofs, int numCells, IntPtr ckzgSetup)
     {
         ThrowOnUninitializedTrustedSetup(ckzgSetup);
@@ -283,7 +283,7 @@ public static partial class Ckzg
         {
             fixed (ulong* cellIndicesPtr = cellIndices)
             {
-                KzgResult kzgResult = VerifyCellKzgProofBatch(out var result, commitmentsPtr,
+                KzgResult kzgResult = VerifyCellKZGProofBatch(out var result, commitmentsPtr,
                     cellIndicesPtr, cellsPtr, proofsPtr, (ulong)numCells, ckzgSetup);
                 ThrowOnError(kzgResult);
                 return result;

--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -32,15 +32,15 @@ public class ReferenceTests
 
     private IntPtr _ts;
     private const string TestDir = "../../../../../../tests";
-    private readonly string _blobToKzgCommitmentTests = Path.Join(TestDir, "blob_to_kzg_commitment");
-    private readonly string _computeKzgProofTests = Path.Join(TestDir, "compute_kzg_proof");
-    private readonly string _computeBlobKzgProofTests = Path.Join(TestDir, "compute_blob_kzg_proof");
-    private readonly string _verifyKzgProofTests = Path.Join(TestDir, "verify_kzg_proof");
-    private readonly string _verifyBlobKzgProofTests = Path.Join(TestDir, "verify_blob_kzg_proof");
-    private readonly string _verifyBlobKzgProofBatchTests = Path.Join(TestDir, "verify_blob_kzg_proof_batch");
-    private static readonly string _computeCellsAndKzgProofsTests = Path.Join(TestDir, "compute_cells_and_kzg_proofs");
-    private static readonly string _recoverCellsAndKzgProofsTests = Path.Join(TestDir, "recover_cells_and_kzg_proofs");
-    private static readonly string _verifyCellKzgProofBatchTests = Path.Join(TestDir, "verify_cell_kzg_proof_batch");
+    private readonly string _blobToKZGCommitmentTests = Path.Join(TestDir, "blob_to_kzg_commitment");
+    private readonly string _computeKZGProofTests = Path.Join(TestDir, "compute_kzg_proof");
+    private readonly string _computeBlobKZGProofTests = Path.Join(TestDir, "compute_blob_kzg_proof");
+    private readonly string _verifyKZGProofTests = Path.Join(TestDir, "verify_kzg_proof");
+    private readonly string _verifyBlobKZGProofTests = Path.Join(TestDir, "verify_blob_kzg_proof");
+    private readonly string _verifyBlobKZGProofBatchTests = Path.Join(TestDir, "verify_blob_kzg_proof_batch");
+    private static readonly string _computeCellsAndKZGProofsTests = Path.Join(TestDir, "compute_cells_and_kzg_proofs");
+    private static readonly string _recoverCellsAndKZGProofsTests = Path.Join(TestDir, "recover_cells_and_kzg_proofs");
+    private static readonly string _verifyCellKZGProofBatchTests = Path.Join(TestDir, "verify_cell_kzg_proof_batch");
 
     #region Helper Functions
 
@@ -66,32 +66,32 @@ public class ReferenceTests
 
     #endregion
 
-    #region BlobToKzgCommitment
+    #region BlobToKZGCommitment
 
-    private class BlobToKzgCommitmentInput
+    private class BlobToKZGCommitmentInput
     {
         public string Blob { get; set; } = null!;
     }
 
-    private class BlobToKzgCommitmentTest
+    private class BlobToKZGCommitmentTest
     {
-        public BlobToKzgCommitmentInput Input { get; set; } = null!;
+        public BlobToKZGCommitmentInput Input { get; set; } = null!;
         public string? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestBlobToKzgCommitment()
+    public void TestBlobToKZGCommitment()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_blobToKzgCommitmentTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_blobToKZGCommitmentTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            BlobToKzgCommitmentTest test = _deserializer.Deserialize<BlobToKzgCommitmentTest>(yaml);
+            BlobToKZGCommitmentTest test = _deserializer.Deserialize<BlobToKZGCommitmentTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] commitment = new byte[48];
@@ -99,7 +99,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.BlobToKzgCommitment(commitment, blob, _ts);
+                Ckzg.BlobToKZGCommitment(commitment, blob, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedCommitment = GetBytes(test.Output);
                 Assert.That(commitment, Is.EqualTo(expectedCommitment));
@@ -113,33 +113,33 @@ public class ReferenceTests
 
     #endregion
 
-    #region ComputeKzgProof
+    #region ComputeKZGProof
 
-    private class ComputeKzgProofInput
+    private class ComputeKZGProofInput
     {
         public string Blob { get; set; } = null!;
         public string Z { get; set; } = null!;
     }
 
-    private class ComputeKzgProofTest
+    private class ComputeKZGProofTest
     {
-        public ComputeKzgProofInput Input { get; set; } = null!;
+        public ComputeKZGProofInput Input { get; set; } = null!;
         public List<string>? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestComputeKzgProof()
+    public void TestComputeKZGProof()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeKzgProofTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeKZGProofTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            ComputeKzgProofTest test = _deserializer.Deserialize<ComputeKzgProofTest>(yaml);
+            ComputeKZGProofTest test = _deserializer.Deserialize<ComputeKZGProofTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] proof = new byte[48];
@@ -149,7 +149,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.ComputeKzgProof(proof, y, blob, z, _ts);
+                Ckzg.ComputeKZGProof(proof, y, blob, z, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(test.Output.ElementAt(0));
                 Assert.That(proof, Is.EqualTo(expectedProof));
@@ -165,33 +165,33 @@ public class ReferenceTests
 
     #endregion
 
-    #region ComputeBlobKzgProof
+    #region ComputeBlobKZGProof
 
-    private class ComputeBlobKzgProofInput
+    private class ComputeBlobKZGProofInput
     {
         public string Blob { get; set; } = null!;
         public string Commitment { get; set; } = null!;
     }
 
-    private class ComputeBlobKzgProofTest
+    private class ComputeBlobKZGProofTest
     {
-        public ComputeBlobKzgProofInput Input { get; set; } = null!;
+        public ComputeBlobKZGProofInput Input { get; set; } = null!;
         public string? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestComputeBlobKzgProof()
+    public void TestComputeBlobKZGProof()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeBlobKzgProofTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeBlobKZGProofTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            ComputeBlobKzgProofTest test = _deserializer.Deserialize<ComputeBlobKzgProofTest>(yaml);
+            ComputeBlobKZGProofTest test = _deserializer.Deserialize<ComputeBlobKZGProofTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] proof = new byte[48];
@@ -200,7 +200,7 @@ public class ReferenceTests
 
             try
             {
-                Ckzg.ComputeBlobKzgProof(proof, blob, commitment, _ts);
+                Ckzg.ComputeBlobKZGProof(proof, blob, commitment, _ts);
                 Assert.That(test.Output, Is.Not.EqualTo(null));
                 byte[] expectedProof = GetBytes(test.Output);
                 Assert.That(proof, Is.EqualTo(expectedProof));
@@ -214,9 +214,9 @@ public class ReferenceTests
 
     #endregion
 
-    #region VerifyKzgProof
+    #region VerifyKZGProof
 
-    private class VerifyKzgProofInput
+    private class VerifyKZGProofInput
     {
         public string Commitment { get; set; } = null!;
         public string Z { get; set; } = null!;
@@ -224,25 +224,25 @@ public class ReferenceTests
         public string Proof { get; set; } = null!;
     }
 
-    private class VerifyKzgProofTest
+    private class VerifyKZGProofTest
     {
-        public VerifyKzgProofInput Input { get; set; } = null!;
+        public VerifyKZGProofInput Input { get; set; } = null!;
         public bool? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestVerifyKzgProof()
+    public void TestVerifyKZGProof()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyKzgProofTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyKZGProofTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            VerifyKzgProofTest test = _deserializer.Deserialize<VerifyKzgProofTest>(yaml);
+            VerifyKZGProofTest test = _deserializer.Deserialize<VerifyKZGProofTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] commitment = GetBytes(test.Input.Commitment);
@@ -252,7 +252,7 @@ public class ReferenceTests
 
             try
             {
-                bool isCorrect = Ckzg.VerifyKzgProof(commitment, z, y, proof, _ts);
+                bool isCorrect = Ckzg.VerifyKZGProof(commitment, z, y, proof, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -264,34 +264,34 @@ public class ReferenceTests
 
     #endregion
 
-    #region VerifyBlobKzgProof
+    #region VerifyBlobKZGProof
 
-    private class VerifyBlobKzgProofInput
+    private class VerifyBlobKZGProofInput
     {
         public string Blob { get; set; } = null!;
         public string Commitment { get; set; } = null!;
         public string Proof { get; set; } = null!;
     }
 
-    private class VerifyBlobKzgProofTest
+    private class VerifyBlobKZGProofTest
     {
-        public VerifyBlobKzgProofInput Input { get; set; } = null!;
+        public VerifyBlobKZGProofInput Input { get; set; } = null!;
         public bool? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestVerifyBlobKzgProof()
+    public void TestVerifyBlobKZGProof()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKzgProofTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKZGProofTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            VerifyBlobKzgProofTest test = _deserializer.Deserialize<VerifyBlobKzgProofTest>(yaml);
+            VerifyBlobKZGProofTest test = _deserializer.Deserialize<VerifyBlobKZGProofTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] blob = GetBytes(test.Input.Blob);
@@ -299,7 +299,7 @@ public class ReferenceTests
             byte[] proof = GetBytes(test.Input.Proof);
             try
             {
-                bool isCorrect = Ckzg.VerifyBlobKzgProof(blob, commitment, proof, _ts);
+                bool isCorrect = Ckzg.VerifyBlobKZGProof(blob, commitment, proof, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -311,34 +311,34 @@ public class ReferenceTests
 
     #endregion
 
-    #region VerifyBlobKzgProofBatch
+    #region VerifyBlobKZGProofBatch
 
-    private class VerifyBlobKzgProofBatchInput
+    private class VerifyBlobKZGProofBatchInput
     {
         public List<string> Blobs { get; set; } = null!;
         public List<string> Commitments { get; set; } = null!;
         public List<string> Proofs { get; set; } = null!;
     }
 
-    private class VerifyBlobKzgProofBatchTest
+    private class VerifyBlobKZGProofBatchTest
     {
-        public VerifyBlobKzgProofBatchInput Input { get; set; } = null!;
+        public VerifyBlobKZGProofBatchInput Input { get; set; } = null!;
         public bool? Output { get; set; } = null!;
     }
 
     [TestCase]
-    public void TestVerifyBlobKzgProofBatch()
+    public void TestVerifyBlobKZGProofBatch()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
 
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKzgProofBatchTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyBlobKZGProofBatchTests);
         Assert.That(testFiles.Count(), Is.GreaterThan(0));
 
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            VerifyBlobKzgProofBatchTest test = _deserializer.Deserialize<VerifyBlobKzgProofBatchTest>(yaml);
+            VerifyBlobKZGProofBatchTest test = _deserializer.Deserialize<VerifyBlobKZGProofBatchTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
 
             byte[] blobs = GetFlatBytes(test.Input.Blobs);
@@ -348,7 +348,7 @@ public class ReferenceTests
 
             try
             {
-                bool isCorrect = Ckzg.VerifyBlobKzgProofBatch(blobs, commitments, proofs, count, _ts);
+                bool isCorrect = Ckzg.VerifyBlobKZGProofBatch(blobs, commitments, proofs, count, _ts);
                 Assert.That(isCorrect, Is.EqualTo(test.Output));
             }
             catch
@@ -360,36 +360,36 @@ public class ReferenceTests
 
     #endregion
 
-    #region ComputeCellsAndKzgProofs
+    #region ComputeCellsAndKZGProofs
 
-    public class ComputeCellsAndKzgProofsInput
+    public class ComputeCellsAndKZGProofsInput
     {
         public string Blob { get; set; } = null!;
     }
 
-    public class ComputeCellsAndKzgProofsTest
+    public class ComputeCellsAndKZGProofsTest
     {
-        public ComputeCellsAndKzgProofsInput Input { get; set; } = null!;
+        public ComputeCellsAndKZGProofsInput Input { get; set; } = null!;
         public List<List<string>>? Output { get; set; } = null!;
     }
 
-    private static IEnumerable<ComputeCellsAndKzgProofsTest> GetComputeCellsAndKzgProofsTests()
+    private static IEnumerable<ComputeCellsAndKZGProofsTest> GetComputeCellsAndKZGProofsTests()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeCellsAndKzgProofsTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_computeCellsAndKZGProofsTests);
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            ComputeCellsAndKzgProofsTest test = _deserializer.Deserialize<ComputeCellsAndKzgProofsTest>(yaml);
+            ComputeCellsAndKZGProofsTest test = _deserializer.Deserialize<ComputeCellsAndKZGProofsTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
             yield return test;
         }
     }
 
 
-    [Test, TestCaseSource(nameof(GetComputeCellsAndKzgProofsTests))]
-    public void TestComputeCellsAndKzgProofs(ComputeCellsAndKzgProofsTest test)
+    [Test, TestCaseSource(nameof(GetComputeCellsAndKZGProofsTests))]
+    public void TestComputeCellsAndKZGProofs(ComputeCellsAndKZGProofsTest test)
     {
         byte[] cells = new byte[CellsPerExtBlob * Ckzg.BytesPerCell];
         byte[] proofs = new byte[CellsPerExtBlob * Ckzg.BytesPerProof];
@@ -397,7 +397,7 @@ public class ReferenceTests
 
         try
         {
-            Ckzg.ComputeCellsAndKzgProofs(cells, proofs, blob, _ts);
+            Ckzg.ComputeCellsAndKZGProofs(cells, proofs, blob, _ts);
             Assert.That(test.Output, Is.Not.EqualTo(null));
             byte[] expectedCells = GetFlatBytes(test.Output.ElementAt(0));
             Assert.That(cells, Is.EqualTo(expectedCells));
@@ -412,36 +412,36 @@ public class ReferenceTests
 
     #endregion
 
-    #region RecoverCellsAndKzgProofs
+    #region RecoverCellsAndKZGProofs
 
-    public class RecoverCellsAndKzgProofsInput
+    public class RecoverCellsAndKZGProofsInput
     {
         public List<ulong> CellIndices { get; set; } = null!;
         public List<string> Cells { get; set; } = null!;
     }
 
-    public class RecoverCellsAndKzgProofsTest
+    public class RecoverCellsAndKZGProofsTest
     {
-        public RecoverCellsAndKzgProofsInput Input { get; set; } = null!;
+        public RecoverCellsAndKZGProofsInput Input { get; set; } = null!;
         public List<List<string>>? Output { get; set; } = null!;
     }
 
-    private static IEnumerable<RecoverCellsAndKzgProofsTest> GetRecoverCellsAndKzgProofsTests()
+    private static IEnumerable<RecoverCellsAndKZGProofsTest> GetRecoverCellsAndKZGProofsTests()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_recoverCellsAndKzgProofsTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_recoverCellsAndKZGProofsTests);
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            RecoverCellsAndKzgProofsTest test = _deserializer.Deserialize<RecoverCellsAndKzgProofsTest>(yaml);
+            RecoverCellsAndKZGProofsTest test = _deserializer.Deserialize<RecoverCellsAndKZGProofsTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
             yield return test;
         }
     }
 
-    [Test, TestCaseSource(nameof(GetRecoverCellsAndKzgProofsTests))]
-    public void TestRecoverCellsAndKzgProofs(RecoverCellsAndKzgProofsTest test)
+    [Test, TestCaseSource(nameof(GetRecoverCellsAndKZGProofsTests))]
+    public void TestRecoverCellsAndKZGProofs(RecoverCellsAndKZGProofsTest test)
     {
         byte[] recoveredCells = new byte[CellsPerExtBlob * Ckzg.BytesPerCell];
         byte[] recoveredProofs = new byte[CellsPerExtBlob * Ckzg.BytesPerProof];
@@ -451,7 +451,7 @@ public class ReferenceTests
 
         try
         {
-            Ckzg.RecoverCellsAndKzgProofs(recoveredCells, recoveredProofs, cellIndices, cells, numCells, _ts);
+            Ckzg.RecoverCellsAndKZGProofs(recoveredCells, recoveredProofs, cellIndices, cells, numCells, _ts);
             Assert.That(test.Output, Is.Not.EqualTo(null));
             byte[] expectedCells = GetFlatBytes(test.Output.ElementAt(0));
             Assert.That(recoveredCells, Is.EqualTo(expectedCells));
@@ -466,9 +466,9 @@ public class ReferenceTests
 
     #endregion
 
-    #region VerifyCellKzgProofBatch
+    #region VerifyCellKZGProofBatch
 
-    public class VerifyCellKzgProofBatchInput
+    public class VerifyCellKZGProofBatchInput
     {
         public List<string> Commitments { get; set; } = null!;
         public List<ulong> CellIndices { get; set; } = null!;
@@ -476,28 +476,28 @@ public class ReferenceTests
         public List<string> Proofs { get; set; } = null!;
     }
 
-    public class VerifyCellKzgProofBatchTest
+    public class VerifyCellKZGProofBatchTest
     {
-        public VerifyCellKzgProofBatchInput Input { get; set; } = null!;
+        public VerifyCellKZGProofBatchInput Input { get; set; } = null!;
         public bool? Output { get; set; } = null!;
     }
 
-    private static IEnumerable<VerifyCellKzgProofBatchTest> GetVerifyCellKzgProofBatchTests()
+    private static IEnumerable<VerifyCellKZGProofBatchTest> GetVerifyCellKZGProofBatchTests()
     {
         Matcher matcher = new();
         matcher.AddIncludePatterns(new[] { "*/*/data.yaml" });
-        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyCellKzgProofBatchTests);
+        IEnumerable<string> testFiles = matcher.GetResultsInFullPath(_verifyCellKZGProofBatchTests);
         foreach (string testFile in testFiles)
         {
             string yaml = File.ReadAllText(testFile);
-            VerifyCellKzgProofBatchTest test = _deserializer.Deserialize<VerifyCellKzgProofBatchTest>(yaml);
+            VerifyCellKZGProofBatchTest test = _deserializer.Deserialize<VerifyCellKZGProofBatchTest>(yaml);
             Assert.That(test, Is.Not.EqualTo(null));
             yield return test;
         }
     }
 
-    [Test, TestCaseSource(nameof(GetVerifyCellKzgProofBatchTests))]
-    public void TestVerifyCellKzgProofBatch(VerifyCellKzgProofBatchTest test)
+    [Test, TestCaseSource(nameof(GetVerifyCellKZGProofBatchTests))]
+    public void TestVerifyCellKZGProofBatch(VerifyCellKZGProofBatchTest test)
     {
         byte[] commitments = GetFlatBytes(test.Input.Commitments);
         ulong[] cellIndices = test.Input.CellIndices.ToArray();
@@ -507,7 +507,7 @@ public class ReferenceTests
 
         try
         {
-            bool isCorrect = Ckzg.VerifyCellKzgProofBatch(commitments, cellIndices, cells, proofs, numCells, _ts);
+            bool isCorrect = Ckzg.VerifyCellKZGProofBatch(commitments, cellIndices, cells, proofs, numCells, _ts);
             Assert.That(isCorrect, Is.EqualTo(test.Output));
         }
         catch

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Windows_NT)
 	LOCATION ?= win-x64
 	CLANG_EXECUTABLE = clang
 	EXTENSION ?= ".dll"
-	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg$(EXTENSION)
+	CKZG_LIBRARY_PATH = CKZG.Bindings\runtimes\$(LOCATION)\native\ckzg$(EXTENSION)
 	CFLAGS += -Wl,/def:ckzg_wrap.def
 else
 	BLST_BUILDSCRIPT = ./build.sh
@@ -35,7 +35,7 @@ else
 		endif
 	endif
 
-	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg$(EXTENSION)
+	CKZG_LIBRARY_PATH = CKZG.Bindings/runtimes/$(LOCATION)/native/ckzg$(EXTENSION)
 endif
 
 INCLUDE_DIRS = ../../src ../../blst/bindings

--- a/bindings/java/ckzg_jni.c
+++ b/bindings/java/ckzg_jni.c
@@ -146,7 +146,7 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_freeTrustedSetup(
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitment(JNIEnv *env,
+Java_ethereum_ckzg4844_CKZG4844JNI_blobToKZGCommitment(JNIEnv *env,
                                                        jclass thisCls,
                                                        jbyteArray blob) {
   if (settings == NULL) {
@@ -175,14 +175,14 @@ Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitment(JNIEnv *env,
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in blobToKzgCommitment.");
+                          "There was an error in blobToKZGCommitment.");
     return NULL;
   }
 
   return commitment;
 }
 
-JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(
+JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKZGProof(
     JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray z_bytes) {
   if (settings == NULL) {
     throw_exception(env, TRUSTED_SETUP_NOT_LOADED);
@@ -225,7 +225,7 @@ JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(
   (*env)->ReleaseByteArrayElements(env, z_bytes, (jbyte *)z_native, JNI_ABORT);
 
   if (ret != C_KZG_OK) {
-    throw_c_kzg_exception(env, ret, "There was an error in computeKzgProof.");
+    throw_c_kzg_exception(env, ret, "There was an error in computeKZGProof.");
     return NULL;
   }
 
@@ -254,7 +254,7 @@ JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof(
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgProof(
+Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKZGProof(
     JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray commitment_bytes) {
   if (settings == NULL) {
     throw_exception(env, TRUSTED_SETUP_NOT_LOADED);
@@ -294,14 +294,14 @@ Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgProof(
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in computeBlobKzgProof.");
+                          "There was an error in computeBlobKZGProof.");
     return NULL;
   }
 
   return proof;
 }
 
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKZGProof(
     JNIEnv *env, jclass thisCls, jbyteArray commitment_bytes,
     jbyteArray z_bytes, jbyteArray y_bytes, jbyteArray proof_bytes) {
   if (settings == NULL) {
@@ -359,7 +359,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(
                                    JNI_ABORT);
 
   if (ret != C_KZG_OK) {
-    throw_c_kzg_exception(env, ret, "There was an error in verifyKzgProof.");
+    throw_c_kzg_exception(env, ret, "There was an error in verifyKZGProof.");
     return 0;
   }
 
@@ -367,7 +367,7 @@ JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof(
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProof(
+Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKZGProof(
     JNIEnv *env, jclass thisCls, jbyteArray blob, jbyteArray commitment_bytes,
     jbyteArray proof_bytes) {
   if (settings == NULL) {
@@ -415,7 +415,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProof(
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in verifyBlobKzgProof.");
+                          "There was an error in verifyBlobKZGProof.");
     return 0;
   }
 
@@ -423,7 +423,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProof(
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProofBatch(
+Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKZGProofBatch(
     JNIEnv *env, jclass thisCls, jbyteArray blobs, jbyteArray commitments_bytes,
     jbyteArray proofs_bytes, jlong count) {
   if (settings == NULL) {
@@ -475,7 +475,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProofBatch(
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in verifyBlobKzgProofBatch.");
+                          "There was an error in verifyBlobKZGProofBatch.");
     return 0;
   }
 
@@ -483,7 +483,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProofBatch(
 }
 
 JNIEXPORT jobject JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgProofs(JNIEnv *env,
+Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKZGProofs(JNIEnv *env,
                                                             jclass thisCls,
                                                             jbyteArray blob) {
   if (settings == NULL) {
@@ -519,7 +519,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgProofs(JNIEnv *env,
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in computeCellsAndKzgProofs.");
+                          "There was an error in computeCellsAndKZGProofs.");
     return NULL;
   }
 
@@ -551,7 +551,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgProofs(JNIEnv *env,
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKzgProofs(
+Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKZGProofs(
     JNIEnv *env, jclass thisCls, jlongArray cell_indices, jbyteArray cells) {
   if (settings == NULL) {
     throw_exception(env, TRUSTED_SETUP_NOT_LOADED);
@@ -593,7 +593,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKzgProofs(
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in recoverCellsAndKzgProofs.");
+                          "There was an error in recoverCellsAndKZGProofs.");
     return NULL;
   }
 
@@ -625,7 +625,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKzgProofs(
 }
 
 JNIEXPORT jboolean JNICALL
-Java_ethereum_ckzg4844_CKZG4844JNI_verifyCellKzgProofBatch(
+Java_ethereum_ckzg4844_CKZG4844JNI_verifyCellKZGProofBatch(
     JNIEnv *env, jclass thisCls, jbyteArray commitments_bytes,
     jlongArray cell_indices, jbyteArray cells, jbyteArray proofs_bytes) {
   if (settings == NULL) {
@@ -689,7 +689,7 @@ Java_ethereum_ckzg4844_CKZG4844JNI_verifyCellKzgProofBatch(
 
   if (ret != C_KZG_OK) {
     throw_c_kzg_exception(env, ret,
-                          "There was an error in verifyCellKzgProofBatch.");
+                          "There was an error in verifyCellKZGProofBatch.");
     return 0;
   }
 

--- a/bindings/java/ckzg_jni.h
+++ b/bindings/java/ckzg_jni.h
@@ -57,74 +57,74 @@ JNIEXPORT void JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_freeTrustedSetup
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    blobToKzgCommitment
+ * Method:    blobToKZGCommitment
  * Signature: ([B)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKzgCommitment
+JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_blobToKZGCommitment
   (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    computeKzgProof
+ * Method:    computeKZGProof
  * Signature: ([B[B)Lethereum/ckzg4844/ProofAndY;
  */
-JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKzgProof
+JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeKZGProof
   (JNIEnv *, jclass, jbyteArray, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    computeBlobKzgProof
+ * Method:    computeBlobKZGProof
  * Signature: ([B[B)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKzgProof
+JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeBlobKZGProof
   (JNIEnv *, jclass, jbyteArray, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    verifyKzgProof
+ * Method:    verifyKZGProof
  * Signature: ([B[B[B[B)Z
  */
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKzgProof
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyKZGProof
   (JNIEnv *, jclass, jbyteArray, jbyteArray, jbyteArray, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    verifyBlobKzgProof
+ * Method:    verifyBlobKZGProof
  * Signature: ([B[B[B)Z
  */
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProof
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKZGProof
   (JNIEnv *, jclass, jbyteArray, jbyteArray, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    verifyBlobKzgProofBatch
+ * Method:    verifyBlobKZGProofBatch
  * Signature: ([B[B[BJ)Z
  */
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKzgProofBatch
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyBlobKZGProofBatch
   (JNIEnv *, jclass, jbyteArray, jbyteArray, jbyteArray, jlong);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    computeCellsAndKzgProofs
+ * Method:    computeCellsAndKZGProofs
  * Signature: ([B)Lethereum/ckzg4844/CellsAndProofs;
  */
-JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgProofs
+JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKZGProofs
   (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    recoverCellsAndKzgProofs
+ * Method:    recoverCellsAndKZGProofs
  * Signature: ([J[B)Lethereum/ckzg4844/CellsAndProofs;
  */
-JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKzgProofs
+JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKZGProofs
   (JNIEnv *, jclass, jlongArray, jbyteArray);
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
- * Method:    verifyCellKzgProofBatch
+ * Method:    verifyCellKZGProofBatch
  * Signature: ([B[J[B[B)Z
  */
-JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyCellKzgProofBatch
+JNIEXPORT jboolean JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_verifyCellKZGProofBatch
   (JNIEnv *, jclass, jbyteArray, jlongArray, jbyteArray, jbyteArray);
 
 #ifdef __cplusplus

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -141,7 +141,7 @@ public class CKZG4844JNI {
    * @return the commitment
    * @throws CKZGException if there is a crypto error
    */
-  public static native byte[] blobToKzgCommitment(byte[] blob);
+  public static native byte[] blobToKZGCommitment(byte[] blob);
 
   /**
    * Compute proof at point z for the polynomial represented by blob.
@@ -151,7 +151,7 @@ public class CKZG4844JNI {
    * @return an instance of {@link ProofAndY} holding the proof and the value y = f(z)
    * @throws CKZGException if there is a crypto error
    */
-  public static native ProofAndY computeKzgProof(byte[] blob, byte[] zBytes);
+  public static native ProofAndY computeKZGProof(byte[] blob, byte[] zBytes);
 
   /**
    * Given a blob, return the KZG proof that is used to verify it against the commitment
@@ -161,7 +161,7 @@ public class CKZG4844JNI {
    * @return the proof
    * @throws CKZGException if there is a crypto error
    */
-  public static native byte[] computeBlobKzgProof(byte[] blob, byte[] commitmentBytes);
+  public static native byte[] computeBlobKZGProof(byte[] blob, byte[] commitmentBytes);
 
   /**
    * Verify the proof by point evaluation for the given commitment
@@ -173,7 +173,7 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyKzgProof(
+  public static native boolean verifyKZGProof(
       byte[] commitmentBytes, byte[] zBytes, byte[] yBytes, byte[] proofBytes);
 
   /**
@@ -185,7 +185,7 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyBlobKzgProof(
+  public static native boolean verifyBlobKZGProof(
       byte[] blob, byte[] commitmentBytes, byte[] proofBytes);
 
   /**
@@ -199,7 +199,7 @@ public class CKZG4844JNI {
    * @return true if the proof is valid and false otherwise
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyBlobKzgProofBatch(
+  public static native boolean verifyBlobKZGProofBatch(
       byte[] blobs, byte[] commitmentsBytes, byte[] proofsBytes, long count);
 
   /**
@@ -209,7 +209,7 @@ public class CKZG4844JNI {
    * @return a CellsAndProofs object
    * @throws CKZGException if there is a crypto error
    */
-  public static native CellsAndProofs computeCellsAndKzgProofs(byte[] blob);
+  public static native CellsAndProofs computeCellsAndKZGProofs(byte[] blob);
 
   /**
    * Given at least 50% of cells, reconstruct the missing cells/proofs.
@@ -219,7 +219,7 @@ public class CKZG4844JNI {
    * @return all cells/proofs for that blob
    * @throws CKZGException if there is a crypto error
    */
-  public static native CellsAndProofs recoverCellsAndKzgProofs(long[] cellIndices, byte[] cells);
+  public static native CellsAndProofs recoverCellsAndKZGProofs(long[] cellIndices, byte[] cells);
 
   /**
    * Verify that multiple cells' proofs are valid.
@@ -231,6 +231,6 @@ public class CKZG4844JNI {
    * @return true if the cells are valid with respect to the given commitments
    * @throws CKZGException if there is a crypto error
    */
-  public static native boolean verifyCellKzgProofBatch(
+  public static native boolean verifyCellKZGProofBatch(
       byte[] commitmentsBytes, long[] cellIndices, byte[] cells, byte[] proofsBytes);
 }

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -36,10 +36,10 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getBlobToKzgCommitmentTests")
-  public void blobToKzgCommitmentTests(final BlobToKzgCommitmentTest test) {
+  @MethodSource("getBlobToKZGCommitmentTests")
+  public void blobToKZGCommitmentTests(final BlobToKZGCommitmentTest test) {
     try {
-      byte[] commitment = CKZG4844JNI.blobToKzgCommitment(test.getInput().getBlob());
+      byte[] commitment = CKZG4844JNI.blobToKZGCommitment(test.getInput().getBlob());
       assertArrayEquals(test.getOutput(), commitment);
     } catch (CKZGException ex) {
       assertNull(test.getOutput());
@@ -47,11 +47,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getComputeKzgProofTests")
-  public void computeKzgProofTests(final ComputeKzgProofTest test) {
+  @MethodSource("getComputeKZGProofTests")
+  public void computeKZGProofTests(final ComputeKZGProofTest test) {
     try {
       ProofAndY proofAndY =
-          CKZG4844JNI.computeKzgProof(test.getInput().getBlob(), test.getInput().getZ());
+          CKZG4844JNI.computeKZGProof(test.getInput().getBlob(), test.getInput().getZ());
       assertArrayEquals(test.getOutput().getProof(), proofAndY.getProof());
       assertArrayEquals(test.getOutput().getY(), proofAndY.getY());
     } catch (CKZGException ex) {
@@ -60,11 +60,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getComputeBlobKzgProofTests")
-  public void computeBlobKzgProofTests(final ComputeBlobKzgProofTest test) {
+  @MethodSource("getComputeBlobKZGProofTests")
+  public void computeBlobKZGProofTests(final ComputeBlobKZGProofTest test) {
     try {
       byte[] proof =
-          CKZG4844JNI.computeBlobKzgProof(
+          CKZG4844JNI.computeBlobKZGProof(
               test.getInput().getBlob(), test.getInput().getCommitment());
       assertArrayEquals(test.getOutput(), proof);
     } catch (CKZGException ex) {
@@ -73,11 +73,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getVerifyKzgProofTests")
-  public void verifyKzgProofTests(final VerifyKzgProofTest test) {
+  @MethodSource("getVerifyKZGProofTests")
+  public void verifyKZGProofTests(final VerifyKZGProofTest test) {
     try {
       boolean valid =
-          CKZG4844JNI.verifyKzgProof(
+          CKZG4844JNI.verifyKZGProof(
               test.getInput().getCommitment(),
               test.getInput().getZ(),
               test.getInput().getY(),
@@ -89,11 +89,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getVerifyBlobKzgProofTests")
-  public void verifyBlobKzgProofTests(final VerifyBlobKzgProofTest test) {
+  @MethodSource("getVerifyBlobKZGProofTests")
+  public void verifyBlobKZGProofTests(final VerifyBlobKZGProofTest test) {
     try {
       boolean valid =
-          CKZG4844JNI.verifyBlobKzgProof(
+          CKZG4844JNI.verifyBlobKZGProof(
               test.getInput().getBlob(),
               test.getInput().getCommitment(),
               test.getInput().getProof());
@@ -104,12 +104,12 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getVerifyBlobKzgProofBatchTests")
-  public void verifyBlobKzgProofBatchTests(final VerifyBlobKzgProofBatchTest test) {
+  @MethodSource("getVerifyBlobKZGProofBatchTests")
+  public void verifyBlobKZGProofBatchTests(final VerifyBlobKZGProofBatchTest test) {
     try {
       int count = test.getInput().getBlobs().length / CKZG4844JNI.BYTES_PER_BLOB;
       boolean valid =
-          CKZG4844JNI.verifyBlobKzgProofBatch(
+          CKZG4844JNI.verifyBlobKZGProofBatch(
               test.getInput().getBlobs(),
               test.getInput().getCommitments(),
               test.getInput().getProofs(),
@@ -121,11 +121,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getComputeCellsAndKzgProofsTests")
-  public void verifyComputeCellsAndKzgProofsTests(final ComputeCellsAndKzgProofsTest test) {
+  @MethodSource("getComputeCellsAndKZGProofsTests")
+  public void verifyComputeCellsAndKZGProofsTests(final ComputeCellsAndKZGProofsTest test) {
     try {
       CellsAndProofs cellsAndProofs =
-          CKZG4844JNI.computeCellsAndKzgProofs(test.getInput().getBlob());
+          CKZG4844JNI.computeCellsAndKZGProofs(test.getInput().getBlob());
       assertArrayEquals(test.getOutput().getCells(), cellsAndProofs.getCells());
       assertArrayEquals(test.getOutput().getProofs(), cellsAndProofs.getProofs());
     } catch (CKZGException ex) {
@@ -134,11 +134,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getRecoverCellsAndKzgProofsTests")
-  public void recoverCellsAndKzgProofsTests(final RecoverCellsAndKzgProofsTest test) {
+  @MethodSource("getRecoverCellsAndKZGProofsTests")
+  public void recoverCellsAndKZGProofsTests(final RecoverCellsAndKZGProofsTest test) {
     try {
       final CellsAndProofs recoveredCellsAndProofs =
-          CKZG4844JNI.recoverCellsAndKzgProofs(
+          CKZG4844JNI.recoverCellsAndKZGProofs(
               test.getInput().getCellIndices(), test.getInput().getCells());
       assertArrayEquals(test.getOutput().getCells(), recoveredCellsAndProofs.getCells());
       assertArrayEquals(test.getOutput().getProofs(), recoveredCellsAndProofs.getProofs());
@@ -148,11 +148,11 @@ public class CKZG4844JNITest {
   }
 
   @ParameterizedTest
-  @MethodSource("getVerifyCellKzgProofBatchTests")
-  public void verifyCellKzgProofBatchTests(final VerifyCellKzgProofBatchTest test) {
+  @MethodSource("getVerifyCellKZGProofBatchTests")
+  public void verifyCellKZGProofBatchTests(final VerifyCellKZGProofBatchTest test) {
     try {
       boolean valid =
-          CKZG4844JNI.verifyCellKzgProofBatch(
+          CKZG4844JNI.verifyCellKZGProofBatch(
               test.getInput().getCommitments(),
               test.getInput().getCellIndices(),
               test.getInput().getCells(),
@@ -165,7 +165,7 @@ public class CKZG4844JNITest {
 
   @ParameterizedTest
   @EnumSource(TrustedSetupSource.class)
-  public void testVerifyBlobKzgProofBatch(final TrustedSetupSource trustedSetupSource) {
+  public void testVerifyBlobKZGProofBatch(final TrustedSetupSource trustedSetupSource) {
     loadTrustedSetup(trustedSetupSource);
     final int count = 3;
     final byte[][] blobsArray = new byte[count][];
@@ -175,48 +175,48 @@ public class CKZG4844JNITest {
         .forEach(
             i -> {
               blobsArray[i] = TestUtils.createRandomBlob();
-              commitmentsArray[i] = CKZG4844JNI.blobToKzgCommitment(blobsArray[i]);
-              proofsArray[i] = CKZG4844JNI.computeBlobKzgProof(blobsArray[i], commitmentsArray[i]);
+              commitmentsArray[i] = CKZG4844JNI.blobToKZGCommitment(blobsArray[i]);
+              proofsArray[i] = CKZG4844JNI.computeBlobKZGProof(blobsArray[i], commitmentsArray[i]);
             });
     final byte[] blobs = TestUtils.flatten(blobsArray);
     final byte[] commitments = TestUtils.flatten(commitmentsArray);
     final byte[] proofs = TestUtils.flatten(proofsArray);
 
-    assertTrue(CKZG4844JNI.verifyBlobKzgProofBatch(blobs, commitments, proofs, count));
+    assertTrue(CKZG4844JNI.verifyBlobKZGProofBatch(blobs, commitments, proofs, count));
 
     final byte[] fakeBlobs = TestUtils.createRandomBlobs(count);
-    assertFalse(CKZG4844JNI.verifyBlobKzgProofBatch(fakeBlobs, commitments, proofs, count));
+    assertFalse(CKZG4844JNI.verifyBlobKZGProofBatch(fakeBlobs, commitments, proofs, count));
     final byte[] fakeCommitments = TestUtils.createRandomCommitments(count);
-    assertFalse(CKZG4844JNI.verifyBlobKzgProofBatch(blobs, fakeCommitments, proofs, count));
+    assertFalse(CKZG4844JNI.verifyBlobKZGProofBatch(blobs, fakeCommitments, proofs, count));
     final byte[] fakeProofs = TestUtils.createRandomProofs(count);
-    assertFalse(CKZG4844JNI.verifyBlobKzgProofBatch(blobs, commitments, fakeProofs, count));
+    assertFalse(CKZG4844JNI.verifyBlobKZGProofBatch(blobs, commitments, fakeProofs, count));
 
     CKZG4844JNI.freeTrustedSetup();
   }
 
   @Test
-  public void checkComputeKzgProof() {
+  public void checkComputeKZGProof() {
     loadTrustedSetup();
     final byte[] blob = TestUtils.createRandomBlob();
     final byte[] z_bytes = TestUtils.randomBLSFieldElementBytes();
-    final ProofAndY proofAndY = CKZG4844JNI.computeKzgProof(blob, z_bytes);
+    final ProofAndY proofAndY = CKZG4844JNI.computeKZGProof(blob, z_bytes);
     assertEquals(BYTES_PER_PROOF, proofAndY.getProof().length);
     assertEquals(CKZG4844JNI.BYTES_PER_FIELD_ELEMENT, proofAndY.getY().length);
     CKZG4844JNI.freeTrustedSetup();
   }
 
   @Test
-  public void checkRecoverCellsAndKzgProofs() {
+  public void checkRecoverCellsAndKZGProofs() {
     loadTrustedSetup();
     final byte[] blob = TestUtils.createRandomBlob();
-    final CellsAndProofs cellsAndProofs = CKZG4844JNI.computeCellsAndKzgProofs(blob);
+    final CellsAndProofs cellsAndProofs = CKZG4844JNI.computeCellsAndKZGProofs(blob);
     final byte[] cells = cellsAndProofs.getCells();
     final byte[] proofs = cellsAndProofs.getProofs();
     final byte[] partialCells = new byte[BYTES_PER_CELL * CELLS_PER_EXT_BLOB / 2];
     System.arraycopy(cells, 0, partialCells, 0, partialCells.length);
     final long[] cellIndices = LongStream.range(0, CELLS_PER_EXT_BLOB / 2).toArray();
     final CellsAndProofs recoveredCellsAndProofs =
-        CKZG4844JNI.recoverCellsAndKzgProofs(cellIndices, partialCells);
+        CKZG4844JNI.recoverCellsAndKZGProofs(cellIndices, partialCells);
     assertArrayEquals(cells, recoveredCellsAndProofs.getCells());
     assertArrayEquals(proofs, recoveredCellsAndProofs.getProofs());
     CKZG4844JNI.freeTrustedSetup();
@@ -239,7 +239,7 @@ public class CKZG4844JNITest {
 
     for (int i = 0; i < count; i++) {
       final byte[] blob = TestUtils.createRandomBlob();
-      final byte[] commitment = CKZG4844JNI.blobToKzgCommitment(blob);
+      final byte[] commitment = CKZG4844JNI.blobToKZGCommitment(blob);
       for (int j = 0; j < CELLS_PER_EXT_BLOB; j++) {
         System.arraycopy(
             commitment,
@@ -248,7 +248,7 @@ public class CKZG4844JNITest {
             i * commitmentsLength + j * BYTES_PER_COMMITMENT,
             BYTES_PER_COMMITMENT);
       }
-      data[i] = CKZG4844JNI.computeCellsAndKzgProofs(blob);
+      data[i] = CKZG4844JNI.computeCellsAndKZGProofs(blob);
       System.arraycopy(data[i].getCells(), 0, cells, i * cellsLength, cellsLength);
       System.arraycopy(data[i].getProofs(), 0, proofs, i * proofsLength, proofsLength);
     }
@@ -260,16 +260,16 @@ public class CKZG4844JNITest {
       }
     }
 
-    assertTrue(CKZG4844JNI.verifyCellKzgProofBatch(commitments, cellIndices, cells, proofs));
+    assertTrue(CKZG4844JNI.verifyCellKZGProofBatch(commitments, cellIndices, cells, proofs));
     CKZG4844JNI.freeTrustedSetup();
   }
 
   @Test
-  public void checkComputeBlobKzgProof() {
+  public void checkComputeBlobKZGProof() {
     loadTrustedSetup();
     final byte[] blob = TestUtils.createRandomBlob();
     final byte[] commitment = TestUtils.createRandomCommitment();
-    final byte[] proof = CKZG4844JNI.computeBlobKzgProof(blob, commitment);
+    final byte[] proof = CKZG4844JNI.computeBlobKZGProof(blob, commitment);
     assertEquals(BYTES_PER_PROOF, proof.length);
     CKZG4844JNI.freeTrustedSetup();
   }
@@ -282,10 +282,10 @@ public class CKZG4844JNITest {
     final byte[] blob = TestUtils.createNonCanonicalBlob();
 
     final CKZGException exception =
-        assertThrows(CKZGException.class, () -> CKZG4844JNI.blobToKzgCommitment(blob));
+        assertThrows(CKZGException.class, () -> CKZG4844JNI.blobToKZGCommitment(blob));
 
     assertEquals(C_KZG_BADARGS, exception.getError());
-    assertEquals("There was an error in blobToKzgCommitment.", exception.getErrorMessage());
+    assertEquals("There was an error in blobToKZGCommitment.", exception.getErrorMessage());
 
     CKZG4844JNI.freeTrustedSetup();
   }
@@ -303,7 +303,7 @@ public class CKZG4844JNITest {
     final CKZGException exception =
         assertThrows(
             CKZGException.class,
-            () -> CKZG4844JNI.verifyBlobKzgProofBatch(blobs, commitments, proofs, count));
+            () -> CKZG4844JNI.verifyBlobKZGProofBatch(blobs, commitments, proofs, count));
     assertEquals(C_KZG_BADARGS, exception.getError());
     assertEquals(
         "Invalid commitments size. Expected 96 bytes but got 144.", exception.getErrorMessage());
@@ -317,7 +317,7 @@ public class CKZG4844JNITest {
     loadTrustedSetup();
 
     CKZGException exception =
-        assertThrows(CKZGException.class, () -> CKZG4844JNI.blobToKzgCommitment(new byte[0]));
+        assertThrows(CKZGException.class, () -> CKZG4844JNI.blobToKZGCommitment(new byte[0]));
 
     assertEquals(C_KZG_BADARGS, exception.getError());
     assertEquals(
@@ -328,7 +328,7 @@ public class CKZG4844JNITest {
     exception =
         assertThrows(
             CKZGException.class,
-            () -> CKZG4844JNI.computeBlobKzgProof(new byte[123], new byte[32]));
+            () -> CKZG4844JNI.computeBlobKZGProof(new byte[123], new byte[32]));
 
     assertEquals(C_KZG_BADARGS, exception.getError());
     assertEquals(
@@ -340,7 +340,7 @@ public class CKZG4844JNITest {
         assertThrows(
             CKZGException.class,
             () ->
-                CKZG4844JNI.computeBlobKzgProof(
+                CKZG4844JNI.computeBlobKZGProof(
                     new byte[CKZG4844JNI.BYTES_PER_BLOB], new byte[49]));
 
     assertEquals(C_KZG_BADARGS, exception.getError());
@@ -351,7 +351,7 @@ public class CKZG4844JNITest {
         assertThrows(
             CKZGException.class,
             () ->
-                CKZG4844JNI.verifyBlobKzgProofBatch(
+                CKZG4844JNI.verifyBlobKZGProofBatch(
                     new byte[42],
                     TestUtils.createRandomCommitments(2),
                     TestUtils.createRandomProofs(2),
@@ -372,7 +372,7 @@ public class CKZG4844JNITest {
     final RuntimeException exception =
         assertThrows(
             RuntimeException.class,
-            () -> CKZG4844JNI.blobToKzgCommitment(TestUtils.createRandomBlob()));
+            () -> CKZG4844JNI.blobToKZGCommitment(TestUtils.createRandomBlob()));
 
     assertExceptionIsTrustedSetupIsNotLoaded(exception);
   }
@@ -491,52 +491,52 @@ public class CKZG4844JNITest {
     CKZG4844JNI.loadTrustedSetupFromResource(TRUSTED_SETUP_RESOURCE, CKZG4844JNITest.class, 0);
   }
 
-  private static Stream<BlobToKzgCommitmentTest> getBlobToKzgCommitmentTests() {
+  private static Stream<BlobToKZGCommitmentTest> getBlobToKZGCommitmentTests() {
     loadTrustedSetup();
-    return TestUtils.getBlobToKzgCommitmentTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
+    return TestUtils.getBlobToKZGCommitmentTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<ComputeKzgProofTest> getComputeKzgProofTests() {
+  private static Stream<ComputeKZGProofTest> getComputeKZGProofTests() {
     loadTrustedSetup();
-    return TestUtils.getComputeKzgProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
+    return TestUtils.getComputeKZGProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<ComputeBlobKzgProofTest> getComputeBlobKzgProofTests() {
+  private static Stream<ComputeBlobKZGProofTest> getComputeBlobKZGProofTests() {
     loadTrustedSetup();
-    return TestUtils.getComputeBlobKzgProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
+    return TestUtils.getComputeBlobKZGProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<VerifyKzgProofTest> getVerifyKzgProofTests() {
+  private static Stream<VerifyKZGProofTest> getVerifyKZGProofTests() {
     loadTrustedSetup();
-    return TestUtils.getVerifyKzgProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
+    return TestUtils.getVerifyKZGProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<VerifyBlobKzgProofTest> getVerifyBlobKzgProofTests() {
+  private static Stream<VerifyBlobKZGProofTest> getVerifyBlobKZGProofTests() {
     loadTrustedSetup();
-    return TestUtils.getVerifyBlobKzgProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
+    return TestUtils.getVerifyBlobKZGProofTests().stream().onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<VerifyBlobKzgProofBatchTest> getVerifyBlobKzgProofBatchTests() {
+  private static Stream<VerifyBlobKZGProofBatchTest> getVerifyBlobKZGProofBatchTests() {
     loadTrustedSetup();
-    return TestUtils.getVerifyBlobKzgProofBatchTests().stream()
+    return TestUtils.getVerifyBlobKZGProofBatchTests().stream()
         .onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<ComputeCellsAndKzgProofsTest> getComputeCellsAndKzgProofsTests() {
+  private static Stream<ComputeCellsAndKZGProofsTest> getComputeCellsAndKZGProofsTests() {
     loadTrustedSetup();
-    return TestUtils.getComputeCellsAndKzgProofsTests().stream()
+    return TestUtils.getComputeCellsAndKZGProofsTests().stream()
         .onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<RecoverCellsAndKzgProofsTest> getRecoverCellsAndKzgProofsTests() {
+  private static Stream<RecoverCellsAndKZGProofsTest> getRecoverCellsAndKZGProofsTests() {
     loadTrustedSetup();
-    return TestUtils.getRecoverCellsAndKzgProofsTests().stream()
+    return TestUtils.getRecoverCellsAndKZGProofsTests().stream()
         .onClose(CKZG4844JNI::freeTrustedSetup);
   }
 
-  private static Stream<VerifyCellKzgProofBatchTest> getVerifyCellKzgProofBatchTests() {
+  private static Stream<VerifyCellKZGProofBatchTest> getVerifyCellKZGProofBatchTests() {
     loadTrustedSetup();
-    return TestUtils.getVerifyCellKzgProofBatchTests().stream()
+    return TestUtils.getVerifyCellKZGProofBatchTests().stream()
         .onClose(CKZG4844JNI::freeTrustedSetup);
   }
 }

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/TestUtils.java
@@ -66,7 +66,7 @@ public class TestUtils {
   }
 
   public static byte[] createRandomProof() {
-    return CKZG4844JNI.computeBlobKzgProof(createRandomBlob(), createRandomCommitment());
+    return CKZG4844JNI.computeBlobKZGProof(createRandomBlob(), createRandomCommitment());
   }
 
   public static byte[] createRandomProofs(final int count) {
@@ -76,7 +76,7 @@ public class TestUtils {
   }
 
   public static byte[] createRandomCommitment() {
-    return CKZG4844JNI.blobToKzgCommitment(createRandomBlob());
+    return CKZG4844JNI.blobToKZGCommitment(createRandomBlob());
   }
 
   public static byte[] createRandomCommitments(final int count) {
@@ -94,15 +94,15 @@ public class TestUtils {
     return flatten(blob);
   }
 
-  public static List<BlobToKzgCommitmentTest> getBlobToKzgCommitmentTests() {
-    final Stream.Builder<BlobToKzgCommitmentTest> tests = Stream.builder();
+  public static List<BlobToKZGCommitmentTest> getBlobToKZGCommitmentTests() {
+    final Stream.Builder<BlobToKZGCommitmentTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(BLOB_TO_KZG_COMMITMENT_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String data = Files.readString(Path.of(testFile));
-        BlobToKzgCommitmentTest test = OBJECT_MAPPER.readValue(data, BlobToKzgCommitmentTest.class);
+        BlobToKZGCommitmentTest test = OBJECT_MAPPER.readValue(data, BlobToKZGCommitmentTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -112,15 +112,15 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<ComputeKzgProofTest> getComputeKzgProofTests() {
-    final Stream.Builder<ComputeKzgProofTest> tests = Stream.builder();
+  public static List<ComputeKZGProofTest> getComputeKZGProofTests() {
+    final Stream.Builder<ComputeKZGProofTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(COMPUTE_KZG_PROOF_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        ComputeKzgProofTest test = OBJECT_MAPPER.readValue(jsonData, ComputeKzgProofTest.class);
+        ComputeKZGProofTest test = OBJECT_MAPPER.readValue(jsonData, ComputeKZGProofTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -130,16 +130,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<ComputeBlobKzgProofTest> getComputeBlobKzgProofTests() {
-    final Stream.Builder<ComputeBlobKzgProofTest> tests = Stream.builder();
+  public static List<ComputeBlobKZGProofTest> getComputeBlobKZGProofTests() {
+    final Stream.Builder<ComputeBlobKZGProofTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(COMPUTE_BLOB_KZG_PROOF_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        ComputeBlobKzgProofTest test =
-            OBJECT_MAPPER.readValue(jsonData, ComputeBlobKzgProofTest.class);
+        ComputeBlobKZGProofTest test =
+            OBJECT_MAPPER.readValue(jsonData, ComputeBlobKZGProofTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -149,15 +149,15 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<VerifyKzgProofTest> getVerifyKzgProofTests() {
-    final Stream.Builder<VerifyKzgProofTest> tests = Stream.builder();
+  public static List<VerifyKZGProofTest> getVerifyKZGProofTests() {
+    final Stream.Builder<VerifyKZGProofTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(VERIFY_KZG_PROOF_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        VerifyKzgProofTest test = OBJECT_MAPPER.readValue(jsonData, VerifyKzgProofTest.class);
+        VerifyKZGProofTest test = OBJECT_MAPPER.readValue(jsonData, VerifyKZGProofTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -167,16 +167,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<VerifyBlobKzgProofTest> getVerifyBlobKzgProofTests() {
-    final Stream.Builder<VerifyBlobKzgProofTest> tests = Stream.builder();
+  public static List<VerifyBlobKZGProofTest> getVerifyBlobKZGProofTests() {
+    final Stream.Builder<VerifyBlobKZGProofTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(VERIFY_BLOB_KZG_PROOF_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        VerifyBlobKzgProofTest test =
-            OBJECT_MAPPER.readValue(jsonData, VerifyBlobKzgProofTest.class);
+        VerifyBlobKZGProofTest test =
+            OBJECT_MAPPER.readValue(jsonData, VerifyBlobKZGProofTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -186,16 +186,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<VerifyBlobKzgProofBatchTest> getVerifyBlobKzgProofBatchTests() {
-    final Stream.Builder<VerifyBlobKzgProofBatchTest> tests = Stream.builder();
+  public static List<VerifyBlobKZGProofBatchTest> getVerifyBlobKZGProofBatchTests() {
+    final Stream.Builder<VerifyBlobKZGProofBatchTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        VerifyBlobKzgProofBatchTest test =
-            OBJECT_MAPPER.readValue(jsonData, VerifyBlobKzgProofBatchTest.class);
+        VerifyBlobKZGProofBatchTest test =
+            OBJECT_MAPPER.readValue(jsonData, VerifyBlobKZGProofBatchTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -205,16 +205,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<ComputeCellsAndKzgProofsTest> getComputeCellsAndKzgProofsTests() {
-    final Stream.Builder<ComputeCellsAndKzgProofsTest> tests = Stream.builder();
+  public static List<ComputeCellsAndKZGProofsTest> getComputeCellsAndKZGProofsTests() {
+    final Stream.Builder<ComputeCellsAndKZGProofsTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(COMPUTE_CELLS_AND_KZG_PROOFS_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        ComputeCellsAndKzgProofsTest test =
-            OBJECT_MAPPER.readValue(jsonData, ComputeCellsAndKzgProofsTest.class);
+        ComputeCellsAndKZGProofsTest test =
+            OBJECT_MAPPER.readValue(jsonData, ComputeCellsAndKZGProofsTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -224,16 +224,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<RecoverCellsAndKzgProofsTest> getRecoverCellsAndKzgProofsTests() {
-    final Stream.Builder<RecoverCellsAndKzgProofsTest> tests = Stream.builder();
+  public static List<RecoverCellsAndKZGProofsTest> getRecoverCellsAndKZGProofsTests() {
+    final Stream.Builder<RecoverCellsAndKZGProofsTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(RECOVER_CELLS_AND_KZG_PROOFS_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        RecoverCellsAndKzgProofsTest test =
-            OBJECT_MAPPER.readValue(jsonData, RecoverCellsAndKzgProofsTest.class);
+        RecoverCellsAndKZGProofsTest test =
+            OBJECT_MAPPER.readValue(jsonData, RecoverCellsAndKZGProofsTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {
@@ -243,16 +243,16 @@ public class TestUtils {
     return tests.build().collect(Collectors.toList());
   }
 
-  public static List<VerifyCellKzgProofBatchTest> getVerifyCellKzgProofBatchTests() {
-    final Stream.Builder<VerifyCellKzgProofBatchTest> tests = Stream.builder();
+  public static List<VerifyCellKZGProofBatchTest> getVerifyCellKZGProofBatchTests() {
+    final Stream.Builder<VerifyCellKZGProofBatchTest> tests = Stream.builder();
     List<String> testFiles = getTestFiles(VERIFY_CELL_KZG_PROOF_BATCH_TESTS);
     assert !testFiles.isEmpty();
 
     try {
       for (String testFile : testFiles) {
         String jsonData = Files.readString(Path.of(testFile));
-        VerifyCellKzgProofBatchTest test =
-            OBJECT_MAPPER.readValue(jsonData, VerifyCellKzgProofBatchTest.class);
+        VerifyCellKZGProofBatchTest test =
+            OBJECT_MAPPER.readValue(jsonData, VerifyCellKZGProofBatchTest.class);
         tests.add(test);
       }
     } catch (IOException ex) {

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/BlobToKZGCommitmentTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/BlobToKZGCommitmentTest.java
@@ -2,7 +2,7 @@ package ethereum.ckzg4844.test_formats;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class BlobToKzgCommitmentTest {
+public class BlobToKZGCommitmentTest {
   public static class Input {
     private String blob;
 

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKZGProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeBlobKZGProofTest.java
@@ -2,11 +2,10 @@ package ethereum.ckzg4844.test_formats;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class VerifyBlobKzgProofTest {
+public class ComputeBlobKZGProofTest {
   public static class Input {
     private String blob;
     private String commitment;
-    private String proof;
 
     public byte[] getBlob() {
       return Bytes.fromHexString(blob).toArrayUnsafe();
@@ -15,20 +14,19 @@ public class VerifyBlobKzgProofTest {
     public byte[] getCommitment() {
       return Bytes.fromHexString(commitment).toArray();
     }
-
-    public byte[] getProof() {
-      return Bytes.fromHexString(proof).toArray();
-    }
   }
 
   private Input input;
-  private Boolean output;
+  private String output;
 
   public Input getInput() {
     return input;
   }
 
-  public Boolean getOutput() {
-    return output;
+  public byte[] getOutput() {
+    if (output == null) {
+      return null;
+    }
+    return Bytes.fromHexString(output).toArray();
   }
 }

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeCellsAndKZGProofsTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeCellsAndKZGProofsTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 
-public class ComputeCellsAndKzgProofsTest {
+public class ComputeCellsAndKZGProofsTest {
   public static class Input {
     private String blob;
 

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKZGProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/ComputeKZGProofTest.java
@@ -4,7 +4,7 @@ import ethereum.ckzg4844.ProofAndY;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 
-public class ComputeKzgProofTest {
+public class ComputeKZGProofTest {
   public static class Input {
     private String blob;
     private String z;

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/RecoverCellsAndKZGProofsTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/RecoverCellsAndKZGProofsTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 
-public class RecoverCellsAndKzgProofsTest {
+public class RecoverCellsAndKZGProofsTest {
   public static class Input {
     @JsonProperty("cell_indices")
     private List<Long> cellIndices;

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKZGProofBatchTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKZGProofBatchTest.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 
-public class VerifyBlobKzgProofBatchTest {
+public class VerifyBlobKZGProofBatchTest {
   public static class Input {
     private List<String> blobs;
     private List<String> commitments;

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKZGProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyBlobKZGProofTest.java
@@ -2,10 +2,11 @@ package ethereum.ckzg4844.test_formats;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class ComputeBlobKzgProofTest {
+public class VerifyBlobKZGProofTest {
   public static class Input {
     private String blob;
     private String commitment;
+    private String proof;
 
     public byte[] getBlob() {
       return Bytes.fromHexString(blob).toArrayUnsafe();
@@ -14,19 +15,20 @@ public class ComputeBlobKzgProofTest {
     public byte[] getCommitment() {
       return Bytes.fromHexString(commitment).toArray();
     }
+
+    public byte[] getProof() {
+      return Bytes.fromHexString(proof).toArray();
+    }
   }
 
   private Input input;
-  private String output;
+  private Boolean output;
 
   public Input getInput() {
     return input;
   }
 
-  public byte[] getOutput() {
-    if (output == null) {
-      return null;
-    }
-    return Bytes.fromHexString(output).toArray();
+  public Boolean getOutput() {
+    return output;
   }
 }

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyCellKZGProofBatchTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyCellKZGProofBatchTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 
-public class VerifyCellKzgProofBatchTest {
+public class VerifyCellKZGProofBatchTest {
   public static class Input {
     @JsonProperty("commitments")
     private List<String> commitments;

--- a/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyKZGProofTest.java
+++ b/bindings/java/src/testFixtures/java/ethereum/ckzg4844/test_formats/VerifyKZGProofTest.java
@@ -2,7 +2,7 @@ package ethereum.ckzg4844.test_formats;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class VerifyKzgProofTest {
+public class VerifyKZGProofTest {
   public static class Input {
     private String commitment;
     private String z;

--- a/bindings/nim/kzg.nim
+++ b/bindings/nim/kzg.nim
@@ -22,7 +22,7 @@ type
     y*: KzgBytes32
 
   KzgCells* = array[CELLS_PER_EXT_BLOB, KzgCell]
-  KzgCellsAndKzgProofs* = object
+  KzgCellsAndKZGProofs* = object
     cells*: array[CELLS_PER_EXT_BLOB, KzgCell]
     proofs*: array[CELLS_PER_EXT_BLOB, KzgProof]
 
@@ -225,8 +225,8 @@ proc verifyProofs*(ctx: KzgCtx,
   verify(res, valid)
 
 proc computeCellsAndProofs*(ctx: KzgCtx,
-                   blob: KzgBlob): Result[KzgCellsAndKzgProofs, string] {.gcsafe.} =
-  var ret: KzgCellsAndKzgProofs
+                   blob: KzgBlob): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
+  var ret: KzgCellsAndKZGProofs
   var cellsPtr: ptr KzgCell = ret.cells[0].getPtr
   var proofsPtr: ptr KzgProof = ret.proofs[0].getPtr
   let res = compute_cells_and_kzg_proofs(
@@ -238,14 +238,14 @@ proc computeCellsAndProofs*(ctx: KzgCtx,
 
 proc recoverCellsAndProofs*(ctx: KzgCtx,
                    cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell]): Result[KzgCellsAndKzgProofs, string] {.gcsafe.} =
+                   cells: openArray[KzgCell]): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
   if cells.len != cellIndices.len:
     return err($KZG_BADARGS)
 
   if cells.len == 0:
     return err($KZG_BADARGS)
 
-  var ret: KzgCellsAndKzgProofs
+  var ret: KzgCellsAndKZGProofs
   var recoveredCellsPtr: ptr KzgCell = ret.cells[0].getPtr
   var recoveredProofsPtr: ptr KzgProof = ret.proofs[0].getPtr
   let res = recover_cells_and_kzg_proofs(
@@ -295,49 +295,49 @@ template loadTrustedSetupFile*(input: File | string, precompute: Natural): untyp
 template freeTrustedSetup*(ctx: KzgCtx) =
   destroy(ctx)
 
-template blobToKzgCommitment*(ctx: KzgCtx,
+template blobToKZGCommitment*(ctx: KzgCtx,
                    blob: KzgBlob): untyped =
   toCommitment(ctx, blob)
 
-template computeKzgProof*(ctx: KzgCtx,
+template computeKZGProof*(ctx: KzgCtx,
                    blob: KzgBlob,
                    z: KzgBytes32): untyped =
   computeProof(ctx, blob, z)
 
-template computeBlobKzgProof*(ctx: KzgCtx,
+template computeBlobKZGProof*(ctx: KzgCtx,
                    blob: KzgBlob,
                    commitmentBytes: KzgBytes48): untyped =
   computeProof(ctx, blob, commitmentBytes)
 
-template verifyKzgProof*(ctx: KzgCtx,
+template verifyKZGProof*(ctx: KzgCtx,
                    commitment: KzgBytes48,
                    z: KzgBytes32, # Input Point
                    y: KzgBytes32, # Claimed Value
                    proof: KzgBytes48): untyped =
   verifyProof(ctx, commitment, z, y, proof)
 
-template verifyBlobKzgProof*(ctx: KzgCtx,
+template verifyBlobKZGProof*(ctx: KzgCtx,
                    blob: KzgBlob,
                    commitment: KzgBytes48,
                    proof: KzgBytes48): untyped =
   verifyProof(ctx, blob, commitment, proof)
 
-template verifyBlobKzgProofBatch*(ctx: KzgCtx,
+template verifyBlobKZGProofBatch*(ctx: KzgCtx,
                    blobs: openArray[KzgBlob],
                    commitments: openArray[KzgBytes48],
                    proofs: openArray[KzgBytes48]): untyped =
   verifyProofs(ctx, blobs, commitments, proofs)
 
-template computeCellsAndKzgProofs*(ctx: KzgCtx,
+template computeCellsAndKZGProofs*(ctx: KzgCtx,
                    blob: KzgBlob): untyped =
   computeCellsAndProofs(ctx, blob)
 
-template recoverCellsAndKzgProofs*(ctx: KzgCtx,
+template recoverCellsAndKZGProofs*(ctx: KzgCtx,
                    cellIndices: openArray[uint64],
                    cells: openArray[KzgCell]): untyped =
   recoverCellsAndProofs(ctx, cellIndices, cells)
 
-template verifyCellKzgProofBatch*(ctx: KzgCtx,
+template verifyCellKZGProofBatch*(ctx: KzgCtx,
                    commitments: openArray[KzgBytes48],
                    cellIndices: openArray[uint64],
                    cells: openArray[KzgCell],

--- a/bindings/nim/kzg_abi.nim
+++ b/bindings/nim/kzg_abi.nim
@@ -56,40 +56,40 @@ func `==`*(a, b: KZG_RET): bool =
 
 type
   # Stores the setup and parameters needed for performing FFTs.
-  KzgSettings* {.importc: "KZGSettings",
+  KZGSettings* {.importc: "KZGSettings",
     header: "ckzg.h", byref.} = object
 
   # A basic blob data.
-  KzgBlob* {.importc: "Blob",
+  KZGBlob* {.importc: "Blob",
     header: "ckzg.h", completeStruct.} = object
     bytes*: array[BYTES_PER_BLOB, uint8]
 
   # An array of 48 bytes. Represents an untrusted
   # (potentially invalid) commitment/proof.
-  KzgBytes48* {.importc: "Bytes48",
+  KZGBytes48* {.importc: "Bytes48",
     header: "ckzg.h", completeStruct.} = object
     bytes*: array[48, uint8]
 
   # An array of 32 bytes. Represents an untrusted
   # (potentially invalid) field element.
-  KzgBytes32* {.importc: "Bytes32",
+  KZGBytes32* {.importc: "Bytes32",
     header: "ckzg.h", completeStruct.} = object
     bytes*: array[32, uint8]
 
   # A trusted (valid) KZG commitment.
-  KzgCommitment* = KzgBytes48
+  KZGCommitment* = KZGBytes48
 
   # A trusted (valid) KZG proof.
-  KzgProof* = KzgBytes48
+  KZGProof* = KZGBytes48
 
   # A single cell for a blob.
-  KzgCell* {.importc: "Cell",
+  KZGCell* {.importc: "Cell",
     header: "ckzg.h".} = object
     bytes*: array[BYTES_PER_CELL, uint8]
 
 {.pragma: kzg_abi, importc, cdecl, header: "ckzg.h".}
 
-proc load_trusted_setup*(res: KzgSettings,
+proc load_trusted_setup*(res: KZGSettings,
                          g1MonomialBytes: ptr byte,
                          numG1MonomialBytes: csize_t,
                          g1LagrangeBytes: ptr byte,
@@ -98,63 +98,63 @@ proc load_trusted_setup*(res: KzgSettings,
                          numG2MonomialBytes: csize_t,
                          precompute: csize_t): KZG_RET {.kzg_abi.}
 
-proc load_trusted_setup_file*(res: KzgSettings,
+proc load_trusted_setup_file*(res: KZGSettings,
                          input: File,
                          precompute: csize_t): KZG_RET {.kzg_abi.}
 
-proc free_trusted_setup*(s: KzgSettings) {.kzg_abi.}
+proc free_trusted_setup*(s: KZGSettings) {.kzg_abi.}
 
-proc blob_to_kzg_commitment*(res: var KzgCommitment,
-                         blob: ptr KzgBlob,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+proc blob_to_kzg_commitment*(res: var KZGCommitment,
+                         blob: ptr KZGBlob,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
-proc compute_kzg_proof*(res: var KzgProof,
-                         yOut: var KzgBytes32,
-                         blob: ptr KzgBlob,
-                         zBytes: ptr KzgBytes32,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+proc compute_kzg_proof*(res: var KZGProof,
+                         yOut: var KZGBytes32,
+                         blob: ptr KZGBlob,
+                         zBytes: ptr KZGBytes32,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
-proc compute_blob_kzg_proof*(res: var KzgProof,
-                         blob: ptr KzgBlob,
-                         commitmentBytes: ptr KzgBytes48,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+proc compute_blob_kzg_proof*(res: var KZGProof,
+                         blob: ptr KZGBlob,
+                         commitmentBytes: ptr KZGBytes48,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
 proc verify_kzg_proof*(res: var bool,
-                         commitmentBytes: ptr KzgBytes48,
-                         zBytes: ptr KzgBytes32,
-                         yBytes: ptr KzgBytes32,
-                         proofBytes: ptr KzgBytes48,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+                         commitmentBytes: ptr KZGBytes48,
+                         zBytes: ptr KZGBytes32,
+                         yBytes: ptr KZGBytes32,
+                         proofBytes: ptr KZGBytes48,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
 proc verify_blob_kzg_proof*(res: var bool,
-                         blob: ptr KzgBlob,
-                         commitmentsBytes: ptr KzgBytes48,
-                         proofBytes: ptr KzgBytes48,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+                         blob: ptr KZGBlob,
+                         commitmentsBytes: ptr KZGBytes48,
+                         proofBytes: ptr KZGBytes48,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
 proc verify_blob_kzg_proof_batch*(res: var bool,
-                         blobs: ptr KzgBlob,
-                         commitmentsBytes: ptr KzgBytes48,
-                         proofBytes: ptr KzgBytes48,
+                         blobs: ptr KZGBlob,
+                         commitmentsBytes: ptr KZGBytes48,
+                         proofBytes: ptr KZGBytes48,
                          n: csize_t,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
-proc compute_cells_and_kzg_proofs*(cellsOut: ptr KzgCell,
-                         proofsOut: ptr KzgProof,
-                         blob: ptr KzgBlob,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+proc compute_cells_and_kzg_proofs*(cellsOut: ptr KZGCell,
+                         proofsOut: ptr KZGProof,
+                         blob: ptr KZGBlob,
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
-proc recover_cells_and_kzg_proofs*(recoveredOut: ptr KzgCell,
-                         recoveredProofsOut: ptr KzgProof,
+proc recover_cells_and_kzg_proofs*(recoveredOut: ptr KZGCell,
+                         recoveredProofsOut: ptr KZGProof,
                          cellIndices: ptr uint64,
-                         cells: ptr KzgCell,
+                         cells: ptr KZGCell,
                          numCells: csize_t,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+                         s: KZGSettings): KZG_RET {.kzg_abi.}
 
 proc verify_cell_kzg_proof_batch*(res: var bool,
-                         commitments: ptr KzgBytes48,
+                         commitments: ptr KZGBytes48,
                          cellIndices: ptr uint64,
-                         cells: ptr KzgCell,
-                         proofs: ptr KzgBytes48,
+                         cells: ptr KZGCell,
+                         proofs: ptr KZGBytes48,
                          numCells: csize_t,
-                         s: KzgSettings): KZG_RET {.kzg_abi.}
+                         s: KZGSettings): KZG_RET {.kzg_abi.}

--- a/bindings/nim/kzg_ex.nim
+++ b/bindings/nim/kzg_ex.nim
@@ -1,5 +1,5 @@
 ############################################################
-# Convenience wrapper where KzgSettings is a global variable
+# Convenience wrapper where KZGSettings is a global variable
 ############################################################
 
 import
@@ -11,7 +11,7 @@ export
   kzg
 
 type
-  Kzg* = object
+  KZG* = object
 
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
@@ -22,7 +22,7 @@ else:
 # Private helpers
 ##############################################################
 
-var gCtx = KzgCtx(nil)
+var gCtx = KZGCtx(nil)
 
 const
   TrustedSetupNotLoadedErr = "Trusted setup not loaded."
@@ -48,19 +48,19 @@ template verifyCtx(body: untyped): untyped =
 # Public functions
 ##############################################################
 
-proc loadTrustedSetup*(_: type Kzg,
+proc loadTrustedSetup*(_: type KZG,
                        input: File,
                        precompute: Natural): Result[void, string] =
   setupCtx:
     kzg.loadTrustedSetup(input, precompute)
 
-proc loadTrustedSetup*(_: type Kzg,
+proc loadTrustedSetup*(_: type KZG,
                        fileName: string,
                        precompute: Natural): Result[void, string] =
   setupCtx:
     kzg.loadTrustedSetup(fileName, precompute)
 
-proc loadTrustedSetup*(_: type Kzg,
+proc loadTrustedSetup*(_: type KZG,
                        g1MonomialBytes: openArray[byte],
                        g1LagrangeBytes: openArray[byte],
                        g2MonomialBytes: openArray[byte],
@@ -69,66 +69,66 @@ proc loadTrustedSetup*(_: type Kzg,
   setupCtx:
     kzg.loadTrustedSetup(g1MonomialBytes, g1LagrangeBytes, g2MonomialBytes, precompute)
 
-proc loadTrustedSetupFromString*(_: type Kzg,
+proc loadTrustedSetupFromString*(_: type KZG,
                                  input: string,
                                  precompute: Natural): Result[void, string] =
   setupCtx:
     kzg.loadTrustedSetupFromString(input, precompute)
 
-proc freeTrustedSetup*(_: type Kzg): Result[void, string] =
+proc freeTrustedSetup*(_: type KZG): Result[void, string] =
   verifyCtx:
     gCtx.freeTrustedSetup()
     gCtx = nil
     ok()
 
-proc toCommitment*(blob: KzgBlob):
-                    Result[KzgCommitment, string] {.gcsafe.} =
+proc toCommitment*(blob: KZGBlob):
+                    Result[KZGCommitment, string] {.gcsafe.} =
   verifyCtx:
     gCtx.toCommitment(blob)
 
-proc computeProof*(blob: KzgBlob,
-                   z: KzgBytes32): Result[KzgProofAndY, string] {.gcsafe.} =
+proc computeProof*(blob: KZGBlob,
+                   z: KZGBytes32): Result[KZGProofAndY, string] {.gcsafe.} =
   verifyCtx:
     gCtx.computeProof(blob, z)
 
-proc computeProof*(blob: KzgBlob,
-                   commitmentBytes: KzgBytes48):
-                     Result[KzgProof, string] {.gcsafe.} =
+proc computeProof*(blob: KZGBlob,
+                   commitmentBytes: KZGBytes48):
+                     Result[KZGProof, string] {.gcsafe.} =
   verifyCtx:
     gCtx.computeProof(blob, commitmentBytes)
 
-proc verifyProof*(commitment: KzgBytes48,
-                  z: KzgBytes32, # Input Point
-                  y: KzgBytes32, # Claimed Value
-                  proof: KzgBytes48): Result[bool, string] {.gcsafe.} =
+proc verifyProof*(commitment: KZGBytes48,
+                  z: KZGBytes32, # Input Point
+                  y: KZGBytes32, # Claimed Value
+                  proof: KZGBytes48): Result[bool, string] {.gcsafe.} =
   verifyCtx:
     gCtx.verifyProof(commitment, z, y, proof)
 
-proc verifyProof*(blob: KzgBlob,
-                  commitment: KzgBytes48,
-                  proof: KzgBytes48): Result[bool, string] {.gcsafe.} =
+proc verifyProof*(blob: KZGBlob,
+                  commitment: KZGBytes48,
+                  proof: KZGBytes48): Result[bool, string] {.gcsafe.} =
   verifyCtx:
     gCtx.verifyProof(blob, commitment, proof)
 
-proc verifyProofs*(blobs: openArray[KzgBlob],
-                  commitments: openArray[KzgBytes48],
-                  proofs: openArray[KzgBytes48]): Result[bool, string] {.gcsafe.} =
+proc verifyProofs*(blobs: openArray[KZGBlob],
+                  commitments: openArray[KZGBytes48],
+                  proofs: openArray[KZGBytes48]): Result[bool, string] {.gcsafe.} =
   verifyCtx:
     gCtx.verifyProofs(blobs, commitments, proofs)
 
-proc computeCellsAndProofs*(blob: KzgBlob): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
+proc computeCellsAndProofs*(blob: KZGBlob): Result[KZGCellsAndKZGProofs, string] {.gcsafe.} =
   verifyCtx:
     gCtx.computeCellsAndProofs(blob)
 
 proc recoverCellsAndProofs*(cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell]): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
+                   cells: openArray[KZGCell]): Result[KZGCellsAndKZGProofs, string] {.gcsafe.} =
   verifyCtx:
     gCtx.recoverCellsAndProofs(cellIndices, cells)
 
-proc verifyProofs*(commitments: openArray[KzgBytes48],
+proc verifyProofs*(commitments: openArray[KZGBytes48],
                    cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell],
-                   proofs: openArray[KzgBytes48]): Result[bool, string] {.gcsafe.} =
+                   cells: openArray[KZGCell],
+                   proofs: openArray[KZGBytes48]): Result[bool, string] {.gcsafe.} =
   verifyCtx:
     gCtx.verifyProofs(commitments, cellIndices, cells, proofs)
 
@@ -136,46 +136,46 @@ proc verifyProofs*(commitments: openArray[KzgBytes48],
 # Zero overhead aliases that match the spec
 ##############################################################
 
-template loadTrustedSetupFile*(T: type Kzg, input: File | string, precompute: Natural): untyped =
+template loadTrustedSetupFile*(T: type KZG, input: File | string, precompute: Natural): untyped =
   loadTrustedSetup(T, input, precompute)
 
-template blobToKZGCommitment*(blob: KzgBlob): untyped =
+template blobToKZGCommitment*(blob: KZGBlob): untyped =
   toCommitment(blob)
 
-template computeKZGProof*(blob: KzgBlob, z: KzgBytes32): untyped =
+template computeKZGProof*(blob: KZGBlob, z: KZGBytes32): untyped =
   computeProof(blob, z)
 
-template computeBlobKZGProof*(blob: KzgBlob,
-                   commitmentBytes: KzgBytes48): untyped =
+template computeBlobKZGProof*(blob: KZGBlob,
+                   commitmentBytes: KZGBytes48): untyped =
   computeProof(blob, commitmentBytes)
 
-template verifyKZGProof*(commitment: KzgBytes48,
-                   z: KzgBytes32, # Input Point
-                   y: KzgBytes32, # Claimed Value
-                   proof: KzgBytes48): untyped =
+template verifyKZGProof*(commitment: KZGBytes48,
+                   z: KZGBytes32, # Input Point
+                   y: KZGBytes32, # Claimed Value
+                   proof: KZGBytes48): untyped =
   verifyProof(commitment, z, y, proof)
 
-template verifyBlobKZGProof*(blob: KzgBlob,
-                   commitment: KzgBytes48,
-                   proof: KzgBytes48): untyped =
+template verifyBlobKZGProof*(blob: KZGBlob,
+                   commitment: KZGBytes48,
+                   proof: KZGBytes48): untyped =
   verifyProof(blob, commitment, proof)
 
-template verifyBlobKZGProofBatch*(blobs: openArray[KzgBlob],
-                   commitments: openArray[KzgBytes48],
-                   proofs: openArray[KzgBytes48]): untyped =
+template verifyBlobKZGProofBatch*(blobs: openArray[KZGBlob],
+                   commitments: openArray[KZGBytes48],
+                   proofs: openArray[KZGBytes48]): untyped =
   verifyProofs(blobs, commitments, proofs)
 
-template computeCellsAndKZGProofs*(blob: KzgBlob): untyped =
+template computeCellsAndKZGProofs*(blob: KZGBlob): untyped =
   computeCellsAndProofs(blob)
 
 template recoverCellsAndKZGProofs*(cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell]): untyped =
+                   cells: openArray[KZGCell]): untyped =
   recoverCellsAndProofs(cellIndices, cells)
 
-template verifyCellKZGProofBatch*(commitments: openArray[KzgBytes48],
+template verifyCellKZGProofBatch*(commitments: openArray[KZGBytes48],
                    cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell],
-                   proofs: openArray[KzgBytes48]): untyped =
+                   cells: openArray[KZGCell],
+                   proofs: openArray[KZGBytes48]): untyped =
   verifyProofs(commitments, cellIndices, cells, proofs)
 
 {. pop .}

--- a/bindings/nim/kzg_ex.nim
+++ b/bindings/nim/kzg_ex.nim
@@ -116,12 +116,12 @@ proc verifyProofs*(blobs: openArray[KzgBlob],
   verifyCtx:
     gCtx.verifyProofs(blobs, commitments, proofs)
 
-proc computeCellsAndProofs*(blob: KzgBlob): Result[KzgCellsAndKzgProofs, string] {.gcsafe.} =
+proc computeCellsAndProofs*(blob: KzgBlob): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
   verifyCtx:
     gCtx.computeCellsAndProofs(blob)
 
 proc recoverCellsAndProofs*(cellIndices: openArray[uint64],
-                   cells: openArray[KzgCell]): Result[KzgCellsAndKzgProofs, string] {.gcsafe.} =
+                   cells: openArray[KzgCell]): Result[KzgCellsAndKZGProofs, string] {.gcsafe.} =
   verifyCtx:
     gCtx.recoverCellsAndProofs(cellIndices, cells)
 
@@ -139,40 +139,40 @@ proc verifyProofs*(commitments: openArray[KzgBytes48],
 template loadTrustedSetupFile*(T: type Kzg, input: File | string, precompute: Natural): untyped =
   loadTrustedSetup(T, input, precompute)
 
-template blobToKzgCommitment*(blob: KzgBlob): untyped =
+template blobToKZGCommitment*(blob: KzgBlob): untyped =
   toCommitment(blob)
 
-template computeKzgProof*(blob: KzgBlob, z: KzgBytes32): untyped =
+template computeKZGProof*(blob: KzgBlob, z: KzgBytes32): untyped =
   computeProof(blob, z)
 
-template computeBlobKzgProof*(blob: KzgBlob,
+template computeBlobKZGProof*(blob: KzgBlob,
                    commitmentBytes: KzgBytes48): untyped =
   computeProof(blob, commitmentBytes)
 
-template verifyKzgProof*(commitment: KzgBytes48,
+template verifyKZGProof*(commitment: KzgBytes48,
                    z: KzgBytes32, # Input Point
                    y: KzgBytes32, # Claimed Value
                    proof: KzgBytes48): untyped =
   verifyProof(commitment, z, y, proof)
 
-template verifyBlobKzgProof*(blob: KzgBlob,
+template verifyBlobKZGProof*(blob: KzgBlob,
                    commitment: KzgBytes48,
                    proof: KzgBytes48): untyped =
   verifyProof(blob, commitment, proof)
 
-template verifyBlobKzgProofBatch*(blobs: openArray[KzgBlob],
+template verifyBlobKZGProofBatch*(blobs: openArray[KzgBlob],
                    commitments: openArray[KzgBytes48],
                    proofs: openArray[KzgBytes48]): untyped =
   verifyProofs(blobs, commitments, proofs)
 
-template computeCellsAndKzgProofs*(blob: KzgBlob): untyped =
+template computeCellsAndKZGProofs*(blob: KzgBlob): untyped =
   computeCellsAndProofs(blob)
 
-template recoverCellsAndKzgProofs*(cellIndices: openArray[uint64],
+template recoverCellsAndKZGProofs*(cellIndices: openArray[uint64],
                    cells: openArray[KzgCell]): untyped =
   recoverCellsAndProofs(cellIndices, cells)
 
-template verifyCellKzgProofBatch*(commitments: openArray[KzgBytes48],
+template verifyCellKZGProofBatch*(commitments: openArray[KzgBytes48],
                    cellIndices: openArray[uint64],
                    cells: openArray[KzgCell],
                    proofs: openArray[KzgBytes48]): untyped =

--- a/bindings/nim/tests/test_abi.nim
+++ b/bindings/nim/tests/test_abi.nim
@@ -7,7 +7,7 @@ import
   ../kzg_abi,
   ./types
 
-proc readSetup(): KzgSettings =
+proc readSetup(): KZGSettings =
   var s = newFileStream(trustedSetupFile)
 
   doAssert(s.isNil.not,
@@ -45,15 +45,15 @@ proc readSetup(): KzgSettings =
   doAssert(res == KZG_OK,
     "ERROR: " & $res)
 
-proc readSetup(filename: string): KzgSettings =
+proc readSetup(filename: string): KZGSettings =
   var file = open(filename)
   let ret =  load_trusted_setup_file(result, file, 0)
   doAssert ret == KZG_OK
   file.close()
 
-proc createKateBlobs(s: KzgSettings, n: int): KateBlobs =
+proc createKateBlobs(s: KZGSettings, n: int): KateBlobs =
   for i in 0..<n:
-    var blob: KzgBlob
+    var blob: KZGBlob
     discard urandom(blob.bytes)
     for i in 0..<blob.bytes.len:
       # don't overflow modulus
@@ -62,7 +62,7 @@ proc createKateBlobs(s: KzgSettings, n: int): KateBlobs =
     result.blobs.add(blob)
 
   for i in 0..<n:
-    var kate: KzgCommitment
+    var kate: KZGCommitment
     doAssert blob_to_kzg_commitment(kate, result.blobs[i].addr, s) == KZG_OK
     result.kates.add(kate)
 
@@ -75,7 +75,7 @@ suite "verify proof (abi)":
 
   test "verify batch proof success":
     var kb = kzgs.createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
 
     for i in 0..<nblobs:
       let res = compute_blob_kzg_proof(kp[i], kb.blobs[i].addr, kb.kates[i].addr, kzgs)
@@ -93,7 +93,7 @@ suite "verify proof (abi)":
 
   test "verify batch proof failure":
     var kb = kzgs.createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
 
     for i in 0..<nblobs:
       let res = compute_blob_kzg_proof(kp[i], kb.blobs[i].addr, kb.kates[i].addr, kzgs)
@@ -115,7 +115,7 @@ suite "verify proof (abi)":
     check ok == false
 
   test "verify blob proof":
-    var kp: KzgProof
+    var kp: KZGProof
     var res = compute_blob_kzg_proof(kp, blob.addr, commitment.addr, kzgs)
     check res == KZG_OK
 
@@ -125,8 +125,8 @@ suite "verify proof (abi)":
     check ok
 
   test "verify proof":
-    var kp: KzgProof
-    var ky: KzgBytes32
+    var kp: KZGProof
+    var ky: KZGBytes32
     var res = compute_kzg_proof(kp, ky, blob.addr, inputPoint.addr, kzgs)
     check res == KZG_OK
     check kp == proof

--- a/bindings/nim/tests/test_kzg.nim
+++ b/bindings/nim/tests/test_kzg.nim
@@ -82,11 +82,11 @@ suite "verify proof (high-level)":
     check res.isOk
     ctx = res.get
 
-    discard ctx.blobToKzgCommitment(blob)
-    let kp = ctx.computeKzgProof(blob, inputPoint)
-    discard ctx.computeBlobKzgProof(blob, commitment)
-    discard ctx.verifyKzgProof(commitment, inputPoint, claimedValue, kp.get.proof)
-    discard ctx.verifyBlobKzgProof(blob, commitment, proof)
+    discard ctx.blobToKZGCommitment(blob)
+    let kp = ctx.computeKZGProof(blob, inputPoint)
+    discard ctx.computeBlobKZGProof(blob, commitment)
+    discard ctx.verifyKZGProof(commitment, inputPoint, claimedValue, kp.get.proof)
+    discard ctx.verifyBlobKZGProof(blob, commitment, proof)
 
     let kb = ctx.createKateBlobs(1)
-    discard ctx.verifyBlobKzgProofBatch(kb.blobs, kb.kates, [kp.get.proof])
+    discard ctx.verifyBlobKZGProofBatch(kb.blobs, kb.kates, [kp.get.proof])

--- a/bindings/nim/tests/test_kzg.nim
+++ b/bindings/nim/tests/test_kzg.nim
@@ -5,8 +5,8 @@ import
   ../kzg,
   ./types
 
-proc createKateBlobs(ctx: KzgCtx, n: int): KateBlobs =
-  var blob: KzgBlob
+proc createKateBlobs(ctx: KZGCtx, n: int): KateBlobs =
+  var blob: KZGBlob
   for i in 0..<n:
     discard urandom(blob.bytes)
     for i in 0..<blob.bytes.len:
@@ -21,7 +21,7 @@ proc createKateBlobs(ctx: KzgCtx, n: int): KateBlobs =
     result.kates.add(res.get)
 
 suite "verify proof (high-level)":
-  var ctx: KzgCtx
+  var ctx: KZGCtx
 
   test "load trusted setup from string":
     let res = loadTrustedSetupFromString(trustedSetup, 0)
@@ -30,7 +30,7 @@ suite "verify proof (high-level)":
 
   test "verify batch proof success":
     let kb = ctx.createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = ctx.computeProof(kb.blobs[i], kb.kates[i])
       check pres.isOk
@@ -42,14 +42,14 @@ suite "verify proof (high-level)":
 
   test "verify batch proof failure":
     let kb = ctx.createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = ctx.computeProof(kb.blobs[i], kb.kates[i])
       check pres.isOk
       kp[i] = pres.get
 
     let other = ctx.createKateBlobs(nblobs)
-    var badProofs: array[nblobs, KzgProof]
+    var badProofs: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = ctx.computeProof(other.blobs[i], other.kates[i])
       check pres.isOk

--- a/bindings/nim/tests/test_kzg_ex.nim
+++ b/bindings/nim/tests/test_kzg_ex.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 proc createKateBlobs(n: int): KateBlobs =
-  var blob: KzgBlob
+  var blob: KZGBlob
   for i in 0..<n:
     discard urandom(blob.bytes)
     for i in 0..<blob.bytes.len:
@@ -22,12 +22,12 @@ proc createKateBlobs(n: int): KateBlobs =
 
 suite "verify proof (extended version)":
   test "load trusted setup from string":
-    let res = Kzg.loadTrustedSetupFromString(trustedSetup, 0)
+    let res = KZG.loadTrustedSetupFromString(trustedSetup, 0)
     check res.isOk
 
   test "verify batch proof success":
     let kb = createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = computeProof(kb.blobs[i], kb.kates[i])
       check pres.isOk
@@ -39,14 +39,14 @@ suite "verify proof (extended version)":
 
   test "verify batch proof failure":
     let kb = createKateBlobs(nblobs)
-    var kp: array[nblobs, KzgProof]
+    var kp: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = computeProof(kb.blobs[i], kb.kates[i])
       check pres.isOk
       kp[i] = pres.get
 
     let other = createKateBlobs(nblobs)
-    var badProofs: array[nblobs, KzgProof]
+    var badProofs: array[nblobs, KZGProof]
     for i in 0..<nblobs:
       let pres = computeProof(other.blobs[i], other.kates[i])
       check pres.isOk
@@ -75,8 +75,8 @@ suite "verify proof (extended version)":
   test "template aliases":
     # no need to check return value
     # only test if those templates can be compiled successfully
-    check Kzg.freeTrustedSetup().isOk
-    check Kzg.loadTrustedSetupFile(trustedSetupFile, 0).isOk
+    check KZG.freeTrustedSetup().isOk
+    check KZG.loadTrustedSetupFile(trustedSetupFile, 0).isOk
     discard blobToKZGCommitment(blob)
     let kp = computeKZGProof(blob, inputPoint)
     discard computeBlobKZGProof(blob, commitment)
@@ -86,5 +86,5 @@ suite "verify proof (extended version)":
     discard verifyBlobKZGProofBatch(kb.blobs, kb.kates, [kp.get.proof])
 
   test "load trusted setup more than once":
-    let res = Kzg.loadTrustedSetupFromString(trustedSetup, 0)
+    let res = KZG.loadTrustedSetupFromString(trustedSetup, 0)
     check res.isErr

--- a/bindings/nim/tests/test_kzg_ex.nim
+++ b/bindings/nim/tests/test_kzg_ex.nim
@@ -77,13 +77,13 @@ suite "verify proof (extended version)":
     # only test if those templates can be compiled successfully
     check Kzg.freeTrustedSetup().isOk
     check Kzg.loadTrustedSetupFile(trustedSetupFile, 0).isOk
-    discard blobToKzgCommitment(blob)
-    let kp = computeKzgProof(blob, inputPoint)
-    discard computeBlobKzgProof(blob, commitment)
-    discard verifyKzgProof(commitment, inputPoint, claimedValue, kp.get.proof)
-    discard verifyBlobKzgProof(blob, commitment, proof)
+    discard blobToKZGCommitment(blob)
+    let kp = computeKZGProof(blob, inputPoint)
+    discard computeBlobKZGProof(blob, commitment)
+    discard verifyKZGProof(commitment, inputPoint, claimedValue, kp.get.proof)
+    discard verifyBlobKZGProof(blob, commitment, proof)
     let kb = createKateBlobs(1)
-    discard verifyBlobKzgProofBatch(kb.blobs, kb.kates, [kp.get.proof])
+    discard verifyBlobKZGProofBatch(kb.blobs, kb.kates, [kp.get.proof])
 
   test "load trusted setup more than once":
     let res = Kzg.loadTrustedSetupFromString(trustedSetup, 0)

--- a/bindings/nim/tests/test_yaml.nim
+++ b/bindings/nim/tests/test_yaml.nim
@@ -72,11 +72,11 @@ template checkBool(res: untyped) =
 
 template checkBytes48(res: untyped) =
   checkRes(res):
-    let bytes = KzgBytes48.fromHex(n["output"])
+    let bytes = KZGBytes48.fromHex(n["output"])
     check bytes == res.get
 
 suite "yaml tests":
-  var ctx: KzgCtx
+  var ctx: KZGCtx
 
   test "load trusted setup from string":
     let res = loadTrustedSetupFromString(trustedSetup, 8)
@@ -85,82 +85,82 @@ suite "yaml tests":
 
   runTests(BLOB_TO_KZG_COMMITMENT_TESTS):
     let
-      blob = KzgBlob.fromHex(n["input"]["blob"])
+      blob = KZGBlob.fromHex(n["input"]["blob"])
       res = ctx.toCommitment(blob)
     checkBytes48(res)
 
   runTests(COMPUTE_KZG_PROOF_TESTS):
     let
-      blob = KzgBlob.fromHex(n["input"]["blob"])
-      zBytes = KzgBytes32.fromHex(n["input"]["z"])
+      blob = KZGBlob.fromHex(n["input"]["blob"])
+      zBytes = KZGBytes32.fromHex(n["input"]["z"])
       res = ctx.computeProof(blob, zBytes)
 
     checkRes(res):
-      let proof = KzgProof.fromHex(n["output"][0])
+      let proof = KZGProof.fromHex(n["output"][0])
       check proof == res.get.proof
-      let y = KzgBytes32.fromHex(n["output"][1])
+      let y = KZGBytes32.fromHex(n["output"][1])
       check y == res.get.y
 
   runTests(COMPUTE_BLOB_KZG_PROOF_TESTS):
     let
-      blob = KzgBlob.fromHex(n["input"]["blob"])
-      commitment = KzgCommitment.fromHex(n["input"]["commitment"])
+      blob = KZGBlob.fromHex(n["input"]["blob"])
+      commitment = KZGCommitment.fromHex(n["input"]["commitment"])
       res = ctx.computeProof(blob, commitment)
     checkBytes48(res)
 
   runTests(VERIFY_KZG_PROOF_TESTS):
     let
-      commitment = KzgCommitment.fromHex(n["input"]["commitment"])
-      z = KzgBytes32.fromHex(n["input"]["z"])
-      y = KzgBytes32.fromHex(n["input"]["y"])
-      proof = KzgProof.fromHex(n["input"]["proof"])
+      commitment = KZGCommitment.fromHex(n["input"]["commitment"])
+      z = KZGBytes32.fromHex(n["input"]["z"])
+      y = KZGBytes32.fromHex(n["input"]["y"])
+      proof = KZGProof.fromHex(n["input"]["proof"])
       res = ctx.verifyProof(commitment, z, y, proof)
     checkBool(res)
 
   runTests(VERIFY_BLOB_KZG_PROOF_TESTS):
     let
-      blob = KzgBlob.fromHex(n["input"]["blob"])
-      commitment = KzgCommitment.fromHex(n["input"]["commitment"])
-      proof = KzgProof.fromHex(n["input"]["proof"])
+      blob = KZGBlob.fromHex(n["input"]["blob"])
+      commitment = KZGCommitment.fromHex(n["input"]["commitment"])
+      proof = KZGProof.fromHex(n["input"]["proof"])
       res = ctx.verifyProof(blob, commitment, proof)
     checkBool(res)
 
   runTests(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS):
     let
-      blobs = KzgBlob.fromHexList(n["input"]["blobs"])
-      commitments = KzgCommitment.fromHexList(n["input"]["commitments"])
-      proofs = KzgProof.fromHexList(n["input"]["proofs"])
+      blobs = KZGBlob.fromHexList(n["input"]["blobs"])
+      commitments = KZGCommitment.fromHexList(n["input"]["commitments"])
+      proofs = KZGProof.fromHexList(n["input"]["proofs"])
       res = ctx.verifyProofs(blobs, commitments, proofs)
     checkBool(res)
 
   runTests(COMPUTE_CELLS_AND_KZG_PROOFS_TESTS):
     let
-      blob = KzgBlob.fromHex(n["input"]["blob"])
+      blob = KZGBlob.fromHex(n["input"]["blob"])
       res = ctx.computeCellsAndProofs(blob)
 
     checkRes(res):
-      let cells = KzgCell.fromHexList(n["output"][0])
+      let cells = KZGCell.fromHexList(n["output"][0])
       check cells == res.get.cells
-      let proofs = KzgProof.fromHexList(n["output"][1])
+      let proofs = KZGProof.fromHexList(n["output"][1])
       check proofs == res.get.proofs
 
   runTests(RECOVER_CELLS_AND_KZG_PROOFS_TESTS):
     let
       cellIndices = uint64.fromIntList(n["input"]["cell_indices"])
-      cells = KzgCell.fromHexList(n["input"]["cells"])
+      cells = KZGCell.fromHexList(n["input"]["cells"])
       res = ctx.recoverCellsAndProofs(cellIndices, cells)
 
     checkRes(res):
-      let expectedCells = KzgCell.fromHexList(n["output"][0])
+      let expectedCells = KZGCell.fromHexList(n["output"][0])
       check expectedCells == res.get.cells
-      let expectedProofs = KzgProof.fromHexList(n["output"][1])
+      let expectedProofs = KZGProof.fromHexList(n["output"][1])
       check expectedProofs == res.get.proofs
 
   runTests(VERIFY_CELL_KZG_PROOF_BATCH_TESTS):
     let
-      commitments = KzgCommitment.fromHexList(n["input"]["commitments"])
+      commitments = KZGCommitment.fromHexList(n["input"]["commitments"])
       cellIndices = uint64.fromIntList(n["input"]["cell_indices"])
-      cells = KzgCell.fromHexList(n["input"]["cells"])
-      proofs = KzgProof.fromHexList(n["input"]["proofs"])
+      cells = KZGCell.fromHexList(n["input"]["cells"])
+      proofs = KZGProof.fromHexList(n["input"]["proofs"])
       res = ctx.verifyProofs(commitments, cellIndices, cells, proofs)
     checkBool(res)

--- a/bindings/nim/tests/types.nim
+++ b/bindings/nim/tests/types.nim
@@ -7,8 +7,8 @@ from os import DirSep
 
 type
   KateBlobs* = object
-    kates*: seq[KzgCommitment]
-    blobs*: seq[KzgBlob]
+    kates*: seq[KZGCommitment]
+    blobs*: seq[KZGBlob]
 
 const
   kzgPath* = currentSourcePath.rsplit(DirSep, 4)[0] & "/"
@@ -23,11 +23,11 @@ const
   trustedSetup* = staticRead(trustedSetupFile)
 
 var
-  blob* = KzgBlob(bytes: blobBytes)
-  commitment* = KzgCommitment(bytes: commitmentBytes)
-  proof* = KzgProof(bytes: proofBytes)
-  inputPoint* = KzgBytes32(bytes: inputPointBytes)
-  claimedValue* = KzgBytes32(bytes: claimedValueBytes)
+  blob* = KZGBlob(bytes: blobBytes)
+  commitment* = KZGCommitment(bytes: commitmentBytes)
+  proof* = KZGProof(bytes: proofBytes)
+  inputPoint* = KZGBytes32(bytes: inputPointBytes)
+  claimedValue* = KZGBytes32(bytes: claimedValueBytes)
 
 when (NimMajor, NimMinor) > (1, 4):
   import std/sysrand

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -34,9 +34,9 @@ import {
   BYTES_PER_BLOB,
   Blob,
   Bytes48,
-  blobToKzgCommitment,
-  computeBlobKzgProof,
-  verifyBlobKzgProofBatch,
+  blobToKZGCommitment,
+  computeBlobKZGProof,
+  verifyBlobKZGProofBatch,
 } from "c-kzg";
 
 const blobs = [] as Blob[];
@@ -45,11 +45,11 @@ const proofs = [] as Bytes48[];
 
 for (let i = 0; i < BATCH_SIZE; i++) {
   blobs.push(Buffer.alloc(BYTES_PER_BLOB, "*"));
-  commitments.push(blobToKzgCommitment(blobs[i]));
-  proofs.push(computeBlobKzgProof(blobs[i], commitments[i]));
+  commitments.push(blobToKZGCommitment(blobs[i]));
+  proofs.push(computeBlobKZGProof(blobs[i], commitments[i]));
 }
 
-const isValid = verifyBlobKzgProofBatch(blobs, commitments, proofs);
+const isValid = verifyBlobKZGProofBatch(blobs, commitments, proofs);
 ```
 
 ## API
@@ -78,7 +78,7 @@ const isValid = verifyBlobKzgProofBatch(blobs, commitments, proofs);
 loadTrustedSetup(filePath: string): void;
 ```
 
-### `blobToKzgCommitment`
+### `blobToKZGCommitment`
 
 ```ts
 /**
@@ -86,10 +86,10 @@ loadTrustedSetup(filePath: string): void;
  *
  * @param {Blob} blob - The blob representing the polynomial to be committed to
  */
-blobToKzgCommitment(blob: Blob): KZGCommitment;
+blobToKZGCommitment(blob: Blob): KZGCommitment;
 ```
 
-### `computeKzgProof`
+### `computeKZGProof`
 
 ```ts
 /**
@@ -101,10 +101,10 @@ blobToKzgCommitment(blob: Blob): KZGCommitment;
  * @return {ProofResult} - Tuple containing the resulting proof and evaluation
  *                         of the polynomial at the evaluation point z
  */
-computeKzgProof(blob: Blob, zBytes: Bytes32): ProofResult;
+computeKZGProof(blob: Blob, zBytes: Bytes32): ProofResult;
 ```
 
-### `computeBlobKzgProof`
+### `computeBlobKZGProof`
 
 ```ts
 /**
@@ -114,13 +114,13 @@ computeKzgProof(blob: Blob, zBytes: Bytes32): ProofResult;
  * @param {Blob}    blob - The blob (polynomial) to generate a proof for
  * @param {Bytes48} commitmentBytes - Commitment to verify
  */
-computeBlobKzgProof(
+computeBlobKZGProof(
   blob: Blob,
   commitmentBytes: Bytes48,
 ): KZGProof;
 ```
 
-### `verifyKzgProof`
+### `verifyKZGProof`
 
 ```ts
 /**
@@ -132,7 +132,7 @@ computeBlobKzgProof(
  * @param {Bytes32} yBytes - The serialized claimed evaluation result
  * @param {Bytes48} proofBytes - The serialized KZG proof
  */
-verifyKzgProof(
+verifyKZGProof(
   commitmentBytes: Bytes48,
   zBytes: Bytes32,
   yBytes: Bytes32,
@@ -140,7 +140,7 @@ verifyKzgProof(
 ): boolean;
 ```
 
-### `verifyBlobKzgProof`
+### `verifyBlobKZGProof`
 
 ```ts
 /**
@@ -151,14 +151,14 @@ verifyKzgProof(
  * @param {Bytes48} commitmentBytes - The serialized commitment to verify
  * @param {Bytes48} proofBytes - The serialized KZG proof for verification
  */
-verifyBlobKzgProof(
+verifyBlobKZGProof(
   blob: Blob,
   commitmentBytes: Bytes48,
   proofBytes: Bytes48,
 ): boolean;
 ```
 
-### `verifyBlobKzgProofBatch`
+### `verifyBlobKZGProofBatch`
 
 ```ts
 /**
@@ -173,14 +173,14 @@ verifyBlobKzgProof(
  * @param {Bytes48} proofBytes - An array of serialized KZG proofs for
  *                               verification
  */
-verifyBlobKzgProofBatch(
+verifyBlobKZGProofBatch(
   blobs: Blob[],
   commitmentsBytes: Bytes48[],
   proofsBytes: Bytes48[],
 ): boolean;
 ```
 
-### `computeCellsAndKzgProofs`
+### `computeCellsAndKZGProofs`
 
 ```ts
 /**
@@ -192,10 +192,10 @@ verifyBlobKzgProofBatch(
  *
  * @throws {Error} - Failure to allocate or compute cells and proofs
  */
-export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
+export function computeCellsAndKZGProofs(blob: Blob): [Cell[], KZGProof[]];
 ```
 
-### `recoverCellsAndKzgProofs`
+### `recoverCellsAndKZGProofs`
 
 ```ts
 /**
@@ -209,13 +209,13 @@ export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
  * @throws {Error} - Invalid input, failure to allocate or error recovering
  * cells and proofs
  */
-export function recoverCellsAndKzgProofs(
+export function recoverCellsAndKZGProofs(
   cellIndices: number[],
   cells: Cell[],
 ): [Cell[], KZGProof[]];
 ```
 
-### `verifyCellKzgProofBatch`
+### `verifyCellKZGProofBatch`
 
 ```ts
 /**
@@ -230,7 +230,7 @@ export function recoverCellsAndKzgProofs(
  *
  * @throws {Error} - Invalid input, failure to allocate memory, or errors verifying batch
  */
-export function verifyCellKzgProofBatch(
+export function verifyCellKZGProofBatch(
   commitmentsBytes: Bytes48[],
   cellIndices: number[],
   cells: Cell[],

--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -57,7 +57,7 @@ export function loadTrustedSetup(precompute: number, filePath?: string): void;
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function blobToKzgCommitment(blob: Blob): KZGCommitment;
+export function blobToKZGCommitment(blob: Blob): KZGCommitment;
 
 /**
  * Compute KZG proof for polynomial in Lagrange form at position z.
@@ -70,7 +70,7 @@ export function blobToKzgCommitment(blob: Blob): KZGCommitment;
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function computeKzgProof(blob: Blob, zBytes: Bytes32): ProofResult;
+export function computeKZGProof(blob: Blob, zBytes: Bytes32): ProofResult;
 
 /**
  * Given a blob, return the KZG proof that is used to verify it against the
@@ -83,7 +83,7 @@ export function computeKzgProof(blob: Blob, zBytes: Bytes32): ProofResult;
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function computeBlobKzgProof(blob: Blob, commitmentBytes: Bytes48): KZGProof;
+export function computeBlobKZGProof(blob: Blob, commitmentBytes: Bytes48): KZGProof;
 
 /**
  * Verify a KZG poof claiming that `p(z) == y`.
@@ -97,7 +97,7 @@ export function computeBlobKzgProof(blob: Blob, commitmentBytes: Bytes48): KZGPr
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function verifyKzgProof(
+export function verifyKZGProof(
   commitmentBytes: Bytes48,
   zBytes: Bytes32,
   yBytes: Bytes32,
@@ -116,7 +116,7 @@ export function verifyKzgProof(
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function verifyBlobKzgProof(blob: Blob, commitmentBytes: Bytes48, proofBytes: Bytes48): boolean;
+export function verifyBlobKZGProof(blob: Blob, commitmentBytes: Bytes48, proofBytes: Bytes48): boolean;
 
 /**
  * Given an array of blobs and their proofs, verify that they correspond to their
@@ -132,7 +132,7 @@ export function verifyBlobKzgProof(blob: Blob, commitmentBytes: Bytes48, proofBy
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-export function verifyBlobKzgProofBatch(blobs: Blob[], commitmentsBytes: Bytes48[], proofsBytes: Bytes48[]): boolean;
+export function verifyBlobKZGProofBatch(blobs: Blob[], commitmentsBytes: Bytes48[], proofsBytes: Bytes48[]): boolean;
 
 /**
  * Get the cells and proofs for a given blob.
@@ -143,7 +143,7 @@ export function verifyBlobKzgProofBatch(blobs: Blob[], commitmentsBytes: Bytes48
  *
  * @throws {Error} - Failure to allocate or compute cells and proofs
  */
-export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
+export function computeCellsAndKZGProofs(blob: Blob): [Cell[], KZGProof[]];
 
 /**
  * Given at least 50% of cells, reconstruct the missing cells/proofs.
@@ -156,7 +156,7 @@ export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
  * @throws {Error} - Invalid input, failure to allocate or error recovering
  * cells and proofs
  */
-export function recoverCellsAndKzgProofs(cellIndices: number[], cells: Cell[]): [Cell[], KZGProof[]];
+export function recoverCellsAndKZGProofs(cellIndices: number[], cells: Cell[]): [Cell[], KZGProof[]];
 
 /**
  * Verify that multiple cells' proofs are valid.
@@ -170,7 +170,7 @@ export function recoverCellsAndKzgProofs(cellIndices: number[], cells: Cell[]): 
  *
  * @throws {Error} - Invalid input, failure to allocate memory, or errors verifying batch
  */
-export function verifyCellKzgProofBatch(
+export function verifyCellKZGProofBatch(
   commitmentsBytes: Bytes48[],
   cellIndices: number[],
   cells: Cell[],

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -229,7 +229,7 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - For invalid arguments or failure of the native library
  */
-Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo &info) {
+Napi::Value BlobToKZGCommitment(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Blob *blob = get_blob(env, info[0]);
     if (blob == nullptr) {
@@ -265,7 +265,7 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - for invalid arguments or failure of the native library
  */
-Napi::Value ComputeKzgProof(const Napi::CallbackInfo &info) {
+Napi::Value ComputeKZGProof(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Blob *blob = get_blob(env, info[0]);
     if (blob == nullptr) {
@@ -314,7 +314,7 @@ Napi::Value ComputeKzgProof(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - for invalid arguments or failure of the native library
  */
-Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo &info) {
+Napi::Value ComputeBlobKZGProof(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Blob *blob = get_blob(env, info[0]);
     if (blob == nullptr) {
@@ -336,7 +336,7 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo &info) {
 
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in computeBlobKzgProof: " << from_c_kzg_ret(ret);
+        msg << "Error in computeBlobKZGProof: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         return env.Undefined();
     }
@@ -359,7 +359,7 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - for invalid arguments or failure of the native library
  */
-Napi::Value VerifyKzgProof(const Napi::CallbackInfo &info) {
+Napi::Value VerifyKZGProof(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Bytes48 *commitment_bytes = get_bytes48(env, info[0], "commitmentBytes");
     if (commitment_bytes == nullptr) {
@@ -409,7 +409,7 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - for invalid arguments or failure of the native library
  */
-Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo &info) {
+Napi::Value VerifyBlobKZGProof(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Blob *blob_bytes = get_blob(env, info[0]);
     if (blob_bytes == nullptr) {
@@ -435,7 +435,7 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo &info) {
 
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in verifyBlobKzgProof: " << from_c_kzg_ret(ret);
+        msg << "Error in verifyBlobKZGProof: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         return env.Undefined();
     }
@@ -459,7 +459,7 @@ Napi::Value VerifyBlobKzgProof(const Napi::CallbackInfo &info) {
  *
  * @throws {TypeError} - for invalid arguments or failure of the native library
  */
-Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo &info) {
+Napi::Value VerifyBlobKZGProofBatch(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     C_KZG_RET ret;
     Blob *blobs = NULL;
@@ -537,7 +537,7 @@ Napi::Value VerifyBlobKzgProofBatch(const Napi::CallbackInfo &info) {
 
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in verifyBlobKzgProofBatch: " << from_c_kzg_ret(ret);
+        msg << "Error in verifyBlobKZGProofBatch: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -560,7 +560,7 @@ out:
  *
  * @throws {Error} - Failure to allocate or compute cells and proofs
  */
-Napi::Value ComputeCellsAndKzgProofs(const Napi::CallbackInfo &info) {
+Napi::Value ComputeCellsAndKZGProofs(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Napi::Value result = env.Null();
     Blob *blob = get_blob(env, info[0]);
@@ -582,7 +582,7 @@ Napi::Value ComputeCellsAndKzgProofs(const Napi::CallbackInfo &info) {
     cells = (Cell *)calloc(CELLS_PER_EXT_BLOB, BYTES_PER_CELL);
     if (cells == nullptr) {
         std::ostringstream msg;
-        msg << "Failed to allocate cells in computeCellsAndKzgProofs";
+        msg << "Failed to allocate cells in computeCellsAndKZGProofs";
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -590,7 +590,7 @@ Napi::Value ComputeCellsAndKzgProofs(const Napi::CallbackInfo &info) {
     proofs = (KZGProof *)calloc(CELLS_PER_EXT_BLOB, BYTES_PER_PROOF);
     if (proofs == nullptr) {
         std::ostringstream msg;
-        msg << "Failed to allocate proofs in computeCellsAndKzgProofs";
+        msg << "Failed to allocate proofs in computeCellsAndKZGProofs";
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -598,7 +598,7 @@ Napi::Value ComputeCellsAndKzgProofs(const Napi::CallbackInfo &info) {
     ret = compute_cells_and_kzg_proofs(cells, proofs, blob, kzg_settings);
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in computeCellsAndKzgProofs: " << from_c_kzg_ret(ret);
+        msg << "Error in computeCellsAndKZGProofs: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -642,7 +642,7 @@ out:
  * @throws {Error} - Invalid input, failure to allocate or error recovering
  * cells and proofs
  */
-Napi::Value RecoverCellsAndKzgProofs(const Napi::CallbackInfo &info) {
+Napi::Value RecoverCellsAndKZGProofs(const Napi::CallbackInfo &info) {
     C_KZG_RET ret;
     uint64_t *cell_indices = NULL;
     Cell *cells = NULL;
@@ -734,7 +734,7 @@ Napi::Value RecoverCellsAndKzgProofs(const Napi::CallbackInfo &info) {
     );
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in recoverCellsAndKzgProofs: " << from_c_kzg_ret(ret);
+        msg << "Error in recoverCellsAndKZGProofs: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -786,7 +786,7 @@ out:
  * @throws {Error} - Invalid input, failure to allocate memory, or errors
  * verifying batch
  */
-Napi::Value VerifyCellKzgProofBatch(const Napi::CallbackInfo &info) {
+Napi::Value VerifyCellKZGProofBatch(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Napi::Value result = env.Null();
     if (!(info[0].IsArray() && info[1].IsArray() && info[2].IsArray() &&
@@ -885,7 +885,7 @@ Napi::Value VerifyCellKzgProofBatch(const Napi::CallbackInfo &info) {
     );
     if (ret != C_KZG_OK) {
         std::ostringstream msg;
-        msg << "Error in verifyCellKzgProofBatch: " << from_c_kzg_ret(ret);
+        msg << "Error in verifyCellKZGProofBatch: " << from_c_kzg_ret(ret);
         Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
         goto out;
     }
@@ -922,32 +922,32 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports["loadTrustedSetup"] = Napi::Function::New(
         env, LoadTrustedSetup, "setup"
     );
-    exports["blobToKzgCommitment"] = Napi::Function::New(
-        env, BlobToKzgCommitment, "blobToKzgCommitment"
+    exports["blobToKZGCommitment"] = Napi::Function::New(
+        env, BlobToKZGCommitment, "blobToKZGCommitment"
     );
-    exports["computeKzgProof"] = Napi::Function::New(
-        env, ComputeKzgProof, "computeKzgProof"
+    exports["computeKZGProof"] = Napi::Function::New(
+        env, ComputeKZGProof, "computeKZGProof"
     );
-    exports["computeBlobKzgProof"] = Napi::Function::New(
-        env, ComputeBlobKzgProof, "computeBlobKzgProof"
+    exports["computeBlobKZGProof"] = Napi::Function::New(
+        env, ComputeBlobKZGProof, "computeBlobKZGProof"
     );
-    exports["verifyKzgProof"] = Napi::Function::New(
-        env, VerifyKzgProof, "verifyKzgProof"
+    exports["verifyKZGProof"] = Napi::Function::New(
+        env, VerifyKZGProof, "verifyKZGProof"
     );
-    exports["verifyBlobKzgProof"] = Napi::Function::New(
-        env, VerifyBlobKzgProof, "verifyBlobKzgProof"
+    exports["verifyBlobKZGProof"] = Napi::Function::New(
+        env, VerifyBlobKZGProof, "verifyBlobKZGProof"
     );
-    exports["verifyBlobKzgProofBatch"] = Napi::Function::New(
-        env, VerifyBlobKzgProofBatch, "verifyBlobKzgProofBatch"
+    exports["verifyBlobKZGProofBatch"] = Napi::Function::New(
+        env, VerifyBlobKZGProofBatch, "verifyBlobKZGProofBatch"
     );
-    exports["computeCellsAndKzgProofs"] = Napi::Function::New(
-        env, ComputeCellsAndKzgProofs, "computeCellsAndKzgProofs"
+    exports["computeCellsAndKZGProofs"] = Napi::Function::New(
+        env, ComputeCellsAndKZGProofs, "computeCellsAndKZGProofs"
     );
-    exports["recoverCellsAndKzgProofs"] = Napi::Function::New(
-        env, RecoverCellsAndKzgProofs, "recoverCellsAndKzgProofs"
+    exports["recoverCellsAndKZGProofs"] = Napi::Function::New(
+        env, RecoverCellsAndKZGProofs, "recoverCellsAndKZGProofs"
     );
-    exports["verifyCellKzgProofBatch"] = Napi::Function::New(
-        env, VerifyCellKzgProofBatch, "verifyCellKzgProofBatch"
+    exports["verifyCellKZGProofBatch"] = Napi::Function::New(
+        env, VerifyCellKZGProofBatch, "verifyCellKZGProofBatch"
     );
 
     // Constants

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -43,7 +43,7 @@ std::string from_c_kzg_ret(C_KZG_RET ret) {
 typedef struct {
     bool is_setup;
     KZGSettings settings;
-} KzgAddonData;
+} KZGAddonData;
 
 /**
  * This cleanup function follows the `napi_finalize` interface and will be
@@ -54,12 +54,12 @@ typedef struct {
  *         the cleanup.
  *
  * @param[in] env  (unused)
- * @param[in] data Pointer KzgAddonData stored by the runtime
+ * @param[in] data Pointer KZGAddonData stored by the runtime
  * @param[in] hint (unused)
  */
 void delete_kzg_addon_data(napi_env /*env*/, void *data, void * /*hint*/) {
-    if (((KzgAddonData *)data)->is_setup) {
-        free_trusted_setup(&((KzgAddonData *)data)->settings);
+    if (((KZGAddonData *)data)->is_setup) {
+        free_trusted_setup(&((KZGAddonData *)data)->settings);
     }
     free(data);
 }
@@ -81,7 +81,7 @@ void delete_kzg_addon_data(napi_env /*env*/, void *data, void * /*hint*/) {
  * @return - Pointer to the KZGSettings
  */
 KZGSettings *get_kzg_settings(Napi::Env &env, const Napi::CallbackInfo &info) {
-    KzgAddonData *data = env.GetInstanceData<KzgAddonData>();
+    KZGAddonData *data = env.GetInstanceData<KZGAddonData>();
     if (!data->is_setup) {
         Napi::Error::New(
             env,
@@ -179,7 +179,7 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     // Check if the trusted setup is already loaded
-    KzgAddonData *data = env.GetInstanceData<KzgAddonData>();
+    KZGAddonData *data = env.GetInstanceData<KZGAddonData>();
     if (data->is_setup) {
         Napi::Error::New(env, "Error trusted setup is already loaded")
             .ThrowAsJavaScriptException();
@@ -902,7 +902,7 @@ out:
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-    KzgAddonData *data = (KzgAddonData *)malloc(sizeof(KzgAddonData));
+    KZGAddonData *data = (KZGAddonData *)malloc(sizeof(KZGAddonData));
     if (data == nullptr) {
         Napi::Error::New(env, "Error allocating memory for kzg setup handle")
             .ThrowAsJavaScriptException();

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -15,20 +15,20 @@ import type {ProofResult} from "../lib/kzg";
 const {
   // EIP-4844
   loadTrustedSetup,
-  blobToKzgCommitment,
-  computeKzgProof,
-  computeBlobKzgProof,
-  verifyKzgProof,
-  verifyBlobKzgProof,
-  verifyBlobKzgProofBatch,
+  blobToKZGCommitment,
+  computeKZGProof,
+  computeBlobKZGProof,
+  verifyKZGProof,
+  verifyBlobKZGProof,
+  verifyBlobKZGProofBatch,
   BYTES_PER_BLOB,
   BYTES_PER_COMMITMENT,
   BYTES_PER_PROOF,
 
   // EIP-7594
-  computeCellsAndKzgProofs,
-  verifyCellKzgProofBatch,
-  recoverCellsAndKzgProofs,
+  computeCellsAndKZGProofs,
+  verifyCellKZGProofBatch,
+  recoverCellsAndKZGProofs,
 } = kzg;
 
 // not exported by types, only exported for testing purposes
@@ -53,16 +53,16 @@ const VERIFY_CELL_KZG_PROOF_BATCH_TESTS = "../../tests/verify_cell_kzg_proof_bat
 
 const BYTES_PER_FIELD_ELEMENT = 32;
 
-type BlobToKzgCommitmentTest = TestMeta<{blob: string}, string>;
-type ComputeKzgProofTest = TestMeta<{blob: string; z: string}, string[]>;
-type ComputeBlobKzgProofTest = TestMeta<{blob: string; commitment: string}, string>;
-type VerifyKzgProofTest = TestMeta<{commitment: string; y: string; z: string; proof: string}, boolean>;
-type VerifyBlobKzgProofTest = TestMeta<{blob: string; commitment: string; proof: string}, boolean>;
+type BlobToKZGCommitmentTest = TestMeta<{blob: string}, string>;
+type ComputeKZGProofTest = TestMeta<{blob: string; z: string}, string[]>;
+type ComputeBlobKZGProofTest = TestMeta<{blob: string; commitment: string}, string>;
+type VerifyKZGProofTest = TestMeta<{commitment: string; y: string; z: string; proof: string}, boolean>;
+type VerifyBlobKZGProofTest = TestMeta<{blob: string; commitment: string; proof: string}, boolean>;
 type VerifyBatchKzgProofTest = TestMeta<{blobs: string[]; commitments: string[]; proofs: string[]}, boolean>;
 
-type ComputeCellsAndKzgProofsTest = TestMeta<{blob: string}, string[][]>;
-type RecoverCellsAndKzgProofsTest = TestMeta<{cell_indices: number[]; cells: string[]}, string[][]>;
-type VerifyCellKzgProofBatchTest = TestMeta<
+type ComputeCellsAndKZGProofsTest = TestMeta<{blob: string}, string[][]>;
+type RecoverCellsAndKZGProofsTest = TestMeta<{cell_indices: number[]; cells: string[]}, string[][]>;
+type VerifyCellKZGProofBatchTest = TestMeta<
   {commitments: string[]; cell_indices: number[]; cells: string[]; proofs: string[]},
   boolean
 >;
@@ -218,18 +218,18 @@ describe("C-KZG", () => {
   });
 
   describe("reference tests should pass", () => {
-    it("reference tests for blobToKzgCommitment should pass", () => {
+    it("reference tests for blobToKZGCommitment should pass", () => {
       const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: BlobToKzgCommitmentTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: BlobToKZGCommitmentTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let commitment: Uint8Array;
         const blob = bytesFromHex(test.input.blob);
 
         try {
-          commitment = blobToKzgCommitment(blob);
+          commitment = blobToKZGCommitment(blob);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -241,19 +241,19 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for computeKzgProof should pass", () => {
+    it("reference tests for computeKZGProof should pass", () => {
       const tests = globSync(COMPUTE_KZG_PROOF_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: ComputeKzgProofTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: ComputeKZGProofTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let proof: ProofResult;
         const blob = bytesFromHex(test.input.blob);
         const z = bytesFromHex(test.input.z);
 
         try {
-          proof = computeKzgProof(blob, z);
+          proof = computeKZGProof(blob, z);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -269,19 +269,19 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for computeBlobKzgProof should pass", () => {
+    it("reference tests for computeBlobKZGProof should pass", () => {
       const tests = globSync(COMPUTE_BLOB_KZG_PROOF_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: ComputeBlobKzgProofTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: ComputeBlobKZGProofTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let proof: Uint8Array;
         const blob = bytesFromHex(test.input.blob);
         const commitment = bytesFromHex(test.input.commitment);
 
         try {
-          proof = computeBlobKzgProof(blob, commitment);
+          proof = computeBlobKZGProof(blob, commitment);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -293,12 +293,12 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for verifyKzgProof should pass", () => {
+    it("reference tests for verifyKZGProof should pass", () => {
       const tests = globSync(VERIFY_KZG_PROOF_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: VerifyKzgProofTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: VerifyKZGProofTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let valid;
         const commitment = bytesFromHex(test.input.commitment);
@@ -307,7 +307,7 @@ describe("C-KZG", () => {
         const proof = bytesFromHex(test.input.proof);
 
         try {
-          valid = verifyKzgProof(commitment, z, y, proof);
+          valid = verifyKZGProof(commitment, z, y, proof);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -317,12 +317,12 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for verifyBlobKzgProof should pass", () => {
+    it("reference tests for verifyBlobKZGProof should pass", () => {
       const tests = globSync(VERIFY_BLOB_KZG_PROOF_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: VerifyBlobKzgProofTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: VerifyBlobKZGProofTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let valid;
         const blob = bytesFromHex(test.input.blob);
@@ -330,7 +330,7 @@ describe("C-KZG", () => {
         const proof = bytesFromHex(test.input.proof);
 
         try {
-          valid = verifyBlobKzgProof(blob, commitment, proof);
+          valid = verifyBlobKZGProof(blob, commitment, proof);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -340,7 +340,7 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for verifyBlobKzgProofBatch should pass", () => {
+    it("reference tests for verifyBlobKZGProofBatch should pass", () => {
       const tests = globSync(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
@@ -353,7 +353,7 @@ describe("C-KZG", () => {
         const proofs = test.input.proofs.map(bytesFromHex);
 
         try {
-          valid = verifyBlobKzgProofBatch(blobs, commitments, proofs);
+          valid = verifyBlobKZGProofBatch(blobs, commitments, proofs);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -363,19 +363,19 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for computeCellsAndKzgProofs should pass", () => {
+    it("reference tests for computeCellsAndKZGProofs should pass", () => {
       const tests = globSync(COMPUTE_CELLS_AND_KZG_PROOFS_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: ComputeCellsAndKzgProofsTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: ComputeCellsAndKZGProofsTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let cells;
         let proofs;
         const blob = bytesFromHex(test.input.blob);
 
         try {
-          [cells, proofs] = computeCellsAndKzgProofs(blob);
+          [cells, proofs] = computeCellsAndKZGProofs(blob);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -396,12 +396,12 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for recoverCellsAndKzgProofs should pass", () => {
+    it("reference tests for recoverCellsAndKZGProofs should pass", () => {
       const tests = globSync(RECOVER_CELLS_AND_KZG_PROOFS_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: RecoverCellsAndKzgProofsTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: RecoverCellsAndKZGProofsTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let recoveredCells;
         let recoveredProofs;
@@ -409,7 +409,7 @@ describe("C-KZG", () => {
         const cells = test.input.cells.map(bytesFromHex);
 
         try {
-          [recoveredCells, recoveredProofs] = recoverCellsAndKzgProofs(cellIndices, cells);
+          [recoveredCells, recoveredProofs] = recoverCellsAndKZGProofs(cellIndices, cells);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -430,12 +430,12 @@ describe("C-KZG", () => {
       });
     });
 
-    it("reference tests for verifyCellKzgProofBatch should pass", () => {
+    it("reference tests for verifyCellKZGProofBatch should pass", () => {
       const tests = globSync(VERIFY_CELL_KZG_PROOF_BATCH_TESTS);
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: VerifyCellKzgProofBatchTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: VerifyCellKZGProofBatchTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let valid;
         const commitments = test.input.commitments.map(bytesFromHex);
@@ -444,7 +444,7 @@ describe("C-KZG", () => {
         const proofs = test.input.proofs.map(bytesFromHex);
 
         try {
-          valid = verifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
+          valid = verifyCellKZGProofBatch(commitments, cellIndices, cells, proofs);
         } catch (err) {
           expect(test.output).toBeNull();
           return;
@@ -455,79 +455,79 @@ describe("C-KZG", () => {
     });
   });
 
-  describe("edge cases for blobToKzgCommitment", () => {
+  describe("edge cases for blobToKZGCommitment", () => {
     describe("check argument count", () => {
-      const test: BlobToKzgCommitmentTest = getValidTest(BLOB_TO_KZG_COMMITMENT_TESTS);
+      const test: BlobToKZGCommitmentTest = getValidTest(BLOB_TO_KZG_COMMITMENT_TESTS);
       const blob = bytesFromHex(test.input.blob);
-      testArgCount(blobToKzgCommitment, [blob]);
+      testArgCount(blobToKZGCommitment, [blob]);
     });
 
     it("throws as expected when given an argument of invalid type", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
-      expect(() => blobToKzgCommitment("wrong type")).toThrowError("Expected blob to be a Uint8Array");
+      expect(() => blobToKZGCommitment("wrong type")).toThrowError("Expected blob to be a Uint8Array");
     });
 
     it("throws as expected when given an argument of invalid length", () => {
-      expect(() => blobToKzgCommitment(blobBadLength)).toThrowError("Expected blob to be 131072 bytes");
+      expect(() => blobToKZGCommitment(blobBadLength)).toThrowError("Expected blob to be 131072 bytes");
     });
   });
 
   // TODO: add more tests for this function.
-  describe("edge cases for computeKzgProof", () => {
+  describe("edge cases for computeKZGProof", () => {
     describe("check argument count", () => {
-      const test: ComputeKzgProofTest = getValidTest(COMPUTE_KZG_PROOF_TESTS);
+      const test: ComputeKZGProofTest = getValidTest(COMPUTE_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const z = bytesFromHex(test.input.z);
-      testArgCount(computeKzgProof, [blob, z]);
+      testArgCount(computeKZGProof, [blob, z]);
     });
 
     it("computes a proof from blob/field element", () => {
       const blob = generateRandomBlob();
       const zBytes = new Uint8Array(BYTES_PER_FIELD_ELEMENT).fill(0);
-      computeKzgProof(blob, zBytes);
+      computeKZGProof(blob, zBytes);
     });
 
     it("throws as expected when given an argument of invalid length", () => {
-      expect(() => computeKzgProof(blobBadLength, fieldElementValidLength)).toThrowError(
+      expect(() => computeKZGProof(blobBadLength, fieldElementValidLength)).toThrowError(
         "Expected blob to be 131072 bytes"
       );
-      expect(() => computeKzgProof(blobValidLength, fieldElementBadLength)).toThrowError(
+      expect(() => computeKZGProof(blobValidLength, fieldElementBadLength)).toThrowError(
         "Expected zBytes to be 32 bytes"
       );
     });
   });
 
   // TODO: add more tests for this function.
-  describe("edge cases for computeBlobKzgProof", () => {
+  describe("edge cases for computeBlobKZGProof", () => {
     describe("check argument count", () => {
-      const test: ComputeBlobKzgProofTest = getValidTest(COMPUTE_BLOB_KZG_PROOF_TESTS);
+      const test: ComputeBlobKZGProofTest = getValidTest(COMPUTE_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const commitment = bytesFromHex(test.input.commitment);
-      testArgCount(computeBlobKzgProof, [blob, commitment]);
+      testArgCount(computeBlobKZGProof, [blob, commitment]);
     });
 
     it("computes a proof from blob", () => {
       const blob = generateRandomBlob();
-      const commitment = blobToKzgCommitment(blob);
-      computeBlobKzgProof(blob, commitment);
+      const commitment = blobToKZGCommitment(blob);
+      computeBlobKZGProof(blob, commitment);
     });
 
     it("throws as expected when given an argument of invalid length", () => {
-      expect(() => computeBlobKzgProof(blobBadLength, blobToKzgCommitment(generateRandomBlob()))).toThrowError(
+      expect(() => computeBlobKZGProof(blobBadLength, blobToKZGCommitment(generateRandomBlob()))).toThrowError(
         "Expected blob to be 131072 bytes"
       );
     });
   });
 
-  describe("edge cases for verifyKzgProof", () => {
+  describe("edge cases for verifyKZGProof", () => {
     describe("check argument count", () => {
-      const test: VerifyKzgProofTest = getValidTest(VERIFY_KZG_PROOF_TESTS);
+      const test: VerifyKZGProofTest = getValidTest(VERIFY_KZG_PROOF_TESTS);
       const commitment = bytesFromHex(test.input.commitment);
       const z = bytesFromHex(test.input.z);
       const y = bytesFromHex(test.input.y);
       const proof = bytesFromHex(test.input.proof);
-      testArgCount(verifyKzgProof, [commitment, z, y, proof]);
+      testArgCount(verifyKZGProof, [commitment, z, y, proof]);
     });
 
     it("valid proof should result in true", () => {
@@ -537,7 +537,7 @@ describe("C-KZG", () => {
       const y = new Uint8Array(BYTES_PER_FIELD_ELEMENT).fill(0);
       const proof = new Uint8Array(BYTES_PER_PROOF).fill(0);
       proof[0] = 0xc0;
-      expect(verifyKzgProof(commitment, z, y, proof)).toBe(true);
+      expect(verifyKZGProof(commitment, z, y, proof)).toBe(true);
     });
 
     it("invalid proof should result in false", () => {
@@ -547,82 +547,82 @@ describe("C-KZG", () => {
       const y = new Uint8Array(BYTES_PER_FIELD_ELEMENT).fill(1);
       const proof = new Uint8Array(BYTES_PER_PROOF).fill(0);
       proof[0] = 0xc0;
-      expect(verifyKzgProof(commitment, z, y, proof)).toBe(false);
+      expect(verifyKZGProof(commitment, z, y, proof)).toBe(false);
     });
 
     it("throws as expected when given an argument of invalid length", () => {
       expect(() =>
-        verifyKzgProof(commitmentBadLength, fieldElementValidLength, fieldElementValidLength, proofValidLength)
+        verifyKZGProof(commitmentBadLength, fieldElementValidLength, fieldElementValidLength, proofValidLength)
       ).toThrowError("Expected commitmentBytes to be 48 bytes");
       expect(() =>
-        verifyKzgProof(commitmentValidLength, fieldElementBadLength, fieldElementValidLength, proofValidLength)
+        verifyKZGProof(commitmentValidLength, fieldElementBadLength, fieldElementValidLength, proofValidLength)
       ).toThrowError("Expected zBytes to be 32 bytes");
       expect(() =>
-        verifyKzgProof(commitmentValidLength, fieldElementValidLength, fieldElementBadLength, proofValidLength)
+        verifyKZGProof(commitmentValidLength, fieldElementValidLength, fieldElementBadLength, proofValidLength)
       ).toThrowError("Expected yBytes to be 32 bytes");
       expect(() =>
-        verifyKzgProof(commitmentValidLength, fieldElementValidLength, fieldElementValidLength, proofBadLength)
+        verifyKZGProof(commitmentValidLength, fieldElementValidLength, fieldElementValidLength, proofBadLength)
       ).toThrowError("Expected proofBytes to be 48 bytes");
     });
   });
 
-  describe("edge cases for verifyBlobKzgProof", () => {
+  describe("edge cases for verifyBlobKZGProof", () => {
     describe("check argument count", () => {
-      const test: VerifyBlobKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_TESTS);
+      const test: VerifyBlobKZGProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_TESTS);
       const blob = bytesFromHex(test.input.blob);
       const commitment = bytesFromHex(test.input.commitment);
       const proof = bytesFromHex(test.input.proof);
-      testArgCount(verifyBlobKzgProof, [blob, commitment, proof]);
+      testArgCount(verifyBlobKZGProof, [blob, commitment, proof]);
     });
 
     it("correct blob/commitment/proof should verify as true", () => {
       const blob = generateRandomBlob();
-      const commitment = blobToKzgCommitment(blob);
-      const proof = computeBlobKzgProof(blob, commitment);
-      expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(true);
+      const commitment = blobToKZGCommitment(blob);
+      const proof = computeBlobKZGProof(blob, commitment);
+      expect(verifyBlobKZGProof(blob, commitment, proof)).toBe(true);
     });
 
     it("incorrect commitment should verify as false", () => {
       const blob = generateRandomBlob();
-      const commitment = blobToKzgCommitment(generateRandomBlob());
-      const proof = computeBlobKzgProof(blob, commitment);
-      expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(false);
+      const commitment = blobToKZGCommitment(generateRandomBlob());
+      const proof = computeBlobKZGProof(blob, commitment);
+      expect(verifyBlobKZGProof(blob, commitment, proof)).toBe(false);
     });
 
     it("incorrect proof should verify as false", () => {
       const blob = generateRandomBlob();
-      const commitment = blobToKzgCommitment(blob);
+      const commitment = blobToKZGCommitment(blob);
       const randomBlob = generateRandomBlob();
-      const randomCommitment = blobToKzgCommitment(randomBlob);
-      const proof = computeBlobKzgProof(randomBlob, randomCommitment);
-      expect(verifyBlobKzgProof(blob, commitment, proof)).toBe(false);
+      const randomCommitment = blobToKZGCommitment(randomBlob);
+      const proof = computeBlobKZGProof(randomBlob, randomCommitment);
+      expect(verifyBlobKZGProof(blob, commitment, proof)).toBe(false);
     });
 
     it("throws as expected when given an argument of invalid length", () => {
-      expect(() => verifyBlobKzgProof(blobBadLength, commitmentValidLength, proofValidLength)).toThrowError(
+      expect(() => verifyBlobKZGProof(blobBadLength, commitmentValidLength, proofValidLength)).toThrowError(
         "Expected blob to be 131072 bytes"
       );
-      expect(() => verifyBlobKzgProof(blobValidLength, commitmentBadLength, proofValidLength)).toThrowError(
+      expect(() => verifyBlobKZGProof(blobValidLength, commitmentBadLength, proofValidLength)).toThrowError(
         "Expected commitmentBytes to be 48 bytes"
       );
-      expect(() => verifyBlobKzgProof(blobValidLength, commitmentValidLength, proofBadLength)).toThrowError(
+      expect(() => verifyBlobKZGProof(blobValidLength, commitmentValidLength, proofBadLength)).toThrowError(
         "Expected proofBytes to be 48 bytes"
       );
     });
   });
 
-  describe("edge cases for verifyBlobKzgProofBatch", () => {
+  describe("edge cases for verifyBlobKZGProofBatch", () => {
     describe("check argument count", () => {
       const test: VerifyBatchKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       const blobs = test.input.blobs.map(bytesFromHex);
       const commitments = test.input.commitments.map(bytesFromHex);
       const proofs = test.input.proofs.map(bytesFromHex);
-      testArgCount(verifyBlobKzgProofBatch, [blobs, commitments, proofs]);
+      testArgCount(verifyBlobKZGProofBatch, [blobs, commitments, proofs]);
     });
 
     it("should reject non-array args", () => {
       expect(() =>
-        verifyBlobKzgProofBatch(
+        verifyBlobKZGProofBatch(
           2 as unknown as Uint8Array[],
           [commitmentValidLength, commitmentValidLength],
           [proofValidLength, proofValidLength]
@@ -632,7 +632,7 @@ describe("C-KZG", () => {
 
     it("should reject non-bytearray blob", () => {
       expect(() =>
-        verifyBlobKzgProofBatch(
+        verifyBlobKZGProofBatch(
           ["foo", "bar"] as unknown as Uint8Array[],
           [commitmentValidLength, commitmentValidLength],
           [proofValidLength, proofValidLength]
@@ -642,21 +642,21 @@ describe("C-KZG", () => {
 
     it("throws as expected when given an argument of invalid length", () => {
       expect(() =>
-        verifyBlobKzgProofBatch(
+        verifyBlobKZGProofBatch(
           [blobBadLength, blobValidLength],
           [commitmentValidLength, commitmentValidLength],
           [proofValidLength, proofValidLength]
         )
       ).toThrowError("Expected blob to be 131072 bytes");
       expect(() =>
-        verifyBlobKzgProofBatch(
+        verifyBlobKZGProofBatch(
           [blobValidLength, blobValidLength],
           [commitmentBadLength, commitmentValidLength],
           [proofValidLength, proofValidLength]
         )
       ).toThrowError("Expected commitmentBytes to be 48 bytes");
       expect(() =>
-        verifyBlobKzgProofBatch(
+        verifyBlobKZGProofBatch(
           [blobValidLength, blobValidLength],
           [commitmentValidLength, commitmentValidLength],
           [proofValidLength, proofBadLength]
@@ -665,7 +665,7 @@ describe("C-KZG", () => {
     });
 
     it("zero blobs/commitments/proofs should verify as true", () => {
-      expect(verifyBlobKzgProofBatch([], [], [])).toBe(true);
+      expect(verifyBlobKZGProofBatch([], [], [])).toBe(true);
     });
 
     it("mismatching blobs/commitments/proofs should throw error", () => {
@@ -675,17 +675,17 @@ describe("C-KZG", () => {
       const proofs = new Array(count);
       for (const [i] of blobs.entries()) {
         blobs[i] = generateRandomBlob();
-        commitments[i] = blobToKzgCommitment(blobs[i]);
-        proofs[i] = computeBlobKzgProof(blobs[i], commitments[i]);
+        commitments[i] = blobToKZGCommitment(blobs[i]);
+        proofs[i] = computeBlobKZGProof(blobs[i], commitments[i]);
       }
-      expect(verifyBlobKzgProofBatch(blobs, commitments, proofs)).toBe(true);
-      expect(() => verifyBlobKzgProofBatch(blobs.slice(0, 1), commitments, proofs)).toThrowError(
+      expect(verifyBlobKZGProofBatch(blobs, commitments, proofs)).toBe(true);
+      expect(() => verifyBlobKZGProofBatch(blobs.slice(0, 1), commitments, proofs)).toThrowError(
         "Requires equal number of blobs/commitments/proofs"
       );
-      expect(() => verifyBlobKzgProofBatch(blobs, commitments.slice(0, 1), proofs)).toThrowError(
+      expect(() => verifyBlobKZGProofBatch(blobs, commitments.slice(0, 1), proofs)).toThrowError(
         "Requires equal number of blobs/commitments/proofs"
       );
-      expect(() => verifyBlobKzgProofBatch(blobs, commitments, proofs.slice(0, 1))).toThrowError(
+      expect(() => verifyBlobKZGProofBatch(blobs, commitments, proofs.slice(0, 1))).toThrowError(
         "Requires equal number of blobs/commitments/proofs"
       );
     });

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -58,7 +58,7 @@ type ComputeKZGProofTest = TestMeta<{blob: string; z: string}, string[]>;
 type ComputeBlobKZGProofTest = TestMeta<{blob: string; commitment: string}, string>;
 type VerifyKZGProofTest = TestMeta<{commitment: string; y: string; z: string; proof: string}, boolean>;
 type VerifyBlobKZGProofTest = TestMeta<{blob: string; commitment: string; proof: string}, boolean>;
-type VerifyBatchKzgProofTest = TestMeta<{blobs: string[]; commitments: string[]; proofs: string[]}, boolean>;
+type VerifyBatchKZGProofTest = TestMeta<{blobs: string[]; commitments: string[]; proofs: string[]}, boolean>;
 
 type ComputeCellsAndKZGProofsTest = TestMeta<{blob: string}, string[][]>;
 type RecoverCellsAndKZGProofsTest = TestMeta<{cell_indices: number[]; cells: string[]}, string[][]>;
@@ -345,7 +345,7 @@ describe("C-KZG", () => {
       expect(tests.length).toBeGreaterThan(0);
 
       tests.forEach((testFile: string) => {
-        const test: VerifyBatchKzgProofTest = yaml.load(readFileSync(testFile, "ascii"));
+        const test: VerifyBatchKZGProofTest = yaml.load(readFileSync(testFile, "ascii"));
 
         let valid;
         const blobs = test.input.blobs.map(bytesFromHex);
@@ -613,7 +613,7 @@ describe("C-KZG", () => {
 
   describe("edge cases for verifyBlobKZGProofBatch", () => {
     describe("check argument count", () => {
-      const test: VerifyBatchKzgProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
+      const test: VerifyBatchKZGProofTest = getValidTest(VERIFY_BLOB_KZG_PROOF_BATCH_TESTS);
       const blobs = test.input.blobs.map(bytesFromHex);
       const commitments = test.input.commitments.map(bytesFromHex);
       const proofs = test.input.proofs.map(bytesFromHex);

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -62,15 +62,15 @@ pub enum Error {
     /// The hex string is invalid.
     InvalidHexFormat(String),
     /// The KZG proof is invalid.
-    InvalidKzgProof(String),
+    InvalidKZGProof(String),
     /// The KZG commitment is invalid.
-    InvalidKzgCommitment(String),
+    InvalidKZGCommitment(String),
     /// The provided trusted setup is invalid.
     InvalidTrustedSetup(String),
     /// Paired arguments have different lengths.
     MismatchLength(String),
     /// Loading the trusted setup failed.
-    LoadingTrustedSetupFailed(KzgErrors),
+    LoadingTrustedSetupFailed(KZGErrors),
     /// The underlying c-kzg library returned an error.
     CError(C_KZG_RET),
 }
@@ -83,24 +83,24 @@ impl fmt::Display for Error {
         match self {
             Self::InvalidBytesLength(s)
             | Self::InvalidHexFormat(s)
-            | Self::InvalidKzgProof(s)
-            | Self::InvalidKzgCommitment(s)
+            | Self::InvalidKZGProof(s)
+            | Self::InvalidKZGCommitment(s)
             | Self::InvalidTrustedSetup(s)
             | Self::MismatchLength(s) => f.write_str(s),
-            Self::LoadingTrustedSetupFailed(s) => write!(f, "KzgErrors: {:?}", s),
+            Self::LoadingTrustedSetupFailed(s) => write!(f, "KZGErrors: {:?}", s),
             Self::CError(s) => fmt::Debug::fmt(s, f),
         }
     }
 }
 
-impl From<KzgErrors> for Error {
-    fn from(e: KzgErrors) -> Self {
+impl From<KZGErrors> for Error {
+    fn from(e: KZGErrors) -> Self {
         Error::LoadingTrustedSetupFailed(e)
     }
 }
 
 #[derive(Debug)]
-pub enum KzgErrors {
+pub enum KZGErrors {
     /// Failed to get current directory.
     FailedCurrentDirectory,
     /// The specified path does not exist.
@@ -185,28 +185,28 @@ impl KZGSettings {
         Self::load_trusted_setup_file_inner(&file_path, precompute)
     }
 
-    /// Parses the contents of a KZG trusted setup file into a KzgSettings.
+    /// Parses the contents of a KZG trusted setup file into a KZGSettings.
     pub fn parse_kzg_trusted_setup(trusted_setup: &str, precompute: usize) -> Result<Self, Error> {
         let mut lines = trusted_setup.lines();
 
         // Load number of g1 points
         let n_g1 = lines
             .next()
-            .ok_or(KzgErrors::FileFormatError)?
+            .ok_or(KZGErrors::FileFormatError)?
             .parse::<usize>()
-            .map_err(|_| KzgErrors::ParseError)?;
+            .map_err(|_| KZGErrors::ParseError)?;
         if n_g1 != NUM_G1_POINTS {
-            return Err(KzgErrors::MismatchedNumberOfPoints.into());
+            return Err(KZGErrors::MismatchedNumberOfPoints.into());
         }
 
         // Load number of g2 points
         let n_g2 = lines
             .next()
-            .ok_or(KzgErrors::FileFormatError)?
+            .ok_or(KZGErrors::FileFormatError)?
             .parse::<usize>()
-            .map_err(|_| KzgErrors::ParseError)?;
+            .map_err(|_| KZGErrors::ParseError)?;
         if n_g2 != NUM_G2_POINTS {
-            return Err(KzgErrors::MismatchedNumberOfPoints.into());
+            return Err(KZGErrors::MismatchedNumberOfPoints.into());
         }
 
         let mut g1_lagrange_bytes = alloc::boxed::Box::new([0; BYTES_PER_G1_POINT * NUM_G1_POINTS]);
@@ -217,31 +217,31 @@ impl KZGSettings {
         g1_lagrange_bytes
             .chunks_mut(BYTES_PER_G1_POINT)
             .map(|chunk| {
-                let line = lines.next().ok_or(KzgErrors::FileFormatError)?;
-                hex::decode_to_slice(line, chunk).map_err(|_| KzgErrors::ParseError)
+                let line = lines.next().ok_or(KZGErrors::FileFormatError)?;
+                hex::decode_to_slice(line, chunk).map_err(|_| KZGErrors::ParseError)
             })
-            .collect::<Result<(), KzgErrors>>()?;
+            .collect::<Result<(), KZGErrors>>()?;
 
         // Load g2 monomial bytes
         g2_monomial_bytes
             .chunks_mut(BYTES_PER_G2_POINT)
             .map(|chunk| {
-                let line = lines.next().ok_or(KzgErrors::FileFormatError)?;
-                hex::decode_to_slice(line, chunk).map_err(|_| KzgErrors::ParseError)
+                let line = lines.next().ok_or(KZGErrors::FileFormatError)?;
+                hex::decode_to_slice(line, chunk).map_err(|_| KZGErrors::ParseError)
             })
-            .collect::<Result<(), KzgErrors>>()?;
+            .collect::<Result<(), KZGErrors>>()?;
 
         // Load g1 monomial bytes
         g1_monomial_bytes
             .chunks_mut(BYTES_PER_G1_POINT)
             .map(|chunk| {
-                let line = lines.next().ok_or(KzgErrors::FileFormatError)?;
-                hex::decode_to_slice(line, chunk).map_err(|_| KzgErrors::ParseError)
+                let line = lines.next().ok_or(KZGErrors::FileFormatError)?;
+                hex::decode_to_slice(line, chunk).map_err(|_| KZGErrors::ParseError)
             })
-            .collect::<Result<(), KzgErrors>>()?;
+            .collect::<Result<(), KZGErrors>>()?;
 
         if lines.next().is_some() {
-            return Err(KzgErrors::FileFormatError.into());
+            return Err(KZGErrors::FileFormatError.into());
         }
 
         Self::load_trusted_setup(
@@ -649,7 +649,7 @@ impl Bytes48 {
 impl KZGProof {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != BYTES_PER_PROOF {
-            return Err(Error::InvalidKzgProof(format!(
+            return Err(Error::InvalidKZGProof(format!(
                 "Invalid byte length. Expected {} got {}",
                 BYTES_PER_PROOF,
                 bytes.len(),
@@ -672,7 +672,7 @@ impl KZGProof {
 impl KZGCommitment {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != BYTES_PER_COMMITMENT {
-            return Err(Error::InvalidKzgCommitment(format!(
+            return Err(Error::InvalidKZGCommitment(format!(
                 "Invalid byte length. Expected {} got {}",
                 BYTES_PER_PROOF,
                 bytes.len(),

--- a/bindings/rust/src/ethereum_kzg_settings/mod.rs
+++ b/bindings/rust/src/ethereum_kzg_settings/mod.rs
@@ -1,4 +1,4 @@
-use crate::KzgSettings;
+use crate::KZGSettings;
 use alloc::{boxed::Box, sync::Arc};
 use once_cell::race::OnceBox;
 
@@ -12,21 +12,21 @@ const ETH_G2_MONOMIAL_POINTS: &[u8] = include_bytes!("./g2_monomial_bytes.bin");
 /// Returns default Ethereum mainnet KZG settings.
 ///
 /// If you need a cloneable settings use `ethereum_kzg_settings_arc` instead.
-pub fn ethereum_kzg_settings(precompute: usize) -> &'static KzgSettings {
+pub fn ethereum_kzg_settings(precompute: usize) -> &'static KZGSettings {
     ethereum_kzg_settings_inner(precompute).as_ref()
 }
 
 /// Returns default Ethereum mainnet KZG settings as an `Arc`.
 ///
 /// It is useful for sharing the settings in multiple places.
-pub fn ethereum_kzg_settings_arc(precompute: usize) -> Arc<KzgSettings> {
+pub fn ethereum_kzg_settings_arc(precompute: usize) -> Arc<KZGSettings> {
     ethereum_kzg_settings_inner(precompute).clone()
 }
 
-fn ethereum_kzg_settings_inner(precompute: usize) -> &'static Arc<KzgSettings> {
-    static DEFAULT: OnceBox<Arc<KzgSettings>> = OnceBox::new();
+fn ethereum_kzg_settings_inner(precompute: usize) -> &'static Arc<KZGSettings> {
+    static DEFAULT: OnceBox<Arc<KZGSettings>> = OnceBox::new();
     DEFAULT.get_or_init(|| {
-        let settings = KzgSettings::load_trusted_setup(
+        let settings = KZGSettings::load_trusted_setup(
             ETH_G1_MONOMIAL_POINTS,
             ETH_G1_LAGRANGE_POINTS,
             ETH_G2_MONOMIAL_POINTS,
@@ -40,14 +40,14 @@ fn ethereum_kzg_settings_inner(precompute: usize) -> &'static Arc<KzgSettings> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bindings::BYTES_PER_BLOB, Blob, KzgSettings};
+    use crate::{bindings::BYTES_PER_BLOB, Blob, KZGSettings};
     use std::path::Path;
 
     #[test]
     pub fn compare_default_with_file() {
         let precompute = 0;
         let ts_settings =
-            KzgSettings::load_trusted_setup_file(Path::new("src/trusted_setup.txt"), precompute)
+            KZGSettings::load_trusted_setup_file(Path::new("src/trusted_setup.txt"), precompute)
                 .unwrap();
         let eth_settings = ethereum_kzg_settings(precompute);
         let blob = Blob::new([1u8; BYTES_PER_BLOB]);

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -15,8 +15,8 @@ mod ethereum_kzg_settings;
 
 // Expose relevant types with idiomatic names.
 pub use bindings::{
-    KZGCommitment as KzgCommitment, KZGProof as KzgProof, KZGSettings as KzgSettings,
-    C_KZG_RET as CkzgError,
+    KZGCommitment as KZGCommitment, KZGProof as KZGProof, KZGSettings as KZGSettings,
+    C_KZG_RET as CKZGError,
 };
 
 // Expose the default settings.

--- a/fuzz/fuzz_targets/fuzz_blob_to_kzg_commitment.rs
+++ b/fuzz/fuzz_targets/fuzz_blob_to_kzg_commitment.rs
@@ -15,10 +15,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 

--- a/fuzz/fuzz_targets/fuzz_compute_blob_kzg_proof.rs
+++ b/fuzz/fuzz_targets/fuzz_compute_blob_kzg_proof.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 

--- a/fuzz/fuzz_targets/fuzz_compute_cells_and_kzg_proofs.rs
+++ b/fuzz/fuzz_targets/fuzz_compute_cells_and_kzg_proofs.rs
@@ -5,17 +5,17 @@
 extern crate core;
 
 use c_kzg::Blob;
-use c_kzg::KzgSettings;
+use c_kzg::KZGSettings;
 use lazy_static::lazy_static;
 use libfuzzer_sys::fuzz_target;
 use rust_eth_kzg::DASContext;
 use std::path::PathBuf;
 
 lazy_static! {
-    static ref KZG_SETTINGS: KzgSettings = {
+    static ref KZG_SETTINGS: KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        KzgSettings::load_trusted_setup_file(&trusted_setup_file, 8).unwrap()
+        KZGSettings::load_trusted_setup_file(&trusted_setup_file, 8).unwrap()
     };
     static ref DAS_CONTEXT: DASContext = DASContext::default();
 }

--- a/fuzz/fuzz_targets/fuzz_compute_kzg_proof.rs
+++ b/fuzz/fuzz_targets/fuzz_compute_kzg_proof.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 

--- a/fuzz/fuzz_targets/fuzz_recover_cells_and_kzg_proofs.rs
+++ b/fuzz/fuzz_targets/fuzz_recover_cells_and_kzg_proofs.rs
@@ -6,7 +6,7 @@ extern crate core;
 
 use arbitrary::Arbitrary;
 use c_kzg::Cell;
-use c_kzg::KzgSettings;
+use c_kzg::KZGSettings;
 use c_kzg::BYTES_PER_CELL;
 use lazy_static::lazy_static;
 use libfuzzer_sys::fuzz_target;
@@ -14,10 +14,10 @@ use rust_eth_kzg::DASContext;
 use std::path::PathBuf;
 
 lazy_static! {
-    static ref KZG_SETTINGS: KzgSettings = {
+    static ref KZG_SETTINGS: KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
     static ref DAS_CONTEXT: DASContext = DASContext::default();
 }

--- a/fuzz/fuzz_targets/fuzz_verify_blob_kzg_proof.rs
+++ b/fuzz/fuzz_targets/fuzz_verify_blob_kzg_proof.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 

--- a/fuzz/fuzz_targets/fuzz_verify_blob_kzg_proof_batch.rs
+++ b/fuzz/fuzz_targets/fuzz_verify_blob_kzg_proof_batch.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 

--- a/fuzz/fuzz_targets/fuzz_verify_cell_kzg_proof_batch.rs
+++ b/fuzz/fuzz_targets/fuzz_verify_cell_kzg_proof_batch.rs
@@ -5,7 +5,7 @@
 extern crate core;
 
 use arbitrary::Arbitrary;
-use c_kzg::KzgSettings;
+use c_kzg::KZGSettings;
 use c_kzg::BYTES_PER_CELL;
 use c_kzg::BYTES_PER_COMMITMENT;
 use c_kzg::BYTES_PER_PROOF;
@@ -16,10 +16,10 @@ use rust_eth_kzg::DASContext;
 use std::path::PathBuf;
 
 lazy_static! {
-    static ref KZG_SETTINGS: KzgSettings = {
+    static ref KZG_SETTINGS: KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
     static ref DAS_CONTEXT: DASContext = DASContext::default();
 }

--- a/fuzz/fuzz_targets/fuzz_verify_kzg_proof.rs
+++ b/fuzz/fuzz_targets/fuzz_verify_kzg_proof.rs
@@ -16,10 +16,10 @@ use std::sync::{Arc, OnceLock};
 ///////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
-    static ref KZG_SETTINGS: c_kzg::KzgSettings = {
+    static ref KZG_SETTINGS: c_kzg::KZGSettings = {
         let root_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let trusted_setup_file = root_dir.join("..").join("src").join("trusted_setup.txt");
-        c_kzg::KzgSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
+        c_kzg::KZGSettings::load_trusted_setup_file(&trusted_setup_file, 0).unwrap()
     };
 }
 


### PR DESCRIPTION
This PR touches a lot of file, but it's pretty straightforward. Renames `Kzg` to `KZG` in the bindings. For consistency. I used find/replace to do this, so I'm pretty sure all of the instances are updated.

I'm afraid these changes might be too annoying for clients though.