### PR TITLE
Update versions in preparation of v2.0.0 release

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 env:
-  binding_build_number_based_version: 1.0.3.${{ github.run_number }}
+  binding_build_number_based_version: 2.0.0.${{ github.run_number }}
 
 jobs:
   build-ckzg:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
  "arbitrary",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "A minimal implementation of the Polynomial Commitments API for EIP-4844, written in C."
+description = "A minimal implementation of the Polynomial Commitments API for EIP-4844 and EIP-7594, written in C."
 links = "ckzg"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -23,7 +23,7 @@
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Version>0.1.0.3</Version>
+		<Version>0.2.0.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
  "arbitrary",
  "blst",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def main():
 
     setup(
         name="ckzg",
-        version="1.0.3",
+        version="2.0.0",
         author="Ethereum Foundation",
         author_email="security@ethereum.org",
         url="https://github.com/ethereum/c-kzg-4844",


### PR DESCRIPTION
Updates all of the versions. Note that the nodejs bindings have already set this to `v4.0.0`.