### PR TITLE
Convert some internal variables from `uint64_t` to `size_t`

### DIFF
--- a/src/common/lincomb.c
+++ b/src/common/lincomb.c
@@ -22,15 +22,14 @@
 /**
  * Calculate a linear combination of G1 group elements.
  *
- * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n`
- * where `n` is `len - 1`.
+ * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n` where `n` is `len - 1`.
  *
  * This function computes the result naively without using Pippenger's algorithm.
  */
-void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, uint64_t len) {
+void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) {
     g1_t tmp;
     *out = G1_IDENTITY;
-    for (uint64_t i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         g1_mul(&tmp, &p[i], &coeffs[i]);
         blst_p1_add_or_double(out, out, &tmp);
     }

--- a/src/common/lincomb.h
+++ b/src/common/lincomb.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, uint64_t len);
+void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len);
 C_KZG_RET g1_lincomb_fast(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len);
 
 #ifdef __cplusplus

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -99,7 +99,7 @@ uint64_t reverse_bits_limited(uint64_t n, uint64_t value) {
  * output array and n' is obtained from n by bit-reversing n. As opposed to reverse_bits, this
  * bit-reversal operates on log2(n)-bit numbers.
  */
-C_KZG_RET bit_reversal_permutation(void *values, size_t size, uint64_t n) {
+C_KZG_RET bit_reversal_permutation(void *values, size_t size, size_t n) {
     C_KZG_RET ret;
     byte *tmp = NULL;
     byte *v = (byte *)values;
@@ -116,7 +116,7 @@ C_KZG_RET bit_reversal_permutation(void *values, size_t size, uint64_t n) {
 
     /* Reorder elements */
     uint64_t unused_bit_len = 64 - log2_pow2(n);
-    for (uint64_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         uint64_t r = reverse_bits(i) >> unused_bit_len;
         if (r > i) {
             /* Swap the two elements */

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -35,7 +35,7 @@ bool is_power_of_two(uint64_t n);
 uint64_t log2_pow2(uint64_t n);
 uint64_t reverse_bits(uint64_t n);
 uint64_t reverse_bits_limited(uint64_t n, uint64_t value);
-C_KZG_RET bit_reversal_permutation(void *values, size_t size, uint64_t n);
+C_KZG_RET bit_reversal_permutation(void *values, size_t size, size_t n);
 void compute_powers(fr_t *out, const fr_t *x, size_t n);
 bool pairings_verify(const g1_t *a1, const g2_t *a2, const g1_t *b1, const g2_t *b2);
 

--- a/src/eip7594/fft.c
+++ b/src/eip7594/fft.c
@@ -160,14 +160,14 @@ C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
  * @param[in]  n            Length of the FFT, must be a power of two
  */
 static void g1_fft_fast(
-    g1_t *out, const g1_t *in, uint64_t stride, const fr_t *roots, uint64_t roots_stride, uint64_t n
+    g1_t *out, const g1_t *in, size_t stride, const fr_t *roots, size_t roots_stride, size_t n
 ) {
     g1_t y_times_root;
-    uint64_t half = n / 2;
+    size_t half = n / 2;
     if (half > 0) { /* Tunable parameter */
         g1_fft_fast(out, in, stride * 2, roots, roots_stride * 2, half);
         g1_fft_fast(out + half, in + stride, stride * 2, roots, roots_stride * 2, half);
-        for (uint64_t i = 0; i < half; i++) {
+        for (size_t i = 0; i < half; i++) {
             /* If the point is infinity, we can skip the calculation */
             if (blst_p1_is_inf(&out[i + half])) {
                 out[i + half] = out[i];
@@ -204,7 +204,7 @@ C_KZG_RET g1_fft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t roots_stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
+    size_t roots_stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
     g1_fft_fast(out, in, 1, s->roots_of_unity, roots_stride, n);
 
     return C_KZG_OK;
@@ -227,13 +227,13 @@ C_KZG_RET g1_ifft(g1_t *out, const g1_t *in, size_t n, const KZGSettings *s) {
         return C_KZG_BADARGS;
     }
 
-    uint64_t stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
+    size_t stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
     g1_fft_fast(out, in, 1, s->reverse_roots_of_unity, stride, n);
 
     fr_t inv_len;
     fr_from_uint64(&inv_len, n);
     blst_fr_eucl_inverse(&inv_len, &inv_len);
-    for (uint64_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         g1_mul(&out[i], &out[i], &inv_len);
     }
 

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -59,8 +59,8 @@
  * @remark `root` must be such that `root ^ width` is equal to one, but no smaller power of `root`
  * is equal to one.
  */
-static C_KZG_RET expand_root_of_unity(fr_t *out, const fr_t *root, uint64_t width) {
-    uint64_t i;
+static C_KZG_RET expand_root_of_unity(fr_t *out, const fr_t *root, size_t width) {
+    size_t i;
 
     /* We assume it's at least two */
     if (width < 2) {
@@ -120,7 +120,7 @@ static C_KZG_RET compute_roots_of_unity(KZGSettings *s) {
     if (ret != C_KZG_OK) goto out;
 
     /* Populate reverse roots of unity */
-    for (uint64_t i = 0; i <= FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+    for (size_t i = 0; i <= FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
         s->reverse_roots_of_unity[i] = s->roots_of_unity[FIELD_ELEMENTS_PER_EXT_BLOB - i];
     }
 
@@ -207,7 +207,7 @@ out:
  */
 static C_KZG_RET init_fk20_multi_settings(KZGSettings *s) {
     C_KZG_RET ret;
-    uint64_t n, k, k2;
+    size_t n, k, k2;
     g1_t *x = NULL;
     g1_t *points = NULL;
     blst_p1_affine *p_affine = NULL;
@@ -401,7 +401,7 @@ C_KZG_RET load_trusted_setup(
     if (ret != C_KZG_OK) goto out_error;
 
     /* Convert all g1 monomial bytes to g1 points */
-    for (uint64_t i = 0; i < NUM_G1_POINTS; i++) {
+    for (size_t i = 0; i < NUM_G1_POINTS; i++) {
         blst_p1_affine g1_affine;
         BLST_ERROR err = blst_p1_uncompress(&g1_affine, &g1_monomial_bytes[BYTES_PER_G1 * i]);
         if (err != BLST_SUCCESS) {
@@ -412,7 +412,7 @@ C_KZG_RET load_trusted_setup(
     }
 
     /* Convert all g1 Lagrange bytes to g1 points */
-    for (uint64_t i = 0; i < NUM_G1_POINTS; i++) {
+    for (size_t i = 0; i < NUM_G1_POINTS; i++) {
         blst_p1_affine g1_affine;
         BLST_ERROR err = blst_p1_uncompress(&g1_affine, &g1_lagrange_bytes[BYTES_PER_G1 * i]);
         if (err != BLST_SUCCESS) {
@@ -423,7 +423,7 @@ C_KZG_RET load_trusted_setup(
     }
 
     /* Convert all g2 bytes to g2 points */
-    for (uint64_t i = 0; i < NUM_G2_POINTS; i++) {
+    for (size_t i = 0; i < NUM_G2_POINTS; i++) {
         blst_p2_affine g2_affine;
         BLST_ERROR err = blst_p2_uncompress(&g2_affine, &g2_monomial_bytes[BYTES_PER_G2 * i]);
         if (err != BLST_SUCCESS) {
@@ -476,7 +476,8 @@ out_success:
 C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in, size_t precompute) {
     C_KZG_RET ret;
     int num_matches;
-    uint64_t i;
+    uint64_t num_g1_points;
+    uint64_t num_g2_points;
     uint8_t *g1_monomial_bytes = NULL;
     uint8_t *g1_lagrange_bytes = NULL;
     uint8_t *g2_monomial_bytes = NULL;
@@ -490,21 +491,21 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in, size_t precompute)
     if (ret != C_KZG_OK) goto out;
 
     /* Read the number of g1 points */
-    num_matches = fscanf(in, "%" SCNu64, &i);
-    if (num_matches != 1 || i != NUM_G1_POINTS) {
+    num_matches = fscanf(in, "%" SCNu64, &num_g1_points);
+    if (num_matches != 1 || num_g1_points != NUM_G1_POINTS) {
         ret = C_KZG_BADARGS;
         goto out;
     }
 
     /* Read the number of g2 points */
-    num_matches = fscanf(in, "%" SCNu64, &i);
-    if (num_matches != 1 || i != NUM_G2_POINTS) {
+    num_matches = fscanf(in, "%" SCNu64, &num_g2_points);
+    if (num_matches != 1 || num_g2_points != NUM_G2_POINTS) {
         ret = C_KZG_BADARGS;
         goto out;
     }
 
     /* Read all of the g1 points in Lagrange form, byte by byte */
-    for (i = 0; i < NUM_G1_POINTS * BYTES_PER_G1; i++) {
+    for (size_t i = 0; i < NUM_G1_POINTS * BYTES_PER_G1; i++) {
         num_matches = fscanf(in, "%2hhx", &g1_lagrange_bytes[i]);
         if (num_matches != 1) {
             ret = C_KZG_BADARGS;
@@ -513,7 +514,7 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in, size_t precompute)
     }
 
     /* Read all of the g2 points in monomial form, byte by byte */
-    for (i = 0; i < NUM_G2_POINTS * BYTES_PER_G2; i++) {
+    for (size_t i = 0; i < NUM_G2_POINTS * BYTES_PER_G2; i++) {
         num_matches = fscanf(in, "%2hhx", &g2_monomial_bytes[i]);
         if (num_matches != 1) {
             ret = C_KZG_BADARGS;
@@ -523,7 +524,7 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in, size_t precompute)
 
     /* Read all of the g1 points in monomial form, byte by byte */
     /* Note: this is last because it is an extension for EIP-7594 */
-    for (i = 0; i < NUM_G1_POINTS * BYTES_PER_G1; i++) {
+    for (size_t i = 0; i < NUM_G1_POINTS * BYTES_PER_G1; i++) {
         num_matches = fscanf(in, "%2hhx", &g1_monomial_bytes[i]);
         if (num_matches != 1) {
             ret = C_KZG_BADARGS;


### PR DESCRIPTION
I reviewed the C code to see where we could use `size_t` instead of `uint64_t`.