### PR TITLE
Reformat some function param docs for consistency

### DIFF
--- a/src/common/alloc.c
+++ b/src/common/alloc.c
@@ -29,10 +29,10 @@
 /**
  * Wrapped malloc() that reports failures to allocate.
  *
- * @remark Will return C_KZG_BADARGS if the requested size is zero.
+ * @param[out]  out     Pointer to the allocated space
+ * @param[in]   size    The number of bytes to be allocated
  *
- * @param[out] out  Pointer to the allocated space
- * @param[in]  size The number of bytes to be allocated
+ * @remark Will return C_KZG_BADARGS if the requested size is zero.
  */
 C_KZG_RET c_kzg_malloc(void **out, size_t size) {
     *out = NULL;
@@ -44,9 +44,9 @@ C_KZG_RET c_kzg_malloc(void **out, size_t size) {
 /**
  * Wrapped calloc() that reports failures to allocate.
  *
- * @param[out] out   Pointer to the allocated space
- * @param[in]  count The number of elements
- * @param[in]  size  The size of each element
+ * @param[out]  out     Pointer to the allocated space
+ * @param[in]   count   The number of elements
+ * @param[in]   size    The size of each element
  *
  * @remark Will return C_KZG_BADARGS if the requested size is zero.
  */
@@ -60,8 +60,8 @@ C_KZG_RET c_kzg_calloc(void **out, size_t count, size_t size) {
 /**
  * Allocate memory for an array of G1 group elements.
  *
- * @param[out] x Pointer to the allocated space
- * @param[in]  n The number of G1 elements to be allocated
+ * @param[out]  x   Pointer to the allocated space
+ * @param[in]   n   The number of G1 elements to be allocated
  *
  * @remark Free the space later using c_kzg_free().
  */
@@ -72,8 +72,8 @@ C_KZG_RET new_g1_array(g1_t **x, size_t n) {
 /**
  * Allocate memory for an array of G2 group elements.
  *
- * @param[out] x Pointer to the allocated space
- * @param[in]  n The number of G2 elements to be allocated
+ * @param[out]  x   Pointer to the allocated space
+ * @param[in]   n   The number of G2 elements to be allocated
  *
  * @remark Free the space later using c_kzg_free().
  */
@@ -84,8 +84,8 @@ C_KZG_RET new_g2_array(g2_t **x, size_t n) {
 /**
  * Allocate memory for an array of field elements.
  *
- * @param[out] x Pointer to the allocated space
- * @param[in]  n The number of field elements to be allocated
+ * @param[out]  x   Pointer to the allocated space
+ * @param[in]   n   The number of field elements to be allocated
  *
  * @remark Free the space later using c_kzg_free().
  */
@@ -96,8 +96,8 @@ C_KZG_RET new_fr_array(fr_t **x, size_t n) {
 /**
  * Allocate memory for an array of booleans.
  *
- * @param[out] x Pointer to the allocated space
- * @param[in]  n The number of booleans to be allocated
+ * @param[out]  x   Pointer to the allocated space
+ * @param[in]   n   The number of booleans to be allocated
  *
  * @remark Free the space later using c_kzg_free().
  */

--- a/src/common/bytes.c
+++ b/src/common/bytes.c
@@ -21,8 +21,8 @@
 /**
  * Serialize a 64-bit unsigned integer into bytes.
  *
- * @param[out] out An 8-byte array to store the serialized integer
- * @param[in]  n   The integer to be serialized
+ * @param[out]  out An 8-byte array to store the serialized integer
+ * @param[in]   n   The integer to be serialized
  *
  * @remark The output format is big-endian.
  */
@@ -36,8 +36,8 @@ void bytes_from_uint64(uint8_t out[8], uint64_t n) {
 /**
  * Serialize a G1 group element into bytes.
  *
- * @param[out] out A 48-byte array to store the serialized G1 element
- * @param[in]  in  The G1 element to be serialized
+ * @param[out]  out A 48-byte array to store the serialized G1 element
+ * @param[in]   in  The G1 element to be serialized
  */
 void bytes_from_g1(Bytes48 *out, const g1_t *in) {
     blst_p1_compress(out->bytes, in);
@@ -46,8 +46,8 @@ void bytes_from_g1(Bytes48 *out, const g1_t *in) {
 /**
  * Serialize a BLS field element into bytes.
  *
- * @param[out] out A 32-byte array to store the serialized field element
- * @param[in] in The field element to be serialized
+ * @param[out]  out A 32-byte array to store the serialized field element
+ * @param[in]   in  The field element to be serialized
  */
 void bytes_from_bls_field(Bytes32 *out, const fr_t *in) {
     blst_scalar s;
@@ -58,8 +58,8 @@ void bytes_from_bls_field(Bytes32 *out, const fr_t *in) {
 /**
  * Convert untrusted bytes to a trusted and validated BLS scalar field element.
  *
- * @param[out] out The field element to store the deserialized data
- * @param[in]  b   A 32-byte array containing the serialized field element
+ * @param[out]  out The field element to store the deserialized data
+ * @param[in]   b   A 32-byte array containing the serialized field element
  */
 C_KZG_RET bytes_to_bls_field(fr_t *out, const Bytes32 *b) {
     blst_scalar tmp;

--- a/src/common/ec.c
+++ b/src/common/ec.c
@@ -22,9 +22,9 @@
 /**
  * Subtraction of G1 group elements.
  *
- * @param[out] out `a - b`
- * @param[in]  a   A G1 group element
- * @param[in]  b   The G1 group element to be subtracted
+ * @param[out]  out The result, `a - b`
+ * @param[in]   a   A G1 group element
+ * @param[in]   b   The G1 group element to be subtracted
  */
 void g1_sub(g1_t *out, const g1_t *a, const g1_t *b) {
     g1_t bneg = *b;
@@ -35,9 +35,9 @@ void g1_sub(g1_t *out, const g1_t *a, const g1_t *b) {
 /**
  * Multiply a G1 group element by a field element.
  *
- * @param[out] out  `a * b`
- * @param[in]  a    The G1 group element
- * @param[in]  b    The multiplier
+ * @param[out]  out The result, `a * b`
+ * @param[in]   a   The G1 group element
+ * @param[in]   b   The multiplier
  */
 void g1_mul(g1_t *out, const g1_t *a, const fr_t *b) {
     blst_scalar s;

--- a/src/common/fr.c
+++ b/src/common/fr.c
@@ -26,8 +26,8 @@
  * @param[in]   a   The first element
  * @param[in]   b   The second element
  *
- * @retval true     The two elements are equal.
- * @retval false    The two elements are not equal.
+ * @retval  true    The two elements are equal.
+ * @retval  false   The two elements are not equal.
  */
 bool fr_equal(const fr_t *a, const fr_t *b) {
     uint64_t _a[4], _b[4];
@@ -39,10 +39,10 @@ bool fr_equal(const fr_t *a, const fr_t *b) {
 /**
  * Test whether the operand is one in the finite field.
  *
- * @param[in] p The field element to be checked
+ * @param[in]   p   The field element to be checked
  *
- * @retval true  The element is one
- * @retval false The element is not one
+ * @retval  true    The element is one
+ * @retval  false   The element is not one
  */
 bool fr_is_one(const fr_t *p) {
     uint64_t a[4];
@@ -53,10 +53,10 @@ bool fr_is_one(const fr_t *p) {
 /**
  * Test whether the operand is null (all 0xff's).
  *
- * @param[in] p The field element to be checked
+ * @param[in]   p   The field element to be checked
  *
- * @retval true  The element is null
- * @retval false The element is not null
+ * @retval  true    The element is null
+ * @retval  false   The element is not null
  */
 bool fr_is_null(const fr_t *p) {
     return fr_equal(p, &FR_NULL);
@@ -65,9 +65,9 @@ bool fr_is_null(const fr_t *p) {
 /**
  * Divide a field element by another.
  *
- * @param[out] out `a` divided by `b` in the field
- * @param[in]  a   The dividend
- * @param[in]  b   The divisor
+ * @param[out]  out The result, `a / b`
+ * @param[in]   a   The dividend
+ * @param[in]   b   The divisor
  *
  * @remark The behavior for `b == 0` is unspecified.
  * @remark This function supports in-place computation.
@@ -83,9 +83,9 @@ void fr_div(fr_t *out, const fr_t *a, const fr_t *b) {
  *
  * Uses square and multiply for log(n) performance.
  *
- * @param[out] out `a` raised to the power of `n`
- * @param[in]  a   The field element to be exponentiated
- * @param[in]  n   The exponent
+ * @param[out]  out The result, `a**n`
+ * @param[in]   a   The field element to be exponentiated
+ * @param[in]   n   The exponent
  *
  * @remark A 64-bit exponent is sufficient for our needs here.
  * @remark This function does support in-place computation.
@@ -106,8 +106,8 @@ void fr_pow(fr_t *out, const fr_t *a, uint64_t n) {
 /**
  * Create a field element from a single 64-bit unsigned integer.
  *
- * @param[out] out The field element equivalent of `n`
- * @param[in]  n   The 64-bit integer to be converted
+ * @param[out]  out The field element equivalent of `n`
+ * @param[in]   n   The 64-bit integer to be converted
  *
  * @remark This can only generate a tiny fraction of possible field elements,
  *         and is mostly useful for testing.

--- a/src/common/lincomb.c
+++ b/src/common/lincomb.c
@@ -24,7 +24,12 @@
  *
  * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n` where `n` is `len - 1`.
  *
- * This function computes the result naively without using Pippenger's algorithm.
+ * @param[out]  out     The resulting sum-product
+ * @param[in]   p       Array of G1 group elements, length `len`
+ * @param[in]   coeffs  Array of field elements, length `len`
+ * @param[in]   len     The number of group/field elements
+ *
+ * @remark This function computes the result naively without using Pippenger's algorithm.
  */
 void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) {
     g1_t tmp;
@@ -40,10 +45,10 @@ void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) 
  *
  * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n` where `n` is `len - 1`.
  *
- * @param[out] out    The resulting sum-product
- * @param[in]  p      Array of G1 group elements, length `len`
- * @param[in]  coeffs Array of field elements, length `len`
- * @param[in]  len    The number of group/field elements
+ * @param[out]  out     The resulting sum-product
+ * @param[in]   p       Array of G1 group elements, length `len`
+ * @param[in]   coeffs  Array of field elements, length `len`
+ * @param[in]   len     The number of group/field elements
  *
  * @remark This function CAN be called with the point at infinity in `p`.
  * @remark While this function is significantly faster than g1_lincomb_naive(), we refrain from

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -24,7 +24,7 @@
 /**
  * Utility function to test whether the argument is a power of two.
  *
- * @param[in] n The number to test
+ * @param[in]   n   The number to test
  *
  * @return True if `n` is zero or a power of two, otherwise false.
  *
@@ -39,7 +39,7 @@ bool is_power_of_two(uint64_t n) {
 /**
  * Calculate log base two of a power of two.
  *
- * @param[in] n The power of two
+ * @param[in]   n   The power of two
  *
  * @return The log base two of n.
  *
@@ -89,9 +89,9 @@ uint64_t reverse_bits_limited(uint64_t n, uint64_t value) {
 /**
  * Reorder an array in reverse bit order of its indices.
  *
- * @param[in,out] values The array, which is re-ordered in-place
- * @param[in]     size   The size in bytes of an element of the array
- * @param[in]     n      The length of the array, must be a power of two strictly greater than 1
+ * @param[in,out]   values  The array, which is re-ordered in-place
+ * @param[in]       size    The size in bytes of an element of the array
+ * @param[in]       n       The length of the array, must be a power of two strictly greater than 1
  *
  * @remark Operates in-place on the array.
  * @remark Can handle arrays of any type: provide the element size in `size`.
@@ -153,10 +153,10 @@ void compute_powers(fr_t *out, const fr_t *x, size_t n) {
  *
  * Tests whether `e(a1, a2) == e(b1, b2)`.
  *
- * @param[in] a1 A G1 group point for the first pairing
- * @param[in] a2 A G2 group point for the first pairing
- * @param[in] b1 A G1 group point for the second pairing
- * @param[in] b2 A G2 group point for the second pairing
+ * @param[in]   a1  A G1 group point for the first pairing
+ * @param[in]   a2  A G2 group point for the first pairing
+ * @param[in]   b1  A G1 group point for the second pairing
+ * @param[in]   b2  A G2 group point for the second pairing
  *
  * @retval true  The pairings were equal
  * @retval false The pairings were not equal

--- a/src/eip4844/eip4844.c
+++ b/src/eip4844/eip4844.c
@@ -63,10 +63,10 @@ typedef struct {
 /**
  * Test whether the operand is zero in the finite field.
  *
- * @param[in] p The field element to be checked
+ * @param[in]   p   The field element to be checked
  *
- * @retval true  The element is zero
- * @retval false The element is not zero
+ * @retval  true    The element is zero
+ * @retval  false   The element is not zero
  */
 static bool fr_is_zero(const fr_t *p) {
     uint64_t a[4];
@@ -77,9 +77,9 @@ static bool fr_is_zero(const fr_t *p) {
 /**
  * Montgomery batch inversion in finite field.
  *
- * @param[out] out The inverses of `a`, length `len`
- * @param[in]  a   A vector of field elements, length `len`
- * @param[in]  len The number of field elements
+ * @param[out]  out The inverses of `a`, length `len`
+ * @param[in]   a   A vector of field elements, length `len`
+ * @param[in]   len The number of field elements
  *
  * @remark This function only supports len > 0.
  * @remark This function does NOT support in-place computation.
@@ -117,9 +117,9 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
 /**
  * Multiply a G2 group element by a field element.
  *
- * @param[out] out `a * b`
- * @param[in]  a   The G2 group element
- * @param[in]  b   The multiplier
+ * @param[out]  out The result, `a * b`
+ * @param[in]   a   The G2 group element
+ * @param[in]   b   The multiplier
  */
 static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
     blst_scalar s;
@@ -130,9 +130,9 @@ static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
 /**
  * Subtraction of G2 group elements.
  *
- * @param[out] out `a - b`
- * @param[in]  a   A G2 group element
- * @param[in]  b   The G2 group element to be subtracted
+ * @param[out]  out The result, `a - b`
+ * @param[in]   a   A G2 group element
+ * @param[in]   b   The G2 group element to be subtracted
  */
 static void g2_sub(g2_t *out, const g2_t *a, const g2_t *b) {
     g2_t bneg = *b;
@@ -147,9 +147,9 @@ static void g2_sub(g2_t *out, const g2_t *a, const g2_t *b) {
 /**
  * Return the Fiat-Shamir challenge required to verify `blob` and `commitment`.
  *
- * @param[out] eval_challenge_out The evaluation challenge
- * @param[in]  blob               A blob
- * @param[in]  commitment         A commitment
+ * @param[out]  eval_challenge_out  The evaluation challenge
+ * @param[in]   blob                A blob
+ * @param[in]   commitment          A commitment
  *
  * @remark This function should compute challenges even if `n == 0`.
  */
@@ -193,10 +193,10 @@ static void compute_challenge(fr_t *eval_challenge_out, const Blob *blob, const 
 /**
  * Evaluate a polynomial in evaluation form at a given point.
  *
- * @param[out] out The result of the evaluation
- * @param[in]  p   The polynomial in evaluation form
- * @param[in]  x   The point to evaluate the polynomial at
- * @param[in]  s   The trusted setup
+ * @param[out]  out The result of the evaluation
+ * @param[in]   p   The polynomial in evaluation form
+ * @param[in]   x   The point to evaluate the polynomial at
+ * @param[in]   s   The trusted setup
  */
 static C_KZG_RET evaluate_polynomial_in_evaluation_form(
     fr_t *out, const Polynomial *p, const fr_t *x, const KZGSettings *s
@@ -255,9 +255,9 @@ out:
 /**
  * Compute a KZG commitment from a polynomial.
  *
- * @param[out] out The resulting commitment
- * @param[in]  p   The polynomial to commit to
- * @param[in]  s   The trusted setup
+ * @param[out]  out The resulting commitment
+ * @param[in]   p   The polynomial to commit to
+ * @param[in]   s   The trusted setup
  */
 static C_KZG_RET poly_to_kzg_commitment(g1_t *out, const Polynomial *p, const KZGSettings *s) {
     return g1_lincomb_fast(
@@ -268,9 +268,9 @@ static C_KZG_RET poly_to_kzg_commitment(g1_t *out, const Polynomial *p, const KZ
 /**
  * Convert a blob to a KZG commitment.
  *
- * @param[out] out  The resulting commitment
- * @param[in]  blob The blob representing the polynomial to be committed to
- * @param[in]  s    The trusted setup
+ * @param[out]  out     The resulting commitment
+ * @param[in]   blob    The blob representing the polynomial to be committed to
+ * @param[in]   s       The trusted setup
  */
 C_KZG_RET blob_to_kzg_commitment(KZGCommitment *out, const Blob *blob, const KZGSettings *s) {
     C_KZG_RET ret;
@@ -298,12 +298,12 @@ static C_KZG_RET verify_kzg_proof_impl(
 /**
  * Verify a KZG proof claiming that `p(z) == y`.
  *
- * @param[out] ok         True if the proofs are valid, otherwise false
- * @param[in]  commitment The KZG commitment corresponding to poly p(x)
- * @param[in]  z          The evaluation point
- * @param[in]  y          The claimed evaluation result
- * @param[in]  kzg_proof  The KZG proof
- * @param[in]  s          The trusted setup
+ * @param[out]  ok          True if the proofs are valid, otherwise false
+ * @param[in]   commitment  The KZG commitment corresponding to poly p(x)
+ * @param[in]   z           The evaluation point
+ * @param[in]   y           The claimed evaluation result
+ * @param[in]   kzg_proof   The KZG proof
+ * @param[in]   s           The trusted setup
  */
 C_KZG_RET verify_kzg_proof(
     bool *ok,
@@ -383,11 +383,11 @@ static C_KZG_RET compute_kzg_proof_impl(
 /**
  * Compute KZG proof for polynomial in Lagrange form at position z.
  *
- * @param[out] proof_out The combined proof as a single G1 element
- * @param[out] y_out     The evaluation of the polynomial at the evaluation point z
- * @param[in]  blob      The blob (polynomial) to generate a proof for
- * @param[in]  z         The generator z-value for the evaluation points
- * @param[in]  s         The trusted setup
+ * @param[out]  proof_out   The combined proof as a single G1 element
+ * @param[out]  y_out       The evaluation of the polynomial at the evaluation point z
+ * @param[in]   blob        The blob (polynomial) to generate a proof for
+ * @param[in]   z           The generator z-value for the evaluation points
+ * @param[in]   s           The trusted setup
  */
 C_KZG_RET compute_kzg_proof(
     KZGProof *proof_out,
@@ -415,11 +415,11 @@ out:
 /**
  * Helper function for compute_kzg_proof() and compute_blob_kzg_proof().
  *
- * @param[out] proof_out  The combined proof as a single G1 element
- * @param[out] y_out      The evaluation of the polynomial at the evaluation point z
- * @param[in]  polynomial The polynomial in Lagrange form
- * @param[in]  z          The evaluation point
- * @param[in]  s          The trusted setup
+ * @param[out]  proof_out   The combined proof as a single G1 element
+ * @param[out]  y_out       The evaluation of the polynomial at the evaluation point z
+ * @param[in]   polynomial  The polynomial in Lagrange form
+ * @param[in]   z           The evaluation point
+ * @param[in]   s           The trusted setup
  */
 static C_KZG_RET compute_kzg_proof_impl(
     KZGProof *proof_out,
@@ -508,10 +508,10 @@ out:
  * commitment. This function does not verify that the commitment is correct with respect to the
  * blob.
  *
- * @param[out] out              The resulting proof
- * @param[in]  blob             A blob
- * @param[in]  commitment_bytes Commitment to verify
- * @param[in]  s                The trusted setup
+ * @param[out]  out                 The resulting proof
+ * @param[in]   blob                A blob
+ * @param[in]   commitment_bytes    Commitment to verify
+ * @param[in]   s                   The trusted setup
  */
 C_KZG_RET compute_blob_kzg_proof(
     KZGProof *out, const Blob *blob, const Bytes48 *commitment_bytes, const KZGSettings *s
@@ -542,11 +542,11 @@ out:
 /**
  * Given a blob and its proof, verify that it corresponds to the provided commitment.
  *
- * @param[out] ok               True if the proofs are valid, otherwise false
- * @param[in]  blob             Blob to verify
- * @param[in]  commitment_bytes Commitment to verify
- * @param[in]  proof_bytes      Proof used for verification
- * @param[in]  s                The trusted setup
+ * @param[out]  ok                  True if the proofs are valid, otherwise false
+ * @param[in]   blob                Blob to verify
+ * @param[in]   commitment_bytes    Commitment to verify
+ * @param[in]   proof_bytes         Proof used for verification
+ * @param[in]   s                   The trusted setup
  */
 C_KZG_RET verify_blob_kzg_proof(
     bool *ok,
@@ -584,11 +584,11 @@ C_KZG_RET verify_blob_kzg_proof(
 /**
  * Compute random linear combination challenge scalars for batch verification.
  *
- * @param[out]  r_powers_out   The output challenges
- * @param[in]   commitments_g1 The input commitments
- * @param[in]   zs_fr          The input evaluation points
- * @param[in]   ys_fr          The input evaluation results
- * @param[in]   proofs_g1      The input proofs
+ * @param[out]  r_powers_out    The output challenges
+ * @param[in]   commitments_g1  The input commitments
+ * @param[in]   zs_fr           The input evaluation points
+ * @param[in]   ys_fr           The input evaluation results
+ * @param[in]   proofs_g1       The input proofs
  */
 static C_KZG_RET compute_r_powers_for_verify_kzg_proof_batch(
     fr_t *r_powers_out,
@@ -659,13 +659,13 @@ out:
 /**
  * Helper function for verify_blob_kzg_proof_batch(): actually perform the verification.
  *
- * @param[out] ok             True if the proofs are valid, otherwise false
- * @param[in]  commitments_g1 Array of commitments to verify
- * @param[in]  zs_fr          Array of evaluation points for the KZG proofs
- * @param[in]  ys_fr          Array of evaluation results for the KZG proofs
- * @param[in]  proofs_g1      Array of proofs used for verification
- * @param[in]  n              The number of blobs/commitments/proofs
- * @param[in]  s              The trusted setup
+ * @param[out]  ok              True if the proofs are valid, otherwise false
+ * @param[in]   commitments_g1  Array of commitments to verify
+ * @param[in]   zs_fr           Array of evaluation points for the KZG proofs
+ * @param[in]   ys_fr           Array of evaluation results for the KZG proofs
+ * @param[in]   proofs_g1       Array of proofs used for verification
+ * @param[in]   n               The number of blobs/commitments/proofs
+ * @param[in]   s               The trusted setup
  *
  * @remark This function only works for `n > 0`.
  * @remark This function assumes that `n` is trusted and that all input arrays contain `n` elements.
@@ -738,12 +738,12 @@ out:
  * Given a list of blobs and blob KZG proofs, verify that they correspond to the provided
  * commitments.
  *
- * @param[out] ok                True if the proofs are valid, otherwise false
- * @param[in]  blobs             Array of blobs to verify
- * @param[in]  commitments_bytes Array of commitments to verify
- * @param[in]  proofs_bytes      Array of proofs used for verification
- * @param[in]  n                 The number of blobs/commitments/proofs
- * @param[in]  s                 The trusted setup
+ * @param[out]  ok                  True if the proofs are valid, otherwise false
+ * @param[in]   blobs               Array of blobs to verify
+ * @param[in]   commitments_bytes   Array of commitments to verify
+ * @param[in]   proofs_bytes        Array of proofs used for verification
+ * @param[in]   n                   The number of blobs/commitments/proofs
+ * @param[in]   s                   The trusted setup
  *
  * @remark This function accepts if called with `n==0`.
  * @remark This function assumes that `n` is trusted and that all input arrays contain `n` elements.

--- a/src/eip7594/fft.c
+++ b/src/eip7594/fft.c
@@ -146,12 +146,12 @@ C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
  *
  * Recursively divide and conquer.
  *
- * @param[out] out          The results (length `n`)
- * @param[in]  in           The input data (length `n * stride`)
- * @param[in]  stride       The input data stride
- * @param[in]  roots        Roots of unity (length `n * roots_stride`)
- * @param[in]  roots_stride The stride interval among the roots of unity
- * @param[in]  n            Length of the FFT, must be a power of two
+ * @param[out]  out             The results (length `n`)
+ * @param[in]   in              The input data (length `n * stride`)
+ * @param[in]   stride          The input data stride
+ * @param[in]   roots           Roots of unity (length `n * roots_stride`)
+ * @param[in]   roots_stride    The stride interval among the roots of unity
+ * @param[in]   n               Length of the FFT, must be a power of two
  */
 static void g1_fft_fast(
     g1_t *out, const g1_t *in, size_t stride, const fr_t *roots, size_t roots_stride, size_t n

--- a/src/eip7594/poly.c
+++ b/src/eip7594/poly.c
@@ -31,9 +31,9 @@
  * Multiplies each coefficient by `shift_factor ^ i`. Equivalent to creating a polynomial that
  * evaluates at `x * shift_factor` rather than `x`.
  *
- * @param[in,out]   p            The polynomial coefficients to be scaled
- * @param[in]       len          Length of the polynomial coefficients
- * @param[in]       shift_factor Shift factor
+ * @param[in,out]   p               The polynomial coefficients to be scaled
+ * @param[in]       len             Length of the polynomial coefficients
+ * @param[in]       shift_factor    Shift factor
  */
 void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
     fr_t factor_power = FR_ONE;

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -86,9 +86,9 @@ static const fr_t ROOT_OF_UNITY = {
 /**
  * Generate powers of a root of unity in the field.
  *
- * @param[out] out   The roots of unity (length `width + 1`)
- * @param[in]  root  A root of unity
- * @param[in]  width One less than the size of `out`
+ * @param[out]  out     The roots of unity (length `width + 1`)
+ * @param[in]   root    A root of unity
+ * @param[in]   width   One less than the size of `out`
  *
  * @remark `root` must be such that `root ^ width` is equal to one, but no smaller power of `root`
  * is equal to one.
@@ -152,7 +152,7 @@ out:
 /**
  * Free a trusted setup (KZGSettings).
  *
- * @param[in] s The trusted setup to free
+ * @param[in]   s   The trusted setup to free
  *
  * @remark This does nothing if `s` is NULL.
  */
@@ -320,9 +320,9 @@ out:
 /**
  * Basic sanity check that the trusted setup was loaded in Lagrange form.
  *
- * @param[in] s  Pointer to the stored trusted setup data
- * @param[in] n1 Number of `g1` points in trusted_setup
- * @param[in] n2 Number of `g2` points in trusted_setup
+ * @param[in]   s   Pointer to the stored trusted setup data
+ * @param[in]   n1  Number of G1 points in the trusted setup
+ * @param[in]   n2  Number of G2 points in the trusted setup
  */
 static C_KZG_RET is_trusted_setup_in_lagrange_form(const KZGSettings *s, size_t n1, size_t n2) {
     /* Trusted setup is too small; we can't work with this */


### PR DESCRIPTION
There were some functions using a single space vs a tab (of spaces) between the params.