### PR TITLE
Use latest cibuildwheel for Python release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: egor-tensin/vs-shell@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.5
+        run: python -m pip install cibuildwheel
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
The Python package release action is failing. Updating this might fix it.

https://github.com/ethereum/c-kzg-4844/actions/runs/10470645204