### PR TITLE
fix: node.js publish

### DIFF
--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -17,8 +17,9 @@ jobs:
           - macos-latest
           - windows-latest
         node:
-          - 16
           - 18
+          - 20
+          - 22
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install setuptools
         run: |
           python -m pip install --upgrade pip
@@ -42,6 +42,3 @@ jobs:
       - name: Build/test bindings
         working-directory: bindings/node.js
         run: make build test
-      - name: Install distribution
-        working-directory: bindings/node.js/dist
-        run: npm install

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: make format
       - name: Build/test bindings
         working-directory: bindings/node.js
-        run: make build test bundle
+        run: make build test
       - name: Install distribution
         working-directory: bindings/node.js/dist
         run: npm install

--- a/bindings/node.js/.dockerignore
+++ b/bindings/node.js/.dockerignore
@@ -1,0 +1,3 @@
+build
+*.node
+node_modules

--- a/bindings/node.js/Dockerfile
+++ b/bindings/node.js/Dockerfile
@@ -3,7 +3,7 @@ RUN apk update && apk add --no-cache g++ make python3
 
 WORKDIR /app/bindings/node.js
 
-COPY dist .
+COPY . .
 RUN yarn install
 
 COPY test ./test

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -44,17 +44,6 @@ build: install clean
 	@$(YARN) node-gyp --loglevel=warn configure
 	@$(YARN) node-gyp --loglevel=warn build
 
-# Bundle the distribution, also helpful for cross compatibility checks
-.PHONY: bundle
-bundle: build
-	@mkdir dist
-	@mv deps dist
-	@cp -r lib dist/lib
-	@cp -r src dist/src
-	@cp README.md dist/README.md
-	@cp package.json dist/package.json
-	@cp binding.gyp dist/binding.gyp
-
 # Run unit tests and ref-tests
 .PHONY: test
 test: install
@@ -69,13 +58,12 @@ format: install
 
 # Publish package to npm (requires an auth token)
 .PHONY: publish
-publish: build bundle
-	@cd dist
-	@npm publish
+publish: build
+	@npm pack
 
 # Run ref-tests in linux environment for cross-compatibility check
 .PHONY: linux-test
-linux-test: bundle
+linux-test: build
 	@# Docker cannot copy from outside this dir
 	@cp -r ../../tests ref-tests
 	@docker build -t "linux-test" .

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -2,7 +2,7 @@
 YARN = yarn --silent
 
 .PHONY: all
-all: format build test bundle
+all: format build test
 
 # Cleans native dependency, bindings and typescript artifacts
 .PHONY: clean

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -58,8 +58,8 @@ format: install
 
 # Publish package to npm (requires an auth token)
 .PHONY: publish
-publish: build
-	@npm pack
+publish: build test
+	@npm publish
 
 # Run ref-tests in linux environment for cross-compatibility check
 .PHONY: linux-test

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,10 +1,10 @@
 {
   "name": "c-kzg",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "NodeJS bindings for C-KZG",
   "contributors": [
-    "Dan Coffman <dgcoffman@gmail.com>",
-    "Matthew Keil <me@matthewkeil.com>"
+    "Matthew Keil <me@matthewkeil.com>",
+    "Dan Coffman <dgcoffman@gmail.com>"
   ],
   "license": "MIT",
   "dependencies": {
@@ -37,5 +37,13 @@
   "homepage": "https://github.com/ethereum/c-kzg-4844",
   "main": "lib/kzg.js",
   "types": "lib/kzg.d.ts",
-  "gypfile": true
+  "gypfile": true,
+  "files": [
+    "deps",
+    "lib",
+    "src",
+    "binding.gyp",
+    "package.json",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
When publishing 4.0.0 there was an error and the bundle published without the `deps` folder.  The `make command` did not correctly switch directories and published the root folder, not the `dist` folder.  I updated the process to use the canonical method that node uses to avoid future issues.

I also updated the supported/tested versions of node that are run in CI