### PR TITLE
Add "/v2" to Go module name

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,7 +6,7 @@ exported functions in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).
 ## Installation
 
 ```
-go get github.com/ethereum/c-kzg-4844
+go get github.com/ethereum/c-kzg-4844/v2
 ```
 
 ## Go version

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethereum/c-kzg-4844
+module github.com/ethereum/c-kzg-4844/v2
 
 go 1.19
 


### PR DESCRIPTION
Seems that this is necessary for a v2 release...

https://pkg.go.dev/github.com/ethereum/c-kzg-4844?tab=versions