### PR TITLE
Fix profiling instructions for Linux

### DIFF
--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -10,7 +10,7 @@ took, but it will help you determine which functions are the most expensive.
 
 On Linux (Debian), you need to install:
 ```
-sudo apt install gperftools graphviz
+sudo apt install google-perftools graphviz
 ```
 
 On macOS, you need to install (via [homebrew](https://brew.sh)):

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -10,8 +10,14 @@ took, but it will help you determine which functions are the most expensive.
 
 On Linux (Debian), you need to install:
 ```
-sudo apt install google-perftools graphviz
+sudo apt install libgoogle-perftools-dev graphviz
 ```
+Assuming you have Go installed, get `pprof` from:
+```
+go install github.com/google/pprof@latest
+```
+Depending on your shell, edit the corresponding configuration file to 
+add the Go binary path (`$HOME/go/bin`) to your `PATH`.
 
 On macOS, you need to install (via [homebrew](https://brew.sh)):
 ```


### PR DESCRIPTION
The debian package name `gperftools` is now deprecated, and is replaced with `libgoogle-perftools-dev`. Additionally the `pprof` binary seems to be decoupled from perftools, for debian we would separately install it from Go packages.

![image](https://github.com/user-attachments/assets/5052d3fc-ab94-4813-a60b-e91138c9ed86)

Overall the instructions would look like this now:
![image](https://github.com/user-attachments/assets/64608258-e387-43fc-b517-dc8377c59da9)

