### PR TITLE
README's: More Consistent Structure + Fix Dead Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ high-level languages, providing convenient wrappers around C functions. These
 bindings are intended to be used by Ethereum clients, to avoid re-implementation
 of crucial cryptographic functions.
 
+For all bindings, you first need to make sure that the `blst` submodule is correctly pulled after clone.
+To do so, you may need to run:
+
+```
+git submodule update --init
+```
+
+
 | Language | Link                                 |
 |----------|--------------------------------------|
 | C#       | [README](bindings/csharp/README.md)  |
@@ -88,8 +96,8 @@ C-KZG-4844 is not expected to be used outside the bindings.
 The source code of C-KZG-4844 was audited by [Sigma
 Prime](https://sigmaprime.io/) in June 2023. You can find the [audit
 report](doc/audit/Sigma_Prime_Ethereum_Foundation_KZG_Implementations_Security_Assessment.pdf)
-in the `doc/audit/` directory. Notably, the audit was for commit `fd24cf8` and 
-code introduced for EIP-7594 *has not been audited yet*. 
+in the `doc/audit/` directory. Notably, the audit was for commit `fd24cf8` and
+code introduced for EIP-7594 *has not been audited yet*.
 
 ### Why C?
 

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -1,4 +1,4 @@
-# C# bindings
+# C# Bindings for the C-KZG Library
 
 This directory contains C# bindings for the C-KZG-4844 library.
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,19 +1,19 @@
-# Go bindings
+# Go Bindings for the C-KZG Library
 
-This package implements Go bindings (using [Cgo](https://go.dev/blog/cgo)) for the
-exported functions in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).
+This directory contains Go bindings for the C-KZG-4844 library.
+The bindings use [Cgo](https://go.dev/blog/cgo).
+
+## Prerequisites
+
+This package requires `1.19rc1` or later. Version `1.19beta1` and before will
+not work. These versions have a linking issue and are unable to see `blst`
+functions.
 
 ## Installation
 
 ```
 go get github.com/ethereum/c-kzg-4844/v2
 ```
-
-## Go version
-
-This package requires `1.19rc1` or later. Version `1.19beta1` and before will
-not work. These versions have a linking issue and are unable to see `blst`
-functions.
 
 ## Tests
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,13 +1,13 @@
-# Java binding
+# Java Bindings for the C-KZG Library
 
-## Build shared library
+This directory contains Java bindings for the C-KZG-4844 library.
 
-### Prerequisites
+## Prerequisites
 
 * Build blst by running `make blst` in the [library source directory](../../src).
 * Set `JAVA_HOME` environment variable to a JDK with an `include` folder containing a `jni.h` file.
 
-### Build
+## Build
 
 ```bash
 make build
@@ -25,7 +25,7 @@ the [Makefile](./Makefile).
 make test
 ```
 
-## Library
+## Public Maven Repo
 
 The library which uses this binding and publishes a package to a public maven repo
 is [jc-kzg-4844](https://github.com/ConsenSys/jc-kzg-4844).

--- a/bindings/nim/README.md
+++ b/bindings/nim/README.md
@@ -1,8 +1,8 @@
-# Nim bindings
+# Nim Bindings for the C-KZG Library
 
-This directory contains Nim bindings for the c-kzg-4844 library.
+This directory contains Nim bindings for the C-KZG-4844 library.
 
-## Requirements
+## Prerequisites
 
 These bindings support Nim compiler version 1.2, 1.4, 1.6, and devel.
 
@@ -11,6 +11,14 @@ You also need to install dependencies:
 ```
 nimble install stew
 ```
+
+## Installation
+Install via nimble:
+
+```
+nimble install https://github.com/ethereum/c-kzg-4844
+```
+
 
 ## Tests
 
@@ -36,12 +44,6 @@ Or from c-kzg-4844 root folder:
 nimble test
 ```
 
-## How to use these bindings in your project
+## Usage
 
-Install via nimble:
-
-```
-nimble install https://github.com/ethereum/c-kzg-4844
-```
-
-Then import `kzg4844/kzg` or `kzg4844/kzg_abi` into your project.
+After installation, import `kzg4844/kzg` or `kzg4844/kzg_abi` into your project.

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -1,15 +1,6 @@
-# C-KZG-4844
+# Node.js Bindings for the C-KZG Library
 
-This is a TypeScript library for EIP-4844 and EIP-7594 that implements the
-[Polynomial Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md)
-API. The core functionality was originally a stripped-down copy of
-[C-KZG](https://github.com/benjaminion/c-kzg), but has been heavily modified
-since then. This package wraps that native `c-kzg` C code in C/C++ NAPI
-bindings for use in node.js applications.
-
-Important Links:
-[EIP-4844 - Polynomial Commitments](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md)
-[EIP-7594 - Polynomial Commitments Sampling](https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/polynomial-commitments-sampling.md)
+This directory contains Node.js bindings for the C-KZG-4844 library.
 
 ## Prerequisites
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,10 +1,10 @@
-# Python bindings
+# Python Bindings for the C-KZG Library
 
 This directory contains Python bindings for the C-KZG-4844 library.
 
 ## Prerequisites
 
-These bindings require `python3` and `PyYAML`.
+These bindings require `python3`, `PyYAML` and `make`.
 ```
 sudo apt install python3 python3-pip
 python3 -m pip install PyYAML

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,6 +1,15 @@
-# Rust bindings
+# Rust Bindings for the C-KZG Library
 
-Generates the rust bindings for the c-kzg library. 
+This directory contains Rust bindings for the C-KZG-4844 library.
+
+## Prerequisites
+
+Make sure you have `cargo` and `rust` installed.
+You can do so with [`rustup`](https://rustup.rs):
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
 
 ## Build
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -7,7 +7,7 @@ there is a `fuzz_<function>.rs` file for each target. These use
 can provide the reference tests as the starting corpus, which gives `arbitrary` a better idea of
 what inputs should be. This will differentially fuzz EIP-4844 functions with
 [Constantine](https://github.com/mratsim/constantine) and EIP-7594 functions with
-[Rust-Eth-KZG](https://github.com/crate-crypto/rust-eth-kzg(https://github.com/crate-crypto/peerdas-kzg).
+[Rust-Eth-KZG](https://github.com/crate-crypto/rust-eth-kzg).
 
 ## Dependencies
 
@@ -30,6 +30,8 @@ cargo install cargo-fuzz
 ```
 
 # Nim dependencies
+
+Get and build `nim v1.6` like this:
 
 ```
 git clone git@github.com:nim-lang/Nim.git


### PR DESCRIPTION
This PR does two things related to README files:

1. Fix a dead link in the the fuzzing README.
2. Try to make the structure of README's for bindings more consistent.

I think for 2, we can improve it more in the future. For now, I mostly made sure all files have consistent headings and a consistent first sentence, as well as a Prerequisites section.

Happy about feedback how to improve it even more. 