### PR TITLE
Fix inconsistent parameter doc in blob.c

### DIFF
--- a/src/eip4844/blob.c
+++ b/src/eip4844/blob.c
@@ -24,7 +24,9 @@
  *
  * @param[out]  p       The output polynomial (array of field elements)
  * @param[in]   blob    The blob (an array of bytes)
- * @param[in]   n       The number of field elements in the polynomial/blob
+ *
+ * @remark The polynomial is of degree (at most) FIELD_ELEMENTS_PER_BLOB - 1. That is,
+ * the function will set the first FIELD_ELEMENTS_PER_BLOB elements of p.
  */
 C_KZG_RET blob_to_polynomial(fr_t *p, const Blob *blob) {
     C_KZG_RET ret;


### PR DESCRIPTION
An input parameter `n` was specified in the documentation.
As it was not present in the function, we remove it in this PR.
