### PR TITLE
Add LOG_EXPANSION_FACTOR constant

### DIFF
--- a/src/eip7594/cell.h
+++ b/src/eip7594/cell.h
@@ -30,8 +30,15 @@
 /** The number of bytes in a single cell. */
 #define BYTES_PER_CELL (FIELD_ELEMENTS_PER_CELL * BYTES_PER_FIELD_ELEMENT)
 
+/**
+ * The logarithm (base 2) of the expansion factor.
+ * In other words, this defines the rate (blob / extended blob).
+ * Note that the code is not guaranteed to work anymore if this is changed.
+ */
+#define LOG_EXPANSION_FACTOR 1
+
 /** The number of field elements in an extended blob. */
-#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB * 2)
+#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB << LOG_EXPANSION_FACTOR)
 
 /** The number of cells in a blob. */
 #define CELLS_PER_BLOB (FIELD_ELEMENTS_PER_BLOB / FIELD_ELEMENTS_PER_CELL)

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -111,7 +111,7 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     ret = poly_lagrange_to_monomial(poly_monomial, poly_lagrange, FIELD_ELEMENTS_PER_BLOB, s);
     if (ret != C_KZG_OK) goto out;
 
-    /* Ensure the upper half of the field elements are still zero */
+    /* Ensure that only the first FIELD_ELEMENTS_PER_BLOB elements can be non-zero */
     for (size_t i = FIELD_ELEMENTS_PER_BLOB; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
         assert(fr_equal(&poly_monomial[i], &FR_ZERO));
     }
@@ -180,7 +180,7 @@ out:
  * @param[in]   num_cells           The number of available cells provided
  * @param[in]   s                   The trusted setup
  *
- * @remark At least 50% of CELLS_PER_EXT_BLOB cells must be provided.
+ * @remark At least CELLS_PER_BLOB cells must be provided.
  * @remark Recovery is faster if there are fewer missing cells.
  * @remark If recovered_proofs is NULL, they will not be recomputed.
  */
@@ -203,7 +203,7 @@ C_KZG_RET recover_cells_and_kzg_proofs(
     }
 
     /* Check if it's possible to recover */
-    if (num_cells < CELLS_PER_EXT_BLOB / 2) {
+    if (num_cells < CELLS_PER_BLOB) {
         ret = C_KZG_BADARGS;
         goto out;
     }

--- a/src/eip7594/fk20.c
+++ b/src/eip7594/fk20.c
@@ -73,6 +73,11 @@ C_KZG_RET compute_fk20_cell_proofs(g1_t *out, const fr_t *p, const KZGSettings *
 
     /* Initialize length variables */
     k = FIELD_ELEMENTS_PER_BLOB / FIELD_ELEMENTS_PER_CELL;
+    /*
+     * Note: this constant 2 is not related to `LOG_EXPANSION_FACTOR`.
+     * Instead, it is related to circulant matrices used in FK20, see
+     * Section 2.2 and 3.2 in https://eprint.iacr.org/2023/033.pdf.
+     */
     k2 = k * 2;
 
     /* Do allocations */

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -254,8 +254,11 @@ C_KZG_RET recover_cells(
         }
     }
 
-    /* Check that we have enough cells */
-    assert(len_missing <= CELLS_PER_EXT_BLOB / 2);
+    /*
+     * Check that we have enough cells to recover.
+     * Concretely, we need to have at least CELLS_PER_BLOB many cells.
+     */
+    assert(CELLS_PER_EXT_BLOB - len_missing >= CELLS_PER_BLOB);
 
     /*
      * Compute Z(x) in monomial form.

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -200,6 +200,11 @@ void free_trusted_setup(KZGSettings *s) {
  */
 static C_KZG_RET toeplitz_part_1(g1_t *out, const g1_t *x, size_t n, const KZGSettings *s) {
     C_KZG_RET ret;
+    /*
+     * Note: this constant 2 is not related to `LOG_EXPANSION_FACTOR`.
+     * Instead, it is related to circulant matrices used in FK20, see
+     * Section 2.2 and 3.2 in https://eprint.iacr.org/2023/033.pdf.
+     */
     size_t n2 = n * 2;
     g1_t *x_ext;
 
@@ -237,8 +242,13 @@ static C_KZG_RET init_fk20_multi_settings(KZGSettings *s) {
     blst_p1_affine *p_affine = NULL;
     bool precompute = s->wbits != 0;
 
-    n = FIELD_ELEMENTS_PER_EXT_BLOB / 2;
+    n = FIELD_ELEMENTS_PER_BLOB;
     k = n / FIELD_ELEMENTS_PER_CELL;
+    /*
+     * Note: this constant 2 is not related to `LOG_EXPANSION_FACTOR`.
+     * Instead, it is related to circulant matrices used in FK20, see
+     * Section 2.2 and 3.2 in https://eprint.iacr.org/2023/033.pdf.
+     */
     k2 = 2 * k;
 
     if (FIELD_ELEMENTS_PER_CELL >= NUM_G2_POINTS) {

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -206,23 +206,23 @@ static C_KZG_RET toeplitz_part_1(g1_t *out, const g1_t *x, size_t n, const KZGSe
      * Instead, it is related to circulant matrices used in FK20, see
      * Section 2.2 and 3.2 in https://eprint.iacr.org/2023/033.pdf.
      */
-    size_t size_circ_domain = n * 2;
+    size_t circulant_domain_size = n * 2;
     g1_t *x_ext;
 
     /* Create extended array of points */
-    ret = new_g1_array(&x_ext, size_circ_domain);
+    ret = new_g1_array(&x_ext, circulant_domain_size);
     if (ret != C_KZG_OK) goto out;
 
     /* Copy x & extend with zero */
     for (size_t i = 0; i < n; i++) {
         x_ext[i] = x[i];
     }
-    for (size_t i = n; i < size_circ_domain; i++) {
+    for (size_t i = n; i < circulant_domain_size; i++) {
         x_ext[i] = G1_IDENTITY;
     }
 
     /* Peform forward transformation */
-    ret = g1_fft(out, x_ext, size_circ_domain, s);
+    ret = g1_fft(out, x_ext, circulant_domain_size, s);
     if (ret != C_KZG_OK) goto out;
 
 out:

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -74,6 +74,9 @@
  * for (size_t i = 0; i < 4; i++)
  *     printf("%#018llxL,\n", root_of_unity.l[i]);
  * @endcode
+ *
+ * @remark this constant is tied to LOG_EXPANSION_FACTOR = 1, i.e., if the expansion
+ * factor changes, this constant is no longer correct.
  */
 static const fr_t ROOT_OF_UNITY = {
     0xa33d279ff0ccffc9L, 0x41fac79f59e91972L, 0x065d227fead1139bL, 0x71db41abda03e055L


### PR DESCRIPTION
This PR is to address #512.

Note that in contrast to what is stated in the issue, the code will *not* work for other constants as it is.
This is because it contains precomputed constants such as `ROOT_OF_UNITY` that are tailored to the expansion factor being two (`LOG_EXPANSION_FACTOR = 1`). We could have added code to compute the constants on the fly based on the expansion factor, but this would add significant overhead. Therefore, introducing the constant is more a way to improve readability instead of a way to make the code more general.