### PR TITLE
Delete trailing whitespace

### DIFF
--- a/.github/workflows/repo-tests.yml
+++ b/.github/workflows/repo-tests.yml
@@ -1,0 +1,25 @@
+name: Repo
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  whitespace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check for trailing whitespace
+        run: |
+          if git grep -I -n '[[:blank:]]$'; then
+            echo "Trailing whitespace found. Please fix it."
+            exit 1
+          fi

--- a/bindings/java/gradlew
+++ b/bindings/java/gradlew
@@ -144,7 +144,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045 
+        # shellcheck disable=SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -152,7 +152,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045 
+        # shellcheck disable=SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -9,16 +9,16 @@ const bindings = require("bindings")("kzg");
 /**
  * NOTE: This path is only exported for testing purposes. It is not announced in
  * the type file.
- * 
+ *
  * It is critical that this path is kept in sync with where the trusted setup
  * file will be found. The path is dictated by the `build` command in the
  * Makefile in the bindings/node.js folder.
- * 
+ *
  * This path works for two situations:
  * 1) Production case
  * - this file in BUNDLE_ROOT/dist/lib/kzg.js
  * - trusted_setup in BUNDLE_ROOT/dist/deps/c-kzg/trusted_setup.txt
- * 
+ *
  *  2) Post `build` state before `bundle` command works
  * - this file in bindings/node.js/lib/kzg.js
  * - trusted_setup in bindings/node.js/deps/c-kzg/trusted_setup.txt

--- a/scripts/format_c_params.py
+++ b/scripts/format_c_params.py
@@ -60,7 +60,7 @@ def format_param_lines(lines: Sequence[str]) -> Sequence[str]:
     for line in lines:
         index = find_space_after(line, line.find("@param"))
         valid_var_index = max(valid_var_index, tab(index))
-        
+
     new_lines = []
     for line in lines:
         var_index = next_word_index(line, line.find('@param'))
@@ -90,7 +90,7 @@ def format_param_lines(lines: Sequence[str]) -> Sequence[str]:
         new_lines.append(line)
 
     return new_lines
-    
+
 
 def format_params(file_path: str):
     """

--- a/src/PROFILE.md
+++ b/src/PROFILE.md
@@ -16,7 +16,7 @@ Assuming you have Go installed, get `pprof` from:
 ```
 go install github.com/google/pprof@latest
 ```
-Depending on your shell, edit the corresponding configuration file to 
+Depending on your shell, edit the corresponding configuration file to
 add the Go binary path (`$HOME/go/bin`) to your `PATH`.
 
 On macOS, you need to install (via [homebrew](https://brew.sh)):
@@ -71,7 +71,7 @@ These might not make much sense without guidance. From a high-level, this works
 by polling the instruction pointer (what's being executed) at a specific rate
 (like once every 5 nanoseconds) and tracking this information. From this, you
 can infer the relative time each function uses by counting the number of samples
-that are in each function. 
+that are in each function.
 
 Given a box containing:
 ```

--- a/src/test/tinytest.h
+++ b/src/test/tinytest.h
@@ -102,7 +102,7 @@ static int tt_report(void)
       tt_current_file, tt_passes, tt_fails, tt_passes + tt_fails);
     return -1;
   } else {
-    printf("%c%sPASSED%c%s [%s] (total:%d)\n", 
+    printf("%c%sPASSED%c%s [%s] (total:%d)\n",
       TT_COLOR_CODE, TT_COLOR_GREEN, TT_COLOR_CODE, TT_COLOR_RESET,
       tt_current_file, tt_passes);
     return 0;


### PR DESCRIPTION
This PR deletes trailing white space from all non-binary files & adds a CI check to catch future instances.

Rationale: it bothers me when I modify a file and there's a distracting/unrelated whitespace change.