### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimal implementation of the Polynomial Commitments API for
 
 While the core implementation is in C, bindings are available for various
 high-level languages, providing convenient wrappers around C functions. These
-bindings are intended to be used by Ethereum clients, to avoid re-implementation
+bindings are intended to be used by Ethereum clients to avoid re-implementation
 of crucial cryptographic functions.
 
 | Language | Link                                 |


### PR DESCRIPTION
Removed the comma after "Ethereum clients": This was to improve the sentence flow, as the comma was unnecessary in this context.