### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -1,6 +1,6 @@
 /**
  * The public interface of this module exposes the functions as specified by
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#kzg
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#kzg
  */
 export type Bytes32 = Uint8Array; // 32 bytes
 export type Bytes48 = Uint8Array; // 48 bytes

--- a/bindings/node.js/lib/kzg.js
+++ b/bindings/node.js/lib/kzg.js
@@ -1,6 +1,6 @@
 /**
  * The public interface of this module exposes the functions as specified by
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#kzg
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#kzg
  */
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.