### PR TITLE
Fix grammatical and spelling errors in documentation

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -14,7 +14,7 @@ make build
 ```
 
 This will install the shared library in `src/main/resources/ethereum/ckzg4844/lib` with a folder
-structure and name according your OS.
+structure and name according to your OS.
 
 All variables which could be passed to the `make` command and the defaults can be found in
 the [Makefile](./Makefile).

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -115,7 +115,7 @@ computeBlobKzgProof(
 
 ```ts
 /**
- * Verify a KZG poof claiming that `p(z) == y`.
+ * Verify a KZG proof claiming that `p(z) == y`.
  *
  * @param {Bytes48} commitmentBytes - The serialized commitment corresponding to
  *                                    polynomial p(x)

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -103,7 +103,7 @@ fn make_bindings(
         .blocklist_type("FILE")
         // Inject rust code using libc's FILE
         .raw_line("use libc::FILE;")
-        // Do no generate layout tests.
+        // Do not generate layout tests.
         .layout_tests(false)
         // Extern functions do not need individual extern blocks.
         .merge_extern_blocks(true)


### PR DESCRIPTION

## Changes

### bindings/rust/build.rs
- Old: `// Do no generate layout tests.`
- New: `// Do not generate layout tests.`
Reason: Corrected grammatical error by using proper negative form "do not" instead of incorrect "do no".

### bindings/node.js/README.md
- Old: `* Verify a KZG poof claiming that p(z) == y.`
- New: `* Verify a KZG proof claiming that p(z) == y.`
Reason: Fixed spelling error - "poof" to "proof" for technical accuracy.

### bindings/java/README.md
- Old: `structure and name according your OS.`
- New: `structure and name according to your OS.`
Reason: Added missing preposition "to" for grammatical correctness.

## Summary
These changes improve documentation readability and professionalism by fixing grammatical and spelling errors. Proper technical terminology and grammar are important for maintaining high-quality documentation that is clear and accurate for all users.

The changes are minor text corrections that do not affect any functionality but make the documentation more polished and professional.