### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -80,5 +80,5 @@ jobs:
         if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.os }}
           path: src/coverage.html

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
     steps:
       # Checkout repository and blst submodule.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -78,7 +78,7 @@ jobs:
       # Didn't generate it for Windows.
       - name: Save coverage report
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: src/coverage.html

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -94,20 +94,28 @@ jobs:
     name: Build .NET wrapper
     runs-on: ubuntu-latest
     needs: test-ckzg-dotnet
-    strategy:
-      matrix:
-        runtime:
-          - linux-x64
-          - osx-x64
-          - win-x64
-          - osx-arm64
-          - linux-arm64
     steps:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.runtime }}/native
+        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ckzg-library-wrapper-*
+        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ckzg-library-wrapper-*
+        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ckzg-library-wrapper-*
+        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ckzg-library-wrapper-*
+        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
     - name: Install dependencies

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -84,7 +84,7 @@ jobs:
       run: cd bindings/csharp && dotnet restore
     - uses: actions/download-artifact@v4
       with:
-        pattern: '**/runtimes/ckzg-library-wrapper-*/native/*'
+        pattern: '**/runtimes/${{ matrix.target.location }}/native/*'
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
         merge-multiple: true
     - name: Test

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -107,7 +107,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-win-x64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
+        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64-default/native
     - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-osx-arm64

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -94,28 +94,20 @@ jobs:
     name: Build .NET wrapper
     runs-on: ubuntu-latest
     needs: test-ckzg-dotnet
+    strategy:
+      matrix:
+        runtime:
+          - linux-x64
+          - osx-x64
+          - win-x64
+          - osx-arm64
+          - linux-arm64
     steps:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
+        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.runtime }}/native
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
     - name: Install dependencies

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -84,7 +84,7 @@ jobs:
       run: cd bindings/csharp && dotnet restore
     - uses: actions/download-artifact@v4
       with:
-        pattern: '**/runtimes/${{ matrix.target.location }}/native/*'
+        pattern: 'ckzg-library-wrapper-${{ matrix.target.location }}-*'
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
         merge-multiple: true
     - name: Test

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -106,8 +106,8 @@ jobs:
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-win-x64
-        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64-default/native
+        name: ckzg-library-wrapper-win-x64-default
+        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
     - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-osx-arm64

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ckzg-library-wrapper-${{ matrix.target.location }}
+        name: ckzg-library-wrapper-${{ matrix.target.location }}-${{ matrix.target.arch || 'default' }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
 
   test-ckzg-dotnet:
@@ -84,8 +84,9 @@ jobs:
       run: cd bindings/csharp && dotnet restore
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-${{ matrix.target.location }}
+        pattern: '**/runtimes/ckzg-library-wrapper-*/native/*'
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
+        merge-multiple: true
     - name: Test
       run: dotnet test -c release bindings/csharp/Ckzg.sln
 
@@ -97,11 +98,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-linux-x64
+        name: ckzg-library-wrapper-linux-x64-x86_64-linux-gnu
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-osx-x64
+        name: ckzg-library-wrapper-osx-x64-x86_64-darwin
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -47,7 +47,7 @@ jobs:
             reqs:
     steps:
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install requirements
@@ -56,7 +56,7 @@ jobs:
     - name: Build native library for ${{ matrix.target.location }} using native capabilities
       run: make ckzg -C bindings/csharp CC=clang EXTENSION=${{matrix.target.ext}} LOCATION=${{matrix.target.location}} ARCH=${{matrix.target.arch}}
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
@@ -75,14 +75,14 @@ jobs:
           - host: windows-latest
             location: win-x64
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
     - name: Install dependencies
       run: cd bindings/csharp && dotnet restore
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
@@ -94,35 +94,35 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-ckzg-dotnet
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-linux-x64
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-osx-x64
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-win-x64
         path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-osx-arm64
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ckzg-library-wrapper-linux-arm64
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
     - name: Set up .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
     - name: Install dependencies
       run: cd bindings/csharp && dotnet restore
     - name: Build
       run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -98,23 +98,23 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-linux-x64-x86_64-linux-gnu
+        pattern: ckzg-library-wrapper-*
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-osx-x64-x86_64-darwin
+        pattern: ckzg-library-wrapper-*
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-win-x64-default
+        pattern: ckzg-library-wrapper-*
         path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-osx-arm64
+        pattern: ckzg-library-wrapper-*
         path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
     - uses: actions/download-artifact@v4
       with:
-        name: ckzg-library-wrapper-linux-arm64
+        pattern: ckzg-library-wrapper-*
         path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
     - name: Set up .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -73,9 +73,9 @@ jobs:
             make -C src blst
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: wheelhouse/*
 
   # Build the source distribution under Linux
@@ -100,17 +100,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
-          name: wheels
+          name: sdist-${{ matrix.os }}
+
 
   publish:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-${{ matrix.os }}
           path: wheelhouse
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -97,7 +97,7 @@ jobs:
         run: python setup.py sdist
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
           name: wheels


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025 and github is going to begin temporarily failing jobs that don't update before this deadline. The PR fixes the versions used. The migration docs [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) were followed. 
