### PR TITLE
fix: typos in documentation files

### DIFF
--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -86,7 +86,7 @@ export function computeKzgProof(blob: Blob, zBytes: Bytes32): ProofResult;
 export function computeBlobKzgProof(blob: Blob, commitmentBytes: Bytes48): KZGProof;
 
 /**
- * Verify a KZG poof claiming that `p(z) == y`.
+ * Verify a KZG proof claiming that `p(z) == y`.
  *
  * @param {Bytes48} commitmentBytes - The serialized commitment corresponding to polynomial p(x)
  * @param {Bytes32} zBytes - The serialized evaluation point

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -347,7 +347,7 @@ Napi::Value ComputeBlobKzgProof(const Napi::CallbackInfo &info) {
 }
 
 /**
- * Verify a KZG poof claiming that `p(z) == y`.
+ * Verify a KZG proof claiming that `p(z) == y`.
  *
  * @param[in] {Bytes48} commitmentBytes - The serialized commitment
  * corresponding to polynomial p(x)


### PR DESCRIPTION
Corrected `poof` to `proof` x2