### PR TITLE
Fix NuGet packaging

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ckzg-library-wrapper-${{ matrix.target.location }}-${{ matrix.target.arch || 'default' }}
+        name: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
 
   test-ckzg-dotnet:
@@ -84,7 +84,7 @@ jobs:
       run: cd bindings/csharp && dotnet restore
     - uses: actions/download-artifact@v4
       with:
-        pattern: 'ckzg-library-wrapper-${{ matrix.target.location }}-*'
+        pattern: ckzg-library-wrapper-${{ matrix.target.location }}
         path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
         merge-multiple: true
     - name: Test
@@ -99,23 +99,14 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/win-x64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/osx-arm64/native
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: ckzg-library-wrapper-*
-        path: bindings/csharp/Ckzg.Bindings/runtimes/linux-arm64/native
+        path: bindings/csharp/Ckzg.Bindings/runtimes
+    - name: Move artifacts
+      working-directory: bindings/csharp/Ckzg.Bindings/runtimes
+      run: |
+        ls bindings/csharp/Ckzg.Bindings/runtimes
+        for rid in "linux-arm64" "linux-x64" "osx-arm64" "osx-x64" "win-x64"; do
+          mv -f ckzg-library-wrapper-$rid/ckzg.so $rid/native/ckzg.so
+        done
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
     - name: Install dependencies

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - host: ubuntu-22.04
+          - host: ubuntu-latest
             location: linux-x64
           - host: macos-latest
             location: osx-arm64
@@ -84,9 +84,16 @@ jobs:
       run: cd bindings/csharp && dotnet restore
     - uses: actions/download-artifact@v4
       with:
-        pattern: ckzg-library-wrapper-${{ matrix.target.location }}
-        path: bindings/csharp/Ckzg.Bindings/runtimes/${{ matrix.target.location }}/native
-        merge-multiple: true
+        pattern: ckzg-library-wrapper-*
+        path: bindings/csharp/Ckzg.Bindings/runtimes
+    - name: Move artifacts
+      working-directory: bindings/csharp/Ckzg.Bindings/runtimes
+      run: |
+        mv ckzg-library-wrapper-linux-arm64/ckzg.so linux-arm64/native/ckzg.so
+        mv ckzg-library-wrapper-linux-x64/ckzg.so linux-x64/native/ckzg.so
+        mv ckzg-library-wrapper-osx-arm64/ckzg.dylib osx-arm64/native/ckzg.dylib
+        mv ckzg-library-wrapper-osx-x64/ckzg.dylib osx-x64/native/ckzg.dylib
+        mv ckzg-library-wrapper-win-x64/ckzg.dll win-x64/native/ckzg.dll
     - name: Test
       run: dotnet test -c release bindings/csharp/Ckzg.sln
 
@@ -103,21 +110,21 @@ jobs:
     - name: Move artifacts
       working-directory: bindings/csharp/Ckzg.Bindings/runtimes
       run: |
-        ls bindings/csharp/Ckzg.Bindings/runtimes
-        for rid in "linux-arm64" "linux-x64" "osx-arm64" "osx-x64" "win-x64"; do
-          mv -f ckzg-library-wrapper-$rid/ckzg.so $rid/native/ckzg.so
-        done
+        mv -f ckzg-library-wrapper-linux-arm64/ckzg.so linux-arm64/native/ckzg.so
+        mv -f ckzg-library-wrapper-linux-x64/ckzg.so linux-x64/native/ckzg.so
+        mv -f ckzg-library-wrapper-osx-arm64/ckzg.dylib osx-arm64/native/ckzg.dylib
+        mv -f ckzg-library-wrapper-osx-x64/ckzg.dylib osx-x64/native/ckzg.dylib
+        mv -f ckzg-library-wrapper-win-x64/ckzg.dll win-x64/native/ckzg.dll
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
-    - name: Install dependencies
-      run: cd bindings/csharp && dotnet restore
-    - name: Build
-      run: cd bindings/csharp && dotnet pack -c release --no-restore -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
+    - name: Pack
+      working-directory: bindings/csharp
+      run: dotnet pack -c release -o nupkgs -p:Version=${{ inputs.version || env.binding_build_number_based_version }} -p:ContinuousIntegrationBuild=true
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
-    - name: Publish .NET package
+    - name: Publish package
       if: github.ref == 'refs/heads/main'
       run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg -k ${{ secrets.CSHARP_NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -33,13 +33,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
+        <Content CopyToOutputDirectory="PreserveNewest" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
 
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
+        <Content CopyToOutputDirectory="PreserveNewest" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
+        <Content CopyToOutputDirectory="PreserveNewest" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
 
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.dylib')" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
-        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.dylib')" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
+        <Content CopyToOutputDirectory="PreserveNewest" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
+        <Content CopyToOutputDirectory="PreserveNewest" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
     </ItemGroup>
 
     <ItemGroup>

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
 		<RootNamespace>Ckzg</RootNamespace>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -1,52 +1,52 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<OutputType>Library</OutputType>
-		<RootNamespace>Ckzg</RootNamespace>
-		<TargetFramework>net8.0</TargetFramework>
-	</PropertyGroup>
+    <PropertyGroup>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <OutputType>Library</OutputType>
+        <RootNamespace>Ckzg</RootNamespace>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
 
-	<PropertyGroup>
-		<Authors>Ethereum Foundation</Authors>
-		<Copyright>Ethereum Foundation</Copyright>
-		<Description>The C# bindings for the Polynomial Commitments API library for EIP-4844 and EIP-7594</Description>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<IncludeSymbols>true</IncludeSymbols>
-		<PackageId>Ckzg.Bindings</PackageId>
-		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageTags>c-kzg eip-4844 eip-7594</PackageTags>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Version>0.2.0.1</Version>
-		<!-- Disable the warnings about using UInt64-->
-		<NoWarn>$(NoWarn);IDE0049</NoWarn>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Authors>Ethereum Foundation</Authors>
+        <Copyright>Ethereum Foundation</Copyright>
+        <Description>The C# bindings for the Polynomial Commitments API library for EIP-4844 and EIP-7594</Description>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <PackageId>Ckzg.Bindings</PackageId>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageTags>c-kzg eip-4844 eip-7594</PackageTags>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ethereum/c-kzg-4844</RepositoryUrl>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <Version>0.2.0.1</Version>
+        <!-- Disable the warnings about using UInt64-->
+        <NoWarn>$(NoWarn);IDE0049</NoWarn>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
+    <ItemGroup>
+        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
 
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
+        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
+        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
 
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.dylib')" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.dylib')" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
-	</ItemGroup>
+        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.dylib')" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
+        <Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.dylib')" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
 </Project>

--- a/bindings/csharp/Ckzg.Test/Ckzg.Test.csproj
+++ b/bindings/csharp/Ckzg.Test/Ckzg.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/bindings/csharp/Ckzg.Test/Ckzg.Test.csproj
+++ b/bindings/csharp/Ckzg.Test/Ckzg.Test.csproj
@@ -11,15 +11,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="YamlDotNet" Version="13.2.0" />
+        <PackageReference Include="YamlDotNet" Version="16.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #528 

- Fixed the issue with NuGet package artifacts introduced in #525
- Removed checks for artifacts of the `runtimes` directory in the `.csproj` file to fail the build when those files are missing
- Updated and consolidated the target .NET versions from 6 and 7 to the latest LTS version of 8
- Updated dependencies
- Optimized artifacts downloading in GitHub Actions workflow