### PR TITLE
fix: fix issue with find_space_after returning None

### DIFF
--- a/scripts/format_c_params.py
+++ b/scripts/format_c_params.py
@@ -43,7 +43,8 @@ def next_word_index(line: str, start_index: int) -> int:
     Find the next word. Assumes start index is not a space.
     """
     space_index = line.find(" ", start_index)
-    assert space_index != -1
+    if space_index == -1:
+        raise Exception(f"missing param documentation: {repr(line)}")
 
     # Find the first non-space character after the space
     non_space_index = space_index + 1

--- a/scripts/format_c_params.py
+++ b/scripts/format_c_params.py
@@ -35,6 +35,7 @@ def find_space_after(line: str, start_index: int) -> int:
     for index, c in enumerate(line[start_index:]):
         if c == " ":
             return index + start_index
+    return -1
 
 
 def next_word_index(line: str, start_index: int) -> int:


### PR DESCRIPTION
There was a problem in the `find_space_after` function: if no space was found after the given `start_index`, the function was returning `None`, which doesn't match the expected return type of `int`.
I’ve fixed this by adding `return -1` in case no space is found.
This ensures the function always returns an integer value as expected.