### PR TITLE
Allocate polynomials on heap instead of stack

### DIFF
--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -945,17 +945,17 @@ static void test_g1_lincomb__verify_consistent(void) {
 
 static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial(void) {
     C_KZG_RET ret;
-    Polynomial p;
+    fr_t p[FIELD_ELEMENTS_PER_BLOB];
     fr_t x, y, c;
 
     get_rand_fr(&c);
     get_rand_fr(&x);
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        p.evals[i] = c;
+        p[i] = c;
     }
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, p, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation matches constant", fr_equal(&y, &c));
@@ -963,17 +963,17 @@ static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial(voi
 
 static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_range(void) {
     C_KZG_RET ret;
-    Polynomial p;
+    fr_t p[FIELD_ELEMENTS_PER_BLOB];
     fr_t x, y, c;
 
     get_rand_fr(&c);
     x = s.brp_roots_of_unity[123];
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        p.evals[i] = c;
+        p[i] = c;
     }
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, p, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation matches constant", fr_equal(&y, &c));
@@ -982,7 +982,7 @@ static void test_evaluate_polynomial_in_evaluation_form__constant_polynomial_in_
 static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void) {
     C_KZG_RET ret;
     fr_t poly_coefficients[FIELD_ELEMENTS_PER_BLOB];
-    Polynomial p;
+    fr_t p[FIELD_ELEMENTS_PER_BLOB];
     fr_t x, y, check;
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
@@ -990,13 +990,13 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void)
     }
 
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        eval_poly(&p.evals[i], poly_coefficients, &s.brp_roots_of_unity[i]);
+        eval_poly(&p[i], poly_coefficients, &s.brp_roots_of_unity[i]);
     }
 
     get_rand_fr(&x);
     eval_poly(&check, poly_coefficients, &x);
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, p, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation methods match", fr_equal(&y, &check));
@@ -1005,7 +1005,7 @@ static void test_evaluate_polynomial_in_evaluation_form__random_polynomial(void)
 
     eval_poly(&check, poly_coefficients, &x);
 
-    ret = evaluate_polynomial_in_evaluation_form(&y, &p, &x, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y, p, &x, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ASSERT("evaluation methods match", fr_equal(&y, &check));
@@ -1051,7 +1051,7 @@ static void test_is_power_of_two__fails_not_powers_of_two(void) {
 static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     C_KZG_RET ret;
     Blob blob;
-    Polynomial poly;
+    fr_t poly[FIELD_ELEMENTS_PER_BLOB];
     fr_t y_fr, z_fr;
     Bytes32 input_value, output_value, field_element, expected_output_value;
     Bytes48 proof, expected_proof;
@@ -1083,13 +1083,13 @@ static void test_compute_kzg_proof__succeeds_expected_proof(void) {
     ASSERT_EQUALS(diff, 0);
 
     /* Get the expected y by evaluating the polynomial at input_value */
-    ret = blob_to_polynomial(poly.evals, &blob);
+    ret = blob_to_polynomial(poly, &blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     ret = bytes_to_bls_field(&z_fr, &input_value);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
-    ret = evaluate_polynomial_in_evaluation_form(&y_fr, &poly, &z_fr, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y_fr, poly, &z_fr, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     bytes_from_bls_field(&expected_output_value, &y_fr);
@@ -1105,7 +1105,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
     Bytes32 z, y, computed_y;
     KZGCommitment c;
     Blob blob;
-    Polynomial poly;
+    fr_t poly[FIELD_ELEMENTS_PER_BLOB];
     fr_t y_fr, z_fr;
     bool ok;
     int diff;
@@ -1125,7 +1125,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(poly.evals, &blob);
+    ret = blob_to_polynomial(poly, &blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */
@@ -1133,7 +1133,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_round_trip(void) {
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Now evaluate the poly at `z` to learn `y` */
-    ret = evaluate_polynomial_in_evaluation_form(&y_fr, &poly, &z_fr, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y_fr, poly, &z_fr, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Now also get `y` in bytes */
@@ -1154,7 +1154,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         C_KZG_RET ret;
         Blob blob;
         KZGCommitment c;
-        Polynomial poly;
+        fr_t poly[FIELD_ELEMENTS_PER_BLOB];
         Bytes48 proof;
         Bytes32 z, y, computed_y;
         fr_t y_fr, z_fr;
@@ -1168,7 +1168,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Get the polynomial version of the blob */
-        ret = blob_to_polynomial(poly.evals, &blob);
+        ret = blob_to_polynomial(poly, &blob);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         z_fr = s.brp_roots_of_unity[i];
@@ -1179,7 +1179,7 @@ static void test_compute_and_verify_kzg_proof__succeeds_within_domain(void) {
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Now evaluate the poly at `z` to learn `y` */
-        ret = evaluate_polynomial_in_evaluation_form(&y_fr, &poly, &z_fr, &s);
+        ret = evaluate_polynomial_in_evaluation_form(&y_fr, poly, &z_fr, &s);
         ASSERT_EQUALS(ret, C_KZG_OK);
 
         /* Now also get `y` in bytes */
@@ -1203,7 +1203,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
     Bytes32 z, y, computed_y;
     KZGCommitment c;
     Blob blob;
-    Polynomial poly;
+    fr_t poly[FIELD_ELEMENTS_PER_BLOB];
     fr_t y_fr, z_fr;
     bool ok;
 
@@ -1222,7 +1222,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
      * Now let's attempt to verify the proof.
      * First convert the blob to field elements.
      */
-    ret = blob_to_polynomial(poly.evals, &blob);
+    ret = blob_to_polynomial(poly, &blob);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Also convert z to a field element */
@@ -1230,7 +1230,7 @@ static void test_compute_and_verify_kzg_proof__fails_incorrect_proof(void) {
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Now evaluate the poly at `z` to learn `y` */
-    ret = evaluate_polynomial_in_evaluation_form(&y_fr, &poly, &z_fr, &s);
+    ret = evaluate_polynomial_in_evaluation_form(&y_fr, poly, &z_fr, &s);
     ASSERT_EQUALS(ret, C_KZG_OK);
 
     /* Now also get `y` in bytes */


### PR DESCRIPTION
I think we should allocate polynomials on the heap instead of the stack. These are quite large and could cause problems if, for whatever reason, there isn't much available stack space. In this PR, I've also renamed some variables for clarity.