### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/elixir-tests.yml
+++ b/.github/workflows/elixir-tests.yml
@@ -21,7 +21,7 @@ jobs:
             elixir: "1.18"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: stable
         id: go
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Test

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/setup-java@v3

--- a/.github/workflows/nim-tests.yml
+++ b/.github/workflows/nim-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - 20
           - 22
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Node.js ${{matrix.node}}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/setup-python@v4
@@ -51,7 +51,7 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/setup-python@v4

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/spec-consistency-tests.yml
+++ b/.github/workflows/spec-consistency-tests.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).