### PR TITLE
migrate actions/cache to v4 in workflow files

### DIFF
--- a/.github/workflows/elixir-tests.yml
+++ b/.github/workflows/elixir-tests.yml
@@ -32,7 +32,7 @@ jobs:
           elixir-version: ${{matrix.variation.elixir}}
 
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/nim-tests.yml
+++ b/.github/workflows/nim-tests.yml
@@ -27,14 +27,14 @@ jobs:
 
     - name: Cache choosenim
       id: cache-choosenim
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.choosenim
         key: ${{ runner.os }}-choosenim-${{ matrix.nim-version}}
 
     - name: Cache nimble
       id: cache-nimble
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-${{ matrix.nim-version}}-${{ hashFiles('bindings/nim/kzg_abi.nim') }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows by upgrading the actions/cache version from v3 to v4 to align with the latest best practices and performance improvements.