### PR TITLE
Update clang-format to v20

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
         with:
-          clang-format-version: '18'
+          clang-format-version: '20'
           check-path: 'src'
           exclude-regex: 'tinytest.h'
 

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -37,8 +37,10 @@ jobs:
           pip install setuptools
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
-        working-directory: bindings/node.js
-        run: make format
+        uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
+        with:
+          clang-format-version: '20'
+          check-path: 'bindings/node.js'
       - name: Build/test bindings
         working-directory: bindings/node.js
         run: make build test

--- a/bindings/node.js/.clang-format
+++ b/bindings/node.js/.clang-format
@@ -14,6 +14,6 @@ AlignAfterOpenBracket: BlockIndent
 AlignEscapedNewlines: DontAlign
 AlwaysBreakAfterDefinitionReturnType: None
 BinPackArguments: False
-BinPackParameters: False
+BinPackParameters: OnePerLine
 PenaltyReturnTypeOnItsOwnLine: 1000
 PenaltyBreakAssignment: 100

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -121,7 +121,9 @@ KZGSettings *get_kzg_settings(Napi::Env &env, const Napi::CallbackInfo &info) {
  * @return - native pointer to first byte in ArrayBuffer
  */
 inline uint8_t *get_bytes(
-    const Napi::Env &env, const Napi::Value &val, size_t length,
+    const Napi::Env &env,
+    const Napi::Value &val,
+    size_t length,
     std::string_view name
 ) {
     if (!val.IsTypedArray() ||

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -7,7 +7,7 @@ AlignAfterOpenBracket: BlockIndent
 AlignEscapedNewlines: DontAlign
 AlwaysBreakAfterDefinitionReturnType: None
 BinPackArguments: False
-BinPackParameters: False
+BinPackParameters: OnePerLine
 PenaltyReturnTypeOnItsOwnLine: 1000
 PenaltyBreakAssignment: 100
 ColumnLimit: 100


### PR DESCRIPTION
Updating to the latest stable version of clang-format. Version 18 is no longer available for me, so this is nice.