### PR TITLE
fix: rm unsafe from extern that breaks compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -144,6 +144,9 @@ fn make_bindings(
         .unwrap();
 
     let mut bindings = bindings.to_string();
+    // Remove unsafe from `unsafe extern "C"` from the bindings
+    // Having unsafe extern will break compilation in newer versions of rust.
+    bindings = bindings.replace("unsafe extern", "extern");
     bindings = replace_ckzg_ret_repr(bindings);
     std::fs::write(bindings_out_path, bindings).expect("Failed to write bindings");
 }

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -112,7 +112,7 @@ pub struct KZGSettings {
 pub struct Cell {
     bytes: [u8; 2048usize],
 }
-unsafe extern "C" {
+extern "C" {
     pub fn blob_to_kzg_commitment(
         out: *mut KZGCommitment,
         blob: *const Blob,


### PR DESCRIPTION
Found here: https://github.com/foundry-rs/foundry-fork-db/actions/runs/14331517446/job/40168425837
happens on 1.8.2 and newer rust

Have removed `unsafe` from the generated code so CI can pass, and it will not be brought back when we regenerate bindings in future.