### PR TITLE
Rename namespace so it's different from main class, and we don't need…

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
-namespace Ckzg;
+namespace CkzgLib;
 
 public static partial class Ckzg
 {

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -1,4 +1,4 @@
-namespace Ckzg;
+namespace CkzgLib;
 
 public static partial class Ckzg
 {

--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace Ckzg.Test;
+namespace CkzgLib.Test;
 
 [TestFixture]
 public class ReferenceTests


### PR DESCRIPTION
… to always write Ckzg.Ckzg.Foo