### PR TITLE
Use correct constant in coeffs allocation

### DIFF
--- a/src/eip7594/fk20.c
+++ b/src/eip7594/fk20.c
@@ -100,7 +100,7 @@ C_KZG_RET compute_fk20_cell_proofs(g1_t *out, const fr_t *p, const KZGSettings *
     ret = c_kzg_calloc((void **)&coeffs, circulant_domain_size, sizeof(void *));
     if (ret != C_KZG_OK) goto out;
     for (size_t i = 0; i < circulant_domain_size; i++) {
-        ret = new_fr_array(&coeffs[i], CELLS_PER_BLOB);
+        ret = new_fr_array(&coeffs[i], FIELD_ELEMENTS_PER_CELL);
         if (ret != C_KZG_OK) goto out;
     }
 


### PR DESCRIPTION
When testing with different cell sizes, I noticed that the constant used in this allocation is wrong; it should have used the `FIELD_ELEMENTS_PER_CELL` constant instead. When `FIELD_ELEMENTS_PER_CELL` is 64, then `CELLS_PER_BLOB` (non-extended) is also 64. But when `FIELD_ELEMENTS_PER_CELL` is 32, `CELLS_PER_BLOB` is 128. This means that we would over-allocate when using a different FEPC count.

For reference, see how `coeffs` is used in this section of code (might need to scroll):

https://github.com/ethereum/c-kzg-4844/blob/0f5e47dc26d79f10bd37084d33e6a174ff06d64b/src/eip7594/fk20.c#L112-L148