### PR TITLE
Remove precomputed CELL_INDICES_RBL table

### DIFF
--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -41,27 +41,6 @@
 /** The domain separator for verify_cell_kzg_proof_batch's random challenge. */
 static const char *RANDOM_CHALLENGE_DOMAIN_VERIFY_CELL_KZG_PROOF_BATCH = "RCKZGCBATCH__V1_";
 
-/**
- * This is a precomputed map of cell index to reverse-bits-limited cell index.
- *
- * for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++)
- *   printf("%#04llx,\n", reverse_bits_limited(CELLS_PER_EXT_BLOB, i));
- *
- * Because of the way our evaluation domain is defined, we can use CELL_INDICES_RBL to find the
- * coset factor of a cell. In particular, for cell i, its coset factor is
- * roots_of_unity[CELLS_INDICES_RBL[i]].
- */
-static const uint64_t CELL_INDICES_RBL[CELLS_PER_EXT_BLOB] = {
-    0x00, 0x40, 0x20, 0x60, 0x10, 0x50, 0x30, 0x70, 0x08, 0x48, 0x28, 0x68, 0x18, 0x58, 0x38, 0x78,
-    0x04, 0x44, 0x24, 0x64, 0x14, 0x54, 0x34, 0x74, 0x0c, 0x4c, 0x2c, 0x6c, 0x1c, 0x5c, 0x3c, 0x7c,
-    0x02, 0x42, 0x22, 0x62, 0x12, 0x52, 0x32, 0x72, 0x0a, 0x4a, 0x2a, 0x6a, 0x1a, 0x5a, 0x3a, 0x7a,
-    0x06, 0x46, 0x26, 0x66, 0x16, 0x56, 0x36, 0x76, 0x0e, 0x4e, 0x2e, 0x6e, 0x1e, 0x5e, 0x3e, 0x7e,
-    0x01, 0x41, 0x21, 0x61, 0x11, 0x51, 0x31, 0x71, 0x09, 0x49, 0x29, 0x69, 0x19, 0x59, 0x39, 0x79,
-    0x05, 0x45, 0x25, 0x65, 0x15, 0x55, 0x35, 0x75, 0x0d, 0x4d, 0x2d, 0x6d, 0x1d, 0x5d, 0x3d, 0x7d,
-    0x03, 0x43, 0x23, 0x63, 0x13, 0x53, 0x33, 0x73, 0x0b, 0x4b, 0x2b, 0x6b, 0x1b, 0x5b, 0x3b, 0x7b,
-    0x07, 0x47, 0x27, 0x67, 0x17, 0x57, 0x37, 0x77, 0x0f, 0x4f, 0x2f, 0x6f, 0x1f, 0x5f, 0x3f, 0x7f,
-};
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Compute
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -549,7 +528,7 @@ static void get_inv_coset_shift_for_cell(
      * Get the cell index in reverse-bit order.
      * This index points to this cell's coset factor h_k in the roots_of_unity array.
      */
-    uint64_t cell_idx_rbl = CELL_INDICES_RBL[cell_index];
+    uint64_t cell_idx_rbl = reverse_bits_limited(CELLS_PER_EXT_BLOB, cell_index);
 
     /*
      * Observe that for every element in roots_of_unity, we can find its inverse by
@@ -581,7 +560,7 @@ static void get_coset_shift_pow_for_cell(
      * Get the cell index in reverse-bit order.
      * This index points to this cell's coset factor h_k in the roots_of_unity array.
      */
-    uint64_t cell_idx_rbl = CELL_INDICES_RBL[cell_index];
+    uint64_t cell_idx_rbl = reverse_bits_limited(CELLS_PER_EXT_BLOB, cell_index);
 
     /*
      * Get the index to h_k^n in the roots_of_unity array.


### PR DESCRIPTION
This was a small optimization which does not work with other `FIELD_ELEMENTS_PER_CELL` values. As we can tell from the comment, it depends on the `CELLS_PER_EXT_BLOB` constant, which would change. Let's do this dynamically.