### PR TITLE
Allow n<=1 in bit_reversal_permutation

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -105,8 +105,14 @@ C_KZG_RET bit_reversal_permutation(void *values, size_t size, size_t n) {
     byte *tmp = NULL;
     byte *v = (byte *)values;
 
-    /* Some sanity checks */
-    if (n < 2 || !is_power_of_two(n)) {
+    /* In these cases, do nothing */
+    if (n == 0 || n == 1) {
+        ret = C_KZG_OK;
+        goto out;
+    }
+
+    /* Ensure n is a power of two */
+    if (!is_power_of_two(n)) {
         ret = C_KZG_BADARGS;
         goto out;
     }

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -853,7 +853,13 @@ static void test_bit_reversal_permutation__fails_n_not_power_of_two(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
-static void test_bit_reversal_permutation__fails_n_is_one(void) {
+static void test_bit_reversal_permutation__n_is_zero(void) {
+    C_KZG_RET ret;
+    ret = bit_reversal_permutation(NULL, sizeof(uint64_t), 0);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+}
+
+static void test_bit_reversal_permutation__n_is_one(void) {
     C_KZG_RET ret;
     uint64_t reversed[1];
 
@@ -861,7 +867,7 @@ static void test_bit_reversal_permutation__fails_n_is_one(void) {
         reversed[i] = 0;
     }
     ret = bit_reversal_permutation(&reversed, sizeof(uint64_t), 1);
-    ASSERT_EQUALS(ret, C_KZG_BADARGS);
+    ASSERT_EQUALS(ret, C_KZG_OK);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2319,7 +2325,8 @@ int main(void) {
     RUN(test_bit_reversal_permutation__specific_items);
     RUN(test_bit_reversal_permutation__coset_structure);
     RUN(test_bit_reversal_permutation__fails_n_not_power_of_two);
-    RUN(test_bit_reversal_permutation__fails_n_is_one);
+    RUN(test_bit_reversal_permutation__n_is_zero);
+    RUN(test_bit_reversal_permutation__n_is_one);
     RUN(test_compute_powers__succeeds_expected_powers);
     RUN(test_g1_lincomb__verify_consistent);
     RUN(test_evaluate_polynomial_in_evaluation_form__constant_polynomial);


### PR DESCRIPTION
When testing `FIELD_ELEMENTS_PER_CELL=1`, I got a `C_KZG_BADARGS` from `bit_reversal_permutation` because we treated 1 as an invalid length. We just hadn't considered this being valid, but it is. For 0 and 1, we can just return without doing anything. This function is only used with controlled constants, so it shouldn't really affect anything.