### PR TITLE
Move FIELD_ELEMENTS_PER_EXT_BLOB to blob.h

### DIFF
--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -7,9 +7,9 @@ pub const BYTES_PER_COMMITMENT: usize = 48;
 pub const BYTES_PER_PROOF: usize = 48;
 pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 pub const BYTES_PER_BLOB: usize = 131072;
+pub const FIELD_ELEMENTS_PER_EXT_BLOB: usize = 8192;
 pub const FIELD_ELEMENTS_PER_CELL: usize = 64;
 pub const BYTES_PER_CELL: usize = 2048;
-pub const FIELD_ELEMENTS_PER_EXT_BLOB: usize = 8192;
 pub const CELLS_PER_EXT_BLOB: usize = 128;
 pub type limb_t = u64;
 #[repr(C)]

--- a/src/eip4844/blob.h
+++ b/src/eip4844/blob.h
@@ -31,6 +31,16 @@
 /** The number of bytes in a blob. */
 #define BYTES_PER_BLOB (FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT)
 
+/**
+ * The logarithm (base 2) of the expansion factor of our Reed-Solomon code.
+ * In other words, this defines the rate of the Reed-Solomon code (blob / extended blob).
+ * Note that our codebase is not guaranteed to work anymore if this is changed.
+ */
+#define LOG_EXPANSION_FACTOR 1
+
+/** The number of field elements in an extended blob. */
+#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB << LOG_EXPANSION_FACTOR)
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Types
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/eip7594/cell.h
+++ b/src/eip7594/cell.h
@@ -30,16 +30,6 @@
 /** The number of bytes in a single cell. */
 #define BYTES_PER_CELL (FIELD_ELEMENTS_PER_CELL * BYTES_PER_FIELD_ELEMENT)
 
-/**
- * The logarithm (base 2) of the expansion factor of our Reed-Solomon code.
- * In other words, this defines the rate of the Reed-Solomon code (blob / extended blob).
- * Note that our codebase is not guaranteed to work anymore if this is changed.
- */
-#define LOG_EXPANSION_FACTOR 1
-
-/** The number of field elements in an extended blob. */
-#define FIELD_ELEMENTS_PER_EXT_BLOB (FIELD_ELEMENTS_PER_BLOB << LOG_EXPANSION_FACTOR)
-
 /** The number of cells in a blob. */
 #define CELLS_PER_BLOB (FIELD_ELEMENTS_PER_BLOB / FIELD_ELEMENTS_PER_CELL)
 


### PR DESCRIPTION
I believe the `FIELD_ELEMENTS_PER_EXT_BLOB` definition makes more sense here.