### PR TITLE
Add commitment cache optimization

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -102,6 +102,8 @@ fn make_bindings(
         /*
          * Cleanup instructions.
          */
+        // Use core::ffi for ctypes
+        .ctypes_prefix("core::ffi")
         // Remove stdio definitions related to FILE.
         .opaque_type("FILE")
         // Remove the definition of FILE to use the libc one, which is more convenient.

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -106,7 +106,7 @@ pub struct KZGSettings {
     #[doc = " The scratch size for the fixed-base MSM."]
     scratch_size: usize,
     #[doc = " A lock for the commitment cache."]
-    comm_cache_lock: *mut u8,
+    comm_cache_lock: *mut ::std::os::raw::c_long,
     #[doc = " The bytes used as the commitment cache key."]
     comm_cache_key: *mut u8,
     #[doc = " The bytes used as the commitment cache value."]

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -105,6 +105,14 @@ pub struct KZGSettings {
     wbits: usize,
     #[doc = " The scratch size for the fixed-base MSM."]
     scratch_size: usize,
+    #[doc = " A lock for the commitment cache."]
+    comm_cache_lock: *mut u8,
+    #[doc = " The bytes used as the commitment cache key."]
+    comm_cache_key: *mut u8,
+    #[doc = " The bytes used as the commitment cache value."]
+    comm_cache_value: *mut u8,
+    #[doc = " The max number of commitments the cache supports."]
+    comm_cache_size: u64,
 }
 #[doc = " A single cell for a blob."]
 #[repr(C)]

--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -106,7 +106,7 @@ pub struct KZGSettings {
     #[doc = " The scratch size for the fixed-base MSM."]
     scratch_size: usize,
     #[doc = " A lock for the commitment cache."]
-    comm_cache_lock: *mut ::std::os::raw::c_long,
+    comm_cache_lock: *mut core::ffi::c_long,
     #[doc = " The bytes used as the commitment cache key."]
     comm_cache_key: *mut u8,
     #[doc = " The bytes used as the commitment cache value."]

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -496,7 +496,7 @@ static C_KZG_RET cached_commitment_validation(
      * time. Even though ckzg is single-threaded, we expect its functions to be called from a
      * multi-threaded context.
      */
-    while (atomic_flag_test_and_set_explicit(s->comm_cache_lock, memory_order_acquire)) {
+    while (__atomic_test_and_set(s->comm_cache_lock, __ATOMIC_ACQUIRE)) {
         /* Wait for the lock to be released */
     }
 
@@ -528,7 +528,7 @@ static C_KZG_RET cached_commitment_validation(
 
 out:
     /* Clear the lock */
-    atomic_flag_clear_explicit(s->comm_cache_lock, memory_order_release);
+    __atomic_clear(s->comm_cache_lock, __ATOMIC_RELEASE);
     return ret;
 }
 

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -481,21 +481,31 @@ out:
     return ret;
 }
 
-static inline void spinlock_lock(volatile long *l) {
+/**
+ * Lock a spinlock.
+ *
+ * @param[in]   lock    The spinlock to lock
+ */
+static inline void spinlock_lock(volatile long *lock) {
 #ifdef _WIN32
-    while (InterlockedExchange(l, 1) != 0) {
+    while (InterlockedExchange(lock, 1) != 0) {
 #else
-    while (__atomic_exchange_n(l, 1, __ATOMIC_ACQUIRE) != 0) {
+    while (__atomic_exchange_n(lock, 1, __ATOMIC_ACQUIRE) != 0) {
 #endif
         /* Wait for the lock to be released */
     }
 }
 
-static inline void spinlock_unlock(volatile long *l) {
+/**
+ * Unlock a spinlock.
+ *
+ * @param[in]   lock    The spinlock to unlock
+ */
+static inline void spinlock_unlock(volatile long *lock) {
 #ifdef _WIN32
-    InterlockedExchange(l, 0);
+    InterlockedExchange(lock, 0);
 #else
-    __atomic_store_n(l, 0, __ATOMIC_RELEASE);
+    __atomic_store_n(lock, 0, __ATOMIC_RELEASE);
 #endif
 }
 

--- a/src/setup/settings.h
+++ b/src/setup/settings.h
@@ -77,7 +77,7 @@ typedef struct {
     /** The scratch size for the fixed-base MSM. */
     size_t scratch_size;
     /** A lock for the commitment cache. */
-    uint8_t *comm_cache_lock;
+    long *comm_cache_lock;
     /** The bytes used as the commitment cache key. */
     uint8_t *comm_cache_key;
     /** The bytes used as the commitment cache value. */

--- a/src/setup/settings.h
+++ b/src/setup/settings.h
@@ -19,6 +19,8 @@
 #include "common/ec.h"
 #include "common/fr.h"
 
+#include <stdatomic.h> /* For atomic_flag */
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Types
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -76,4 +78,12 @@ typedef struct {
     size_t wbits;
     /** The scratch size for the fixed-base MSM. */
     size_t scratch_size;
+    /** A lock for the commitment cache. */
+    atomic_flag *comm_cache_lock;
+    /** The bytes used as the commitment cache key. */
+    uint8_t *comm_cache_key;
+    /** The bytes used as the commitment cache value. */
+    uint8_t *comm_cache_value;
+    /** The max number of commitments the cache supports. */
+    uint64_t comm_cache_size;
 } KZGSettings;

--- a/src/setup/settings.h
+++ b/src/setup/settings.h
@@ -19,8 +19,6 @@
 #include "common/ec.h"
 #include "common/fr.h"
 
-#include <stdatomic.h> /* For atomic_flag */
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Types
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -79,7 +77,7 @@ typedef struct {
     /** The scratch size for the fixed-base MSM. */
     size_t scratch_size;
     /** A lock for the commitment cache. */
-    atomic_flag *comm_cache_lock;
+    uint8_t *comm_cache_lock;
     /** The bytes used as the commitment cache key. */
     uint8_t *comm_cache_key;
     /** The bytes used as the commitment cache value. */

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -421,7 +421,7 @@ C_KZG_RET load_trusted_setup(
     }
 
     /* Initialize lock for cell verification commitment cache */
-    ret = c_kzg_malloc((void **)&out->comm_cache_lock, sizeof(uint8_t));
+    ret = c_kzg_malloc((void **)&out->comm_cache_lock, sizeof(long));
     if (ret != C_KZG_OK) goto out_error;
     *out->comm_cache_lock = 0;
 

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -362,6 +362,28 @@ static C_KZG_RET is_trusted_setup_in_lagrange_form(const KZGSettings *s, size_t 
 }
 
 /**
+ * Initialize all fields in KZGSettings to null/zero.
+ *
+ * @param[out]  out The KZGSettings to initialize.
+ */
+static void init_settings(KZGSettings *out) {
+    out->roots_of_unity = NULL;
+    out->brp_roots_of_unity = NULL;
+    out->reverse_roots_of_unity = NULL;
+    out->g1_values_monomial = NULL;
+    out->g1_values_lagrange_brp = NULL;
+    out->g2_values_monomial = NULL;
+    out->x_ext_fft_columns = NULL;
+    out->tables = NULL;
+    out->wbits = 0;
+    out->scratch_size = 0;
+    out->comm_cache_lock = NULL;
+    out->comm_cache_key = NULL;
+    out->comm_cache_value = NULL;
+    out->comm_cache_size = 0;
+}
+
+/**
  * Load trusted setup into a KZGSettings.
  *
  * @param[out]  out                     Pointer to the stored trusted setup
@@ -387,17 +409,11 @@ C_KZG_RET load_trusted_setup(
 ) {
     C_KZG_RET ret;
 
-    out->brp_roots_of_unity = NULL;
-    out->roots_of_unity = NULL;
-    out->reverse_roots_of_unity = NULL;
-    out->g1_values_monomial = NULL;
-    out->g1_values_lagrange_brp = NULL;
-    out->g2_values_monomial = NULL;
-    out->x_ext_fft_columns = NULL;
-    out->tables = NULL;
-    out->comm_cache_lock = NULL;
-    out->comm_cache_key = NULL;
-    out->comm_cache_value = NULL;
+    /*
+     * Initialize all fields to null/zero so that if there's an error, we can can call
+     * free_trusted_setup() without worrying about freeing a random pointer.
+     */
+    init_settings(out);
 
     /* It seems that blst limits the input to 15 */
     if (precompute > 15) {
@@ -528,6 +544,12 @@ C_KZG_RET load_trusted_setup_file(KZGSettings *out, FILE *in, uint64_t precomput
     uint8_t *g1_monomial_bytes = NULL;
     uint8_t *g1_lagrange_bytes = NULL;
     uint8_t *g2_monomial_bytes = NULL;
+
+    /*
+     * Initialize all fields to null/zero so that if there's an error, we can can call
+     * free_trusted_setup() without worrying about freeing a random pointer.
+     */
+    init_settings(out);
 
     /* Allocate space for points */
     ret = c_kzg_calloc((void **)&g1_monomial_bytes, NUM_G1_POINTS, BYTES_PER_G1);

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -395,6 +395,7 @@ C_KZG_RET load_trusted_setup(
     out->g2_values_monomial = NULL;
     out->x_ext_fft_columns = NULL;
     out->tables = NULL;
+    out->comm_cache_lock = NULL;
     out->comm_cache_key = NULL;
     out->comm_cache_value = NULL;
 

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -20,12 +20,11 @@
 #include "eip7594/eip7594.h"
 #include "eip7594/fft.h"
 
-#include <assert.h>    /* For assert */
-#include <inttypes.h>  /* For SCNu64 */
-#include <stdatomic.h> /* For atomic_flag */
-#include <stdio.h>     /* For FILE */
-#include <stdlib.h>    /* For NULL */
-#include <string.h>    /* For memcpy */
+#include <assert.h>   /* For assert */
+#include <inttypes.h> /* For SCNu64 */
+#include <stdio.h>    /* For FILE */
+#include <stdlib.h>   /* For NULL */
+#include <string.h>   /* For memcpy */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Macros
@@ -422,9 +421,9 @@ C_KZG_RET load_trusted_setup(
     }
 
     /* Initialize lock for cell verification commitment cache */
-    ret = c_kzg_malloc((void **)&out->comm_cache_lock, sizeof(atomic_flag));
+    ret = c_kzg_malloc((void **)&out->comm_cache_lock, sizeof(uint8_t));
     if (ret != C_KZG_OK) goto out_error;
-    atomic_flag_clear_explicit(out->comm_cache_lock, memory_order_relaxed);
+    *out->comm_cache_lock = 0;
 
     /* Set the max cache size to a high value */
     out->comm_cache_size = 4096;


### PR DESCRIPTION
This feels a little dirty, but I've been looking for any optimization that would speed up cell verification. I believe this is a worthy optimization. Let's establish the context:

* When clients receive a column, they will call `verify_cell_kzg_proof_batch` on the cells for that column.
* They may do this in a multi-threaded way; they will spawn a thread to verify the column.
* For each column in a slot, the commitments are expected to be the same.
* Columns will usually be for the same slot; random columns for other slots will not be received.
* At t+0 we'll start to receive columns, by t+4 we'll probably receive most columns for that slot. 

For the first column, there will be no improvement, but on subsequent calls, there will be a ~3ms improvement. For a basic node, who will custody 4 columns, this will save at least 9ms when verifying columns it custodies. For a super node, which custodies 128 columns, this will save at least 381ms of CPU time.

### Before
```
Benchmark/VerifyColumns(count=1)                      76          15628912 ns/op
Benchmark/VerifyColumns(count=2)                      55          20550682 ns/op
Benchmark/VerifyColumns(count=4)                      37          31408771 ns/op
Benchmark/VerifyColumns(count=8)                      22          52450987 ns/op
Benchmark/VerifyColumns(count=16)                     12          93017035 ns/op
Benchmark/VerifyColumns(count=32)                      6         172958548 ns/op
Benchmark/VerifyColumns(count=64)                      4         328076802 ns/op
Benchmark/VerifyColumns(count=128)                     2         639059375 ns/op
```

### After
```
Benchmark/VerifyColumns(count=1)                      97          12343080 ns/op
Benchmark/VerifyColumns(count=2)                      67          17212544 ns/op
Benchmark/VerifyColumns(count=4)                      42          28790411 ns/op
Benchmark/VerifyColumns(count=8)                      22          49900112 ns/op
Benchmark/VerifyColumns(count=16)                     12          91822337 ns/op
Benchmark/VerifyColumns(count=32)                      6         172098938 ns/op
Benchmark/VerifyColumns(count=64)                      4         324300136 ns/op
Benchmark/VerifyColumns(count=128)                     2         631046188 ns/op
```