### PR TITLE
src/Makefile: Enable CC override and remove -Wformat=2 from CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ ifeq ($(PLATFORM),Darwin)
 endif
 
 # The base compiler flags. More can be added on command line.
-CFLAGS += -I. -I../inc -O2 -Werror
+CFLAGS += -I. -I../inc
 # Enable a bunch of optional warnings.
 CFLAGS += \
 	-pedantic \
@@ -81,7 +81,7 @@ ifeq ($(PLATFORM),Windows)
 else
 	CC ?= clang
 	CFLAGS += -fPIC
-	CFLAGS += -Wmissing-braces -Wformat=2
+	CFLAGS += -Wmissing-braces
 endif
 
 # Settings for blst.


### PR DESCRIPTION
* Enable overriding of CC in the Makefile to support alternative build systems.
* Remove -Wformat=2 from CFLAGS to avoid Werror issues like: [-Werror=missing-prototypes], [-Werror=conversion], [-Werror=nested-externs], [-Werror=redundant-decls], [-Werror=strict-aliasing], [-Werror=strict-aliasing] and [-Werror=sign-conversion]

These changes are necessary for compatibility with different build systems. Similar patches have already been applied in [Fedora](https://src.fedoraproject.org/rpms/python-ckzg/tree/f42) as well as in [the Yocto Project and OpenEmbedded layer meta-openembedded](https://git.openembedded.org/meta-openembedded/commit/?h=master-next&id=57b88d28b3b8b866cab0f06f1cc73700d67b70b8).


