### PR TITLE
Remove point-at-infinity filter in g1_lincomb_fast

### DIFF
--- a/src/common/lincomb.c
+++ b/src/common/lincomb.c
@@ -68,7 +68,6 @@ void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) 
 C_KZG_RET g1_lincomb_fast(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) {
     C_KZG_RET ret;
     limb_t *scratch = NULL;
-    blst_p1 *p_filtered = NULL;
     blst_p1_affine *p_affine = NULL;
     blst_scalar *scalars = NULL;
 
@@ -83,8 +82,6 @@ C_KZG_RET g1_lincomb_fast(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t l
     }
 
     /* Allocate space for arrays */
-    ret = c_kzg_calloc((void **)&p_filtered, len, sizeof(blst_p1));
-    if (ret != C_KZG_OK) goto out;
     ret = c_kzg_calloc((void **)&p_affine, len, sizeof(blst_p1_affine));
     if (ret != C_KZG_OK) goto out;
     ret = c_kzg_calloc((void **)&scalars, len, sizeof(blst_scalar));
@@ -100,38 +97,18 @@ C_KZG_RET g1_lincomb_fast(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t l
         blst_scalar_from_fr(&scalars[i], &coeffs[i]);
     }
 
-    /* Filter out zero points: make a new list p_filtered that contains only non-zero points */
-    size_t new_len = 0;
-    for (size_t i = 0; i < len; i++) {
-        if (!blst_p1_is_inf(&p[i])) {
-            /* Copy valid points to the new position */
-            p_filtered[new_len] = p[i];
-            scalars[new_len] = scalars[i];
-            new_len++;
-        }
-    }
-
-    /* Check if the new length is fine */
-    if (new_len < min_length_threshold) {
-        /* We must use the original inputs */
-        g1_lincomb_naive(out, p, coeffs, len);
-        ret = C_KZG_OK;
-        goto out;
-    }
-
     /* Transform the points to affine representation */
-    const blst_p1 *p_arg[2] = {p_filtered, NULL};
-    blst_p1s_to_affine(p_affine, p_arg, new_len);
+    const blst_p1 *p_arg[2] = {p, NULL};
+    blst_p1s_to_affine(p_affine, p_arg, len);
 
     /* Call the Pippenger implementation */
     const byte *scalars_arg[2] = {(byte *)scalars, NULL};
     const blst_p1_affine *points_arg[2] = {p_affine, NULL};
-    blst_p1s_mult_pippenger(out, points_arg, new_len, scalars_arg, BITS_PER_FIELD_ELEMENT, scratch);
+    blst_p1s_mult_pippenger(out, points_arg, len, scalars_arg, BITS_PER_FIELD_ELEMENT, scratch);
     ret = C_KZG_OK;
 
 out:
     c_kzg_free(scratch);
-    c_kzg_free(p_filtered);
     c_kzg_free(p_affine);
     c_kzg_free(scalars);
     return ret;


### PR DESCRIPTION
Now that blst properly handles this, we can remove this filtering 🙂

See: https://github.com/supranational/blst/commit/ae643bad61ac6fd618bffd771d0ccfddfddf8aee