### PR TITLE
Check if blob is nil in ComputeCells/ComputeCellsAndKZGProofs

### DIFF
--- a/bindings/go/main.go
+++ b/bindings/go/main.go
@@ -412,6 +412,9 @@ func ComputeCells(blob *Blob) ([CellsPerExtBlob]Cell, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
 	}
+	if blob == nil {
+		return [CellsPerExtBlob]Cell{}, ErrBadArgs
+	}
 
 	cells := [CellsPerExtBlob]Cell{}
 	ret := C.compute_cells_and_kzg_proofs(
@@ -438,6 +441,9 @@ ComputeCellsAndKZGProofs is the binding for:
 func ComputeCellsAndKZGProofs(blob *Blob) ([CellsPerExtBlob]Cell, [CellsPerExtBlob]KZGProof, error) {
 	if !loaded {
 		panic("trusted setup isn't loaded")
+	}
+	if blob == nil {
+		return [CellsPerExtBlob]Cell{}, [CellsPerExtBlob]KZGProof{}, ErrBadArgs
 	}
 
 	cells := [CellsPerExtBlob]Cell{}


### PR DESCRIPTION
Missing checks here. If provided nil inputs, it would panic.