### PR TITLE
add benchmark for recovering cells without proofs

### DIFF
--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -821,6 +821,28 @@ func Benchmark(b *testing.B) {
 	for i := 2; i <= 8; i *= 2 {
 		percentMissing := (1.0 / float64(i)) * 100
 		cellIndices, partialCells := getPartialCells(blobCells[0], i)
+		b.Run(fmt.Sprintf("RecoverCells(missing=%2.1f%%)", percentMissing), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_, err := RecoverCells(cellIndices, partialCells)
+				require.NoError(b, err)
+			}
+		})
+	}
+
+	for i := 1; i <= 2; i++ {
+		mod := divideRoundUp(CellsPerExtBlob, i)
+		cellIndices, partialCells := getPartialCells(blobCells[0], mod)
+		b.Run(fmt.Sprintf("RecoverCells(missing=%v)", i), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_, err := RecoverCells(cellIndices, partialCells)
+				require.NoError(b, err)
+			}
+		})
+	}
+
+	for i := 2; i <= 8; i *= 2 {
+		percentMissing := (1.0 / float64(i)) * 100
+		cellIndices, partialCells := getPartialCells(blobCells[0], i)
 		b.Run(fmt.Sprintf("RecoverCellsAndKZGProofs(missing=%2.1f%%)", percentMissing), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				_, _, err := RecoverCellsAndKZGProofs(cellIndices, partialCells)


### PR DESCRIPTION
We will often need to recover cells only, without recovering the associated proofs, since proofs will already be available from a side-channel (e.g. as part of a message sent before the per-cell diffusion starts).

The API already supports this by setting the proofs array to NULL. This PR adds benchmarks. 