### PR TITLE
Create cell verification challenge with deduplicated commitments

### DIFF
--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -874,7 +874,7 @@ C_KZG_RET verify_cell_kzg_proof_batch(
     /* Compute the challenge */
     ret = compute_verify_cell_kzg_proof_batch_challenge(
         &r,
-        commitments_bytes,
+        unique_commitments,
         num_commitments,
         commitment_indices,
         cell_indices,


### PR DESCRIPTION
This is a bug fix. We were passing the duplicated commitment count (`num_commitments`) with the original array of commitments (`commitments_bytes`, which may contain duplicates) instead of the deduplicated array of commitments (`unique_commitments`). So it was possible that not all commitments were being included in the challenge computation.

For example, when working with the following commitments:

```python
[commitment_a, commitment_a, commitment_b]
```

`num_commitments` would be 2 and `unique_commitments` would be:

```python
[commitment_a, commitment_b]
```

But we would use `[commitment_a, commitment_a]` to create the challenge.

This would be pretty difficult to exploit, but definitely needs to be fixed.

This was a great find from an auditor in the [fusaka audit competition](https://sherlock.xyz/ethereumfusakacontest), thank you!