### PR TITLE
Use latest python version in CI actions

### DIFF
--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.10"
+          python-version: '3.x'
       - name: Install setuptools
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.x'
 
       # Need this to get cl.exe on the path.
       - name: Set up Visual Studio shell
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.x'
 
       - name: Build source distribution
         run: python setup.py sdist

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -56,7 +56,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Need to update this to install the latest version of cibuildwheel.