### PR TITLE
Install setuptools in source distribution step

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -93,6 +93,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install setuptools
+        run: python -m pip install setuptools
+
       - name: Build source distribution
         run: python setup.py sdist
 


### PR DESCRIPTION
As of python 3.12, `setuptools` isn't installed by default.

This is a necessary dependency.