### PR TITLE
Use std OnceLock to avoid wasted CPU time

### DIFF
--- a/bindings/rust/src/ethereum_kzg_settings/mod.rs
+++ b/bindings/rust/src/ethereum_kzg_settings/mod.rs
@@ -1,6 +1,13 @@
 use crate::KzgSettings;
-use alloc::{boxed::Box, sync::Arc};
-use once_cell::race::OnceBox;
+use alloc::sync::Arc;
+
+#[cfg(not(feature = "std"))]
+use once_cell::race::OnceBox as OnceLock;
+#[cfg(feature = "std")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "std")]
+use once_cell as _;
 
 /// Default G1 monomial bytes.
 const ETH_G1_MONOMIAL_POINTS: &[u8] = include_bytes!("./g1_monomial_bytes.bin");
@@ -11,11 +18,11 @@ const ETH_G2_MONOMIAL_POINTS: &[u8] = include_bytes!("./g2_monomial_bytes.bin");
 
 macro_rules! create_cache {
     ($name:ident) => {
-        static $name: OnceBox<Arc<KzgSettings>> = OnceBox::new();
+        static $name: OnceLock<Arc<KzgSettings>> = OnceLock::new();
     };
 }
 
-// We use separate OnceBox instances for each precompute value.
+// We use separate OnceLock instances for each precompute value.
 // This avoids the need for any unsafe code or mutexes.
 create_cache!(CACHE_0);
 create_cache!(CACHE_1);
@@ -53,7 +60,7 @@ pub fn ethereum_kzg_settings_arc(precompute: u64) -> Arc<KzgSettings> {
 }
 
 fn ethereum_kzg_settings_inner(precompute: u64) -> &'static Arc<KzgSettings> {
-    let cache_box = match precompute {
+    let cache = match precompute {
         0 => &CACHE_0,
         1 => &CACHE_1,
         2 => &CACHE_2,
@@ -75,7 +82,7 @@ fn ethereum_kzg_settings_inner(precompute: u64) -> &'static Arc<KzgSettings> {
         ),
     };
 
-    cache_box.get_or_init(|| {
+    cache.get_or_init(|| {
         let settings = KzgSettings::load_trusted_setup(
             ETH_G1_MONOMIAL_POINTS,
             ETH_G1_LAGRANGE_POINTS,
@@ -83,7 +90,8 @@ fn ethereum_kzg_settings_inner(precompute: u64) -> &'static Arc<KzgSettings> {
             precompute,
         )
         .expect("failed to load default trusted setup");
-        Box::new(Arc::new(settings))
+        #[allow(clippy::useless_conversion)] // `std`: no-op, `not(std)`: allocates into a `Box`.
+        Arc::new(settings).into()
     })
 }
 

--- a/bindings/rust/src/ethereum_kzg_settings/mod.rs
+++ b/bindings/rust/src/ethereum_kzg_settings/mod.rs
@@ -16,31 +16,6 @@ const ETH_G1_LAGRANGE_POINTS: &[u8] = include_bytes!("./g1_lagrange_bytes.bin");
 /// Default G2 monomial bytes.
 const ETH_G2_MONOMIAL_POINTS: &[u8] = include_bytes!("./g2_monomial_bytes.bin");
 
-macro_rules! create_cache {
-    ($name:ident) => {
-        static $name: OnceLock<Arc<KzgSettings>> = OnceLock::new();
-    };
-}
-
-// We use separate OnceLock instances for each precompute value.
-// This avoids the need for any unsafe code or mutexes.
-create_cache!(CACHE_0);
-create_cache!(CACHE_1);
-create_cache!(CACHE_2);
-create_cache!(CACHE_3);
-create_cache!(CACHE_4);
-create_cache!(CACHE_5);
-create_cache!(CACHE_6);
-create_cache!(CACHE_7);
-create_cache!(CACHE_8);
-create_cache!(CACHE_9);
-create_cache!(CACHE_10);
-create_cache!(CACHE_11);
-create_cache!(CACHE_12);
-create_cache!(CACHE_13);
-create_cache!(CACHE_14);
-create_cache!(CACHE_15);
-
 /// Returns default Ethereum mainnet KZG settings.
 ///
 /// If you need a cloneable settings use `ethereum_kzg_settings_arc` instead.
@@ -60,29 +35,14 @@ pub fn ethereum_kzg_settings_arc(precompute: u64) -> Arc<KzgSettings> {
 }
 
 fn ethereum_kzg_settings_inner(precompute: u64) -> &'static Arc<KzgSettings> {
-    let cache = match precompute {
-        0 => &CACHE_0,
-        1 => &CACHE_1,
-        2 => &CACHE_2,
-        3 => &CACHE_3,
-        4 => &CACHE_4,
-        5 => &CACHE_5,
-        6 => &CACHE_6,
-        7 => &CACHE_7,
-        8 => &CACHE_8,
-        9 => &CACHE_9,
-        10 => &CACHE_10,
-        11 => &CACHE_11,
-        12 => &CACHE_12,
-        13 => &CACHE_13,
-        14 => &CACHE_14,
-        15 => &CACHE_15,
-        _ => panic!(
-            "Unsupported precompute value: {precompute}. Only values 0-15 (inclusive) are supported."
-        ),
-    };
+    static CACHES: [OnceLock<Arc<KzgSettings>>; 16] = [const { OnceLock::new() }; 16];
 
-    cache.get_or_init(|| {
+    assert!(
+        precompute <= 15,
+        "Unsupported precompute value: {precompute}. Only values 0-15 (inclusive) are supported."
+    );
+
+    CACHES[precompute as usize].get_or_init(|| {
         let settings = KzgSettings::load_trusted_setup(
             ETH_G1_MONOMIAL_POINTS,
             ETH_G1_LAGRANGE_POINTS,


### PR DESCRIPTION
`once_cell`'s `OnceBox` allows races during initialization, and then only one thread gets to set the value. `std`'s `OnceLock` waits for the first thread to finish computation.