### PR TITLE
Use more common helpers

### DIFF
--- a/src/common/ec.c
+++ b/src/common/ec.c
@@ -20,6 +20,17 @@
 #include <stdio.h> /* For printf */
 
 /**
+ * Addition of G1 group elements.
+ *
+ * @param[out]  out The result, `a + b`
+ * @param[in]   a   A G1 group element
+ * @param[in]   b   The G1 group element to be added
+ */
+void g1_add(g1_t *out, const g1_t *a, const g1_t *b) {
+    blst_p1_add_or_double(out, a, b);
+}
+
+/**
  * Subtraction of G1 group elements.
  *
  * @param[out]  out The result, `a - b`
@@ -29,7 +40,7 @@
 void g1_sub(g1_t *out, const g1_t *a, const g1_t *b) {
     g1_t bneg = *b;
     blst_p1_cneg(&bneg, true);
-    blst_p1_add_or_double(out, a, &bneg);
+    g1_add(out, a, &bneg);
 }
 
 /**

--- a/src/common/ec.h
+++ b/src/common/ec.h
@@ -43,6 +43,7 @@ static const g1_t G1_IDENTITY = {
 extern "C" {
 #endif
 
+void g1_add(g1_t *out, const g1_t *a, const g1_t *b);
 void g1_sub(g1_t *out, const g1_t *a, const g1_t *b);
 void g1_mul(g1_t *out, const g1_t *a, const fr_t *b);
 void print_g1(const g1_t *g);

--- a/src/common/fr.c
+++ b/src/common/fr.c
@@ -51,6 +51,61 @@ bool fr_is_one(const fr_t *p) {
 }
 
 /**
+ * Addition of field elements.
+ *
+ * @param[out]  out The result, `a + b`
+ * @param[in]   a   A field element
+ * @param[in]   b   The field element to be added
+ */
+void fr_add(fr_t *out, const fr_t *a, const fr_t *b) {
+    blst_fr_add(out, a, b);
+}
+
+/**
+ * Subtraction of field elements.
+ *
+ * @param[out]  out The result, `a - b`
+ * @param[in]   a   A field element
+ * @param[in]   b   The field element to be subtracted
+ */
+void fr_sub(fr_t *out, const fr_t *a, const fr_t *b) {
+    blst_fr_sub(out, a, b);
+}
+
+/**
+ * Multiplication of field elements.
+ *
+ * @param[out]  out The result, `a * b`
+ * @param[in]   a   A field element
+ * @param[in]   b   The multiplier
+ */
+void fr_mul(fr_t *out, const fr_t *a, const fr_t *b) {
+    blst_fr_mul(out, a, b);
+}
+
+/**
+ * Negation of a field element.
+ *
+ * @param[out]  out The result, `-a`
+ * @param[in]   a   The field element to be negated
+ */
+void fr_neg(fr_t *out, const fr_t *a) {
+    blst_fr_cneg(out, a, true);
+}
+
+/**
+ * Inversion of a field element.
+ *
+ * @param[out]  out The result, `1 / a`
+ * @param[in]   a   The field element to be inverted
+ *
+ * @remark The behavior for `a == 0` is unspecified.
+ */
+void fr_inv(fr_t *out, const fr_t *a) {
+    blst_fr_eucl_inverse(out, a);
+}
+
+/**
  * Divide a field element by another.
  *
  * @param[out]  out The result, `a / b`
@@ -62,8 +117,8 @@ bool fr_is_one(const fr_t *p) {
  */
 void fr_div(fr_t *out, const fr_t *a, const fr_t *b) {
     fr_t tmp;
-    blst_fr_eucl_inverse(&tmp, b);
-    blst_fr_mul(out, a, &tmp);
+    fr_inv(&tmp, b);
+    fr_mul(out, a, &tmp);
 }
 
 /**
@@ -84,7 +139,7 @@ void fr_pow(fr_t *out, const fr_t *a, uint64_t n) {
 
     while (true) {
         if (n & 1) {
-            blst_fr_mul(out, out, &tmp);
+            fr_mul(out, out, &tmp);
         }
         if ((n >>= 1) == 0) break;
         blst_fr_sqr(&tmp, &tmp);

--- a/src/common/fr.h
+++ b/src/common/fr.h
@@ -58,6 +58,11 @@ extern "C" {
 
 bool fr_equal(const fr_t *a, const fr_t *b);
 bool fr_is_one(const fr_t *p);
+void fr_add(fr_t *out, const fr_t *a, const fr_t *b);
+void fr_sub(fr_t *out, const fr_t *a, const fr_t *b);
+void fr_mul(fr_t *out, const fr_t *a, const fr_t *b);
+void fr_neg(fr_t *out, const fr_t *a);
+void fr_inv(fr_t *out, const fr_t *a);
 void fr_div(fr_t *out, const fr_t *a, const fr_t *b);
 void fr_pow(fr_t *out, const fr_t *a, uint64_t n);
 void fr_from_uint64(fr_t *out, uint64_t n);

--- a/src/common/lincomb.c
+++ b/src/common/lincomb.c
@@ -36,7 +36,7 @@ void g1_lincomb_naive(g1_t *out, const g1_t *p, const fr_t *coeffs, size_t len) 
     *out = G1_IDENTITY;
     for (size_t i = 0; i < len; i++) {
         g1_mul(&tmp, &p[i], &coeffs[i]);
-        blst_p1_add_or_double(out, out, &tmp);
+        g1_add(out, out, &tmp);
     }
 }
 

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -152,7 +152,7 @@ void compute_powers(fr_t *out, const fr_t *x, size_t n) {
     fr_t current_power = FR_ONE;
     for (size_t i = 0; i < n; i++) {
         out[i] = current_power;
-        blst_fr_mul(&current_power, &current_power, x);
+        fr_mul(&current_power, &current_power, x);
     }
 }
 

--- a/src/eip4844/eip4844.c
+++ b/src/eip4844/eip4844.c
@@ -87,7 +87,7 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
 
     for (i = 0; i < len; i++) {
         out[i] = accumulator;
-        blst_fr_mul(&accumulator, &accumulator, &a[i]);
+        fr_mul(&accumulator, &accumulator, &a[i]);
     }
 
     /* Bail on any zero input */
@@ -95,11 +95,11 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
         return C_KZG_BADARGS;
     }
 
-    blst_fr_eucl_inverse(&accumulator, &accumulator);
+    fr_inv(&accumulator, &accumulator);
 
     for (i = len - 1; i >= 0; i--) {
-        blst_fr_mul(&out[i], &out[i], &accumulator);
-        blst_fr_mul(&accumulator, &accumulator, &a[i]);
+        fr_mul(&out[i], &out[i], &accumulator);
+        fr_mul(&accumulator, &accumulator, &a[i]);
     }
 
     return C_KZG_OK;
@@ -215,7 +215,7 @@ static C_KZG_RET evaluate_polynomial_in_evaluation_form(
             ret = C_KZG_OK;
             goto out;
         }
-        blst_fr_sub(&inverses_in[i], x, &brp_roots_of_unity[i]);
+        fr_sub(&inverses_in[i], x, &brp_roots_of_unity[i]);
     }
 
     ret = fr_batch_inv(inverses, inverses_in, FIELD_ELEMENTS_PER_BLOB);
@@ -223,15 +223,15 @@ static C_KZG_RET evaluate_polynomial_in_evaluation_form(
 
     *out = FR_ZERO;
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        blst_fr_mul(&tmp, &inverses[i], &brp_roots_of_unity[i]);
-        blst_fr_mul(&tmp, &tmp, &poly[i]);
-        blst_fr_add(out, out, &tmp);
+        fr_mul(&tmp, &inverses[i], &brp_roots_of_unity[i]);
+        fr_mul(&tmp, &tmp, &poly[i]);
+        fr_add(out, out, &tmp);
     }
     fr_from_uint64(&tmp, FIELD_ELEMENTS_PER_BLOB);
     fr_div(out, out, &tmp);
     fr_pow(&tmp, x, FIELD_ELEMENTS_PER_BLOB);
-    blst_fr_sub(&tmp, &tmp, &FR_ONE);
-    blst_fr_mul(out, out, &tmp);
+    fr_sub(&tmp, &tmp, &FR_ONE);
+    fr_mul(out, out, &tmp);
 
 out:
     c_kzg_free(inverses_in);
@@ -446,15 +446,15 @@ static C_KZG_RET compute_kzg_proof_impl(
             continue;
         }
         // (p_i - y) / (ω_i - z)
-        blst_fr_sub(&q_poly[i], &poly[i], y_out);
-        blst_fr_sub(&inverses_in[i], &brp_roots_of_unity[i], z);
+        fr_sub(&q_poly[i], &poly[i], y_out);
+        fr_sub(&inverses_in[i], &brp_roots_of_unity[i], z);
     }
 
     ret = fr_batch_inv(inverses, inverses_in, FIELD_ELEMENTS_PER_BLOB);
     if (ret != C_KZG_OK) goto out;
 
     for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-        blst_fr_mul(&q_poly[i], &q_poly[i], &inverses[i]);
+        fr_mul(&q_poly[i], &q_poly[i], &inverses[i]);
     }
 
     if (m != 0) { /* ω_{m-1} == z */
@@ -462,8 +462,8 @@ static C_KZG_RET compute_kzg_proof_impl(
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
             if (i == m) continue;
             /* Build denominator: z * (z - ω_i) */
-            blst_fr_sub(&tmp, z, &brp_roots_of_unity[i]);
-            blst_fr_mul(&inverses_in[i], &tmp, z);
+            fr_sub(&tmp, z, &brp_roots_of_unity[i]);
+            fr_mul(&inverses_in[i], &tmp, z);
         }
 
         ret = fr_batch_inv(inverses, inverses_in, FIELD_ELEMENTS_PER_BLOB);
@@ -472,11 +472,11 @@ static C_KZG_RET compute_kzg_proof_impl(
         for (i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
             if (i == m) continue;
             /* Build numerator: ω_i * (p_i - y) */
-            blst_fr_sub(&tmp, &poly[i], y_out);
-            blst_fr_mul(&tmp, &tmp, &brp_roots_of_unity[i]);
+            fr_sub(&tmp, &poly[i], y_out);
+            fr_mul(&tmp, &tmp, &brp_roots_of_unity[i]);
             /* Do the division: (p_i - y) * ω_i / (z * (z - ω_i)) */
-            blst_fr_mul(&tmp, &tmp, &inverses[i]);
-            blst_fr_add(&q_poly[m], &q_poly[m], &tmp);
+            fr_mul(&tmp, &tmp, &inverses[i]);
+            fr_add(&q_poly[m], &q_poly[m], &tmp);
         }
     }
 
@@ -737,7 +737,7 @@ static C_KZG_RET verify_kzg_proof_batch(
         /* Get C_i - [y_i] */
         g1_sub(&C_minus_y[i], &commitments_g1[i], &ys_encrypted);
         /* Get r^i * z_i */
-        blst_fr_mul(&r_times_z[i], &r_powers[i], &zs_fr[i]);
+        fr_mul(&r_times_z[i], &r_powers[i], &zs_fr[i]);
     }
 
     /* Get \sum r^i z_i Proof_i */
@@ -745,7 +745,7 @@ static C_KZG_RET verify_kzg_proof_batch(
     /* Get \sum r^i (C_i - [y_i]) */
     g1_lincomb_naive(&C_minus_y_lincomb, C_minus_y, r_powers, n);
     /* Get C_minus_y_lincomb + proof_z_lincomb */
-    blst_p1_add_or_double(&rhs_g1, &C_minus_y_lincomb, &proof_z_lincomb);
+    g1_add(&rhs_g1, &C_minus_y_lincomb, &proof_z_lincomb);
 
     /* Do the pairing check! */
     *ok = pairings_verify(&proof_lincomb, &s->g2_values_monomial[1], &rhs_g1, blst_p2_generator());

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -16,6 +16,7 @@
 
 #include "eip7594/eip7594.h"
 #include "common/alloc.h"
+#include "common/ec.h"
 #include "common/fr.h"
 #include "common/lincomb.h"
 #include "common/utils.h"
@@ -518,7 +519,7 @@ static C_KZG_RET compute_weighted_sum_of_commitments(
 
     /* Update commitment weights */
     for (uint64_t i = 0; i < num_cells; i++) {
-        blst_fr_add(
+        fr_add(
             &commitment_weights[commitment_indices[i]],
             &commitment_weights[commitment_indices[i]],
             &r_powers[i]
@@ -672,12 +673,12 @@ static C_KZG_RET compute_commitment_to_aggregated_interpolation_poly(
             if (ret != C_KZG_OK) goto out;
 
             /* Scale the field element by the appropriate power of r */
-            blst_fr_mul(&scaled_fr, &original_fr, &r_powers[cell_index]);
+            fr_mul(&scaled_fr, &original_fr, &r_powers[cell_index]);
 
             /* Figure out the right index for this field element within the extended array */
             size_t array_index = column_index * FIELD_ELEMENTS_PER_CELL + fr_index;
             /* Aggregate the scaled field element into the array */
-            blst_fr_add(
+            fr_add(
                 &aggregated_column_cells[array_index],
                 &aggregated_column_cells[array_index],
                 &scaled_fr
@@ -742,7 +743,7 @@ static C_KZG_RET compute_commitment_to_aggregated_interpolation_poly(
 
         /* Update the aggregated poly */
         for (size_t k = 0; k < FIELD_ELEMENTS_PER_CELL; k++) {
-            blst_fr_add(
+            fr_add(
                 &aggregated_interpolation_poly[k],
                 &aggregated_interpolation_poly[k],
                 &column_interpolation_poly[k]
@@ -800,7 +801,7 @@ static C_KZG_RET computed_weighted_sum_of_proofs(
         get_coset_shift_pow_for_cell(&h_k_pow, cell_indices[i], s);
 
         /* Scale the power of r by h_k^n */
-        blst_fr_mul(&weighted_powers_of_r[i], &r_powers[i], &h_k_pow);
+        fr_mul(&weighted_powers_of_r[i], &r_powers[i], &h_k_pow);
     }
 
     ret = g1_lincomb_fast(weighted_proof_sum_out, proofs_g1, weighted_powers_of_r, num_cells);
@@ -944,9 +945,8 @@ C_KZG_RET verify_cell_kzg_proof_batch(
     );
     if (ret != C_KZG_OK) goto out;
 
-    /* Subtract commitment from sum by adding the negated commitment */
-    blst_p1_cneg(&interpolation_poly_commit, true);
-    blst_p1_add(&final_g1_sum, &final_g1_sum, &interpolation_poly_commit);
+    /* Subtract the commitment from the sum */
+    g1_sub(&final_g1_sum, &final_g1_sum, &interpolation_poly_commit);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Compute sum of the proofs scaled by the coset factors
@@ -957,7 +957,7 @@ C_KZG_RET verify_cell_kzg_proof_batch(
     );
     if (ret != C_KZG_OK) goto out;
 
-    blst_p1_add(&final_g1_sum, &final_g1_sum, &weighted_sum_of_proofs);
+    g1_add(&final_g1_sum, &final_g1_sum, &weighted_sum_of_proofs);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Do the final pairing check

--- a/src/eip7594/fft.c
+++ b/src/eip7594/fft.c
@@ -76,9 +76,9 @@ static void fr_fft_fast(
         fr_fft_fast(out, in, stride * 2, roots, roots_stride * 2, half);
         fr_fft_fast(out + half, in + stride, stride * 2, roots, roots_stride * 2, half);
         for (size_t i = 0; i < half; i++) {
-            blst_fr_mul(&y_times_root, &out[i + half], &roots[i * roots_stride]);
-            blst_fr_sub(&out[i + half], &out[i], &y_times_root);
-            blst_fr_add(&out[i], &out[i], &y_times_root);
+            fr_mul(&y_times_root, &out[i + half], &roots[i * roots_stride]);
+            fr_sub(&out[i + half], &out[i], &y_times_root);
+            fr_add(&out[i], &out[i], &y_times_root);
         }
     } else {
         *out = *in;
@@ -138,9 +138,9 @@ C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
 
     fr_t inv_n;
     fr_from_uint64(&inv_n, n);
-    blst_fr_eucl_inverse(&inv_n, &inv_n);
+    fr_inv(&inv_n, &inv_n);
     for (size_t i = 0; i < n; i++) {
-        blst_fr_mul(&out[i], &out[i], &inv_n);
+        fr_mul(&out[i], &out[i], &inv_n);
     }
     return C_KZG_OK;
 }
@@ -177,7 +177,7 @@ static void g1_fft_fast(
                 g1_mul(&y_times_root, &out[i + half], &roots[i * roots_stride]);
             }
             g1_sub(&out[i + half], &out[i], &y_times_root);
-            blst_p1_add_or_double(&out[i], &out[i], &y_times_root);
+            g1_add(&out[i], &out[i], &y_times_root);
         }
     } else {
         *out = *in;

--- a/src/eip7594/fk20.c
+++ b/src/eip7594/fk20.c
@@ -195,7 +195,7 @@ C_KZG_RET compute_fk20_cell_proofs(g1_t *out, const fr_t *poly, const KZGSetting
      * needed in the IFFT scaling step.
      */
     fr_from_uint64(&inv_domain_size, circulant_domain_size);
-    blst_fr_eucl_inverse(&inv_domain_size, &inv_domain_size);
+    fr_inv(&inv_domain_size, &inv_domain_size);
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_CELL; i++) {
         /* Select the coefficients c_i of poly that form the i-th circulant matrix */
         circulant_coeffs_stride(circulant_coeffs, poly, i);
@@ -204,7 +204,7 @@ C_KZG_RET compute_fk20_cell_proofs(g1_t *out, const fr_t *poly, const KZGSetting
         if (ret != C_KZG_OK) goto out;
         /* Transpose and prescale by 1/n in one pass */
         for (size_t j = 0; j < circulant_domain_size; j++) {
-            blst_fr_mul(&coeffs[j][i], &circulant_coeffs_fft[j], &inv_domain_size);
+            fr_mul(&coeffs[j][i], &circulant_coeffs_fft[j], &inv_domain_size);
         }
     }
 

--- a/src/eip7594/poly.c
+++ b/src/eip7594/poly.c
@@ -38,8 +38,8 @@
 void shift_poly(fr_t *p, size_t len, const fr_t *shift_factor) {
     fr_t factor_power = FR_ONE;
     for (size_t i = 1; i < len; i++) {
-        blst_fr_mul(&factor_power, &factor_power, shift_factor);
-        blst_fr_mul(&p[i], &p[i], &factor_power);
+        fr_mul(&factor_power, &factor_power, shift_factor);
+        fr_mul(&p[i], &p[i], &factor_power);
     }
 }
 

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -53,19 +53,19 @@ static C_KZG_RET compute_vanishing_polynomial_from_roots(
     }
 
     /* Initialize with -root[0] */
-    blst_fr_cneg(&poly[0], &roots[0], true);
+    fr_neg(&poly[0], &roots[0]);
 
     for (size_t i = 1; i < roots_len; i++) {
-        blst_fr_cneg(&neg_root, &roots[i], true);
+        fr_neg(&neg_root, &roots[i]);
 
         poly[i] = neg_root;
-        blst_fr_add(&poly[i], &poly[i], &poly[i - 1]);
+        fr_add(&poly[i], &poly[i], &poly[i - 1]);
 
         for (size_t j = i - 1; j > 0; j--) {
-            blst_fr_mul(&poly[j], &poly[j], &neg_root);
-            blst_fr_add(&poly[j], &poly[j], &poly[j - 1]);
+            fr_mul(&poly[j], &poly[j], &neg_root);
+            fr_add(&poly[j], &poly[j], &poly[j - 1]);
         }
-        blst_fr_mul(&poly[0], &poly[0], &neg_root);
+        fr_mul(&poly[0], &poly[0], &neg_root);
     }
 
     poly[roots_len] = FR_ONE;
@@ -279,7 +279,7 @@ C_KZG_RET recover_cells(
      * P(x) is the polynomial we want to reconstruct (degree FIELD_ELEMENTS_PER_BLOB - 1).
      */
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        blst_fr_mul(&extended_evaluation_times_zero[i], &cells_brp[i], &vanishing_poly_eval[i]);
+        fr_mul(&extended_evaluation_times_zero[i], &cells_brp[i], &vanishing_poly_eval[i]);
     }
 
     /*

--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -110,7 +110,7 @@ static C_KZG_RET expand_root_of_unity(fr_t *out, const fr_t *root, size_t width)
 
     /* Compute powers of root */
     for (i = 2; i <= width; i++) {
-        blst_fr_mul(&out[i], &out[i - 1], root);
+        fr_mul(&out[i], &out[i - 1], root);
         if (fr_is_one(&out[i])) break;
     }
 


### PR DESCRIPTION
This has been a nit of mine for a while. We define some EC helpers such as `fr_div` but we don't have helpers like `fr_mul` and `fr_add`. Inconsistencies like this make reading/writing code here confusing.