### PR TITLE
Use `runTests()` instead of `runAllTests()`

### DIFF
--- a/kzg4844.nimble
+++ b/kzg4844.nimble
@@ -36,7 +36,7 @@ requires "nim >= 1.6.0",
 import "bindings/nim/config.nims"
 
 task test, "Run all tests":
-  runAllTest()
+  runTests()
 
 ##################################################
 # Package installation code


### PR DESCRIPTION
According to Claude, this is the reason the Nim CI checks are failing:

> Diagnosis: The Nim job fails with cannot open file: unittest2 at the test step, but the real error happens earlier, in "Install Packages". Each nimble install run from the repo root now tries to parse the repo's own kzg4844.nimble, and that evaluation dies at line 39: undeclared identifier: 'runAllTest'. Because of that, the dependency installs never complete properly (though the step still exits 0), so unittest2 is missing when the tests compile.