### PR TITLE
Add support for free-threaded Python

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,13 +14,19 @@ defaults:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version:
+          - '3.x'
+          - '3.14t'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,13 +56,18 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        python-version:
+          - '3.x'
+        include:
+          - os: windows-latest
+            python-version: '3.14t'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/bindings/python/ckzg_wrap.c
+++ b/bindings/python/ckzg_wrap.c
@@ -3,6 +3,22 @@
 #include <Python.h>
 #include <stdbool.h>
 
+static inline PyObject *get_list_item(PyObject *list, Py_ssize_t index) {
+#ifdef Py_GIL_DISABLED
+  return PyList_GetItemRef(list, index);
+#else
+  return PyList_GetItem(list, index);
+#endif
+}
+
+static inline void release_list_item(PyObject *item) {
+#ifdef Py_GIL_DISABLED
+  Py_DECREF(item);
+#else
+  (void)item;
+#endif
+}
+
 static void free_KZGSettings(PyObject *c) {
   KZGSettings *s = PyCapsule_GetPointer(c, "KZGSettings");
   free_trusted_setup(s);
@@ -483,8 +499,13 @@ static PyObject *recover_cells_and_kzg_proofs_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < cell_indices_count; i++) {
     /* Ensure each cell index is an integer */
-    PyObject *cell_index = PyList_GetItem(input_cell_indices, i);
+    PyObject *cell_index = get_list_item(input_cell_indices, i);
+    if (cell_index == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyLong_Check(cell_index)) {
+      release_list_item(cell_index);
       ret = PyErr_Format(PyExc_ValueError,
                          "expected cell index to be an integer");
       goto out;
@@ -492,12 +513,14 @@ static PyObject *recover_cells_and_kzg_proofs_wrap(PyObject *self,
     /* Convert the cell index to a cell index type (uint64_t) */
     uint64_t value = PyLong_AsUnsignedLongLong(cell_index);
     if (PyErr_Occurred()) {
+      release_list_item(cell_index);
       ret = PyErr_Format(PyExc_ValueError,
                          "failed to convert cell index to uint64_t");
       goto out;
     }
     /* The cell index is good, add it to our array */
     memcpy(&cell_indices[i], &value, sizeof(uint64_t));
+    release_list_item(cell_index);
   }
 
   /* Allocate space for the cells */
@@ -509,20 +532,27 @@ static PyObject *recover_cells_and_kzg_proofs_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < cells_count; i++) {
     /* Ensure each cell is bytes */
-    PyObject *cell = PyList_GetItem(input_cells, i);
+    PyObject *cell = get_list_item(input_cells, i);
+    if (cell == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyBytes_Check(cell)) {
+      release_list_item(cell);
       ret = PyErr_Format(PyExc_ValueError, "expected cell to be bytes");
       goto out;
     }
     /* Ensure each cell is the right size */
     Py_ssize_t cell_size = PyBytes_Size(cell);
     if (cell_size != BYTES_PER_CELL) {
+      release_list_item(cell);
       ret = PyErr_Format(PyExc_ValueError,
                          "expected cell to be BYTES_PER_CELL bytes");
       goto out;
     }
     /* The cell is good, copy it to our array */
     memcpy(&cells[i], PyBytes_AsString(cell), BYTES_PER_CELL);
+    release_list_item(cell);
   }
 
   /* Allocate space for the recovered cells/proofs */
@@ -659,14 +689,20 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < commitments_count; i++) {
     /* Ensure each commitment is bytes */
-    PyObject *commitment = PyList_GetItem(input_commitments, i);
+    PyObject *commitment = get_list_item(input_commitments, i);
+    if (commitment == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyBytes_Check(commitment)) {
+      release_list_item(commitment);
       ret = PyErr_Format(PyExc_ValueError, "expected commitment to be bytes");
       goto out;
     }
     /* Ensure each commitment is the right size */
     Py_ssize_t commitment_size = PyBytes_Size(commitment);
     if (commitment_size != BYTES_PER_COMMITMENT) {
+      release_list_item(commitment);
       ret =
           PyErr_Format(PyExc_ValueError,
                        "expected commitment to be BYTES_PER_COMMITMENT bytes");
@@ -674,6 +710,7 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
     }
     /* The commitment is good, copy it to our array */
     memcpy(&commitments[i], PyBytes_AsString(commitment), BYTES_PER_COMMITMENT);
+    release_list_item(commitment);
   }
 
   /* Allocate space for the column indices */
@@ -685,8 +722,13 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < cell_indices_count; i++) {
     /* Ensure each column index is an integer */
-    PyObject *cell_index = PyList_GetItem(input_cell_indices, i);
+    PyObject *cell_index = get_list_item(input_cell_indices, i);
+    if (cell_index == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyLong_Check(cell_index)) {
+      release_list_item(cell_index);
       ret = PyErr_Format(PyExc_ValueError,
                          "expected column index to be an integer");
       goto out;
@@ -694,12 +736,14 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
     /* Convert the column index to a uint64_t */
     uint64_t value = PyLong_AsUnsignedLongLong(cell_index);
     if (PyErr_Occurred()) {
+      release_list_item(cell_index);
       ret = PyErr_Format(PyExc_ValueError,
                          "failed to convert column index to uint64_t");
       goto out;
     }
     /* The column is good, add it to our array */
     memcpy(&cell_indices[i], &value, sizeof(uint64_t));
+    release_list_item(cell_index);
   }
 
   /* Allocate space for the cells */
@@ -711,20 +755,27 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < cells_count; i++) {
     /* Ensure each cell is bytes */
-    PyObject *cell = PyList_GetItem(input_cells, i);
+    PyObject *cell = get_list_item(input_cells, i);
+    if (cell == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyBytes_Check(cell)) {
+      release_list_item(cell);
       ret = PyErr_Format(PyExc_ValueError, "expected cell to be bytes");
       goto out;
     }
     /* Ensure each cell is the right size */
     Py_ssize_t cell_size = PyBytes_Size(cell);
     if (cell_size != BYTES_PER_CELL) {
+      release_list_item(cell);
       ret = PyErr_Format(PyExc_ValueError,
                          "expected cell to be BYTES_PER_CELL bytes");
       goto out;
     }
     /* The cell is good, copy it to our array */
     memcpy(&cells[i], PyBytes_AsString(cell), BYTES_PER_CELL);
+    release_list_item(cell);
   }
 
   /* Allocate space for the proofs */
@@ -736,20 +787,27 @@ static PyObject *verify_cell_kzg_proof_batch_wrap(PyObject *self,
   }
   for (Py_ssize_t i = 0; i < proofs_count; i++) {
     /* Ensure each proof is bytes */
-    PyObject *proof = PyList_GetItem(input_proofs, i);
+    PyObject *proof = get_list_item(input_proofs, i);
+    if (proof == NULL) {
+      ret = NULL;
+      goto out;
+    }
     if (!PyBytes_Check(proof)) {
+      release_list_item(proof);
       ret = PyErr_Format(PyExc_ValueError, "expected proof to be bytes");
       goto out;
     }
     /* Ensure each proof is the right size */
     Py_ssize_t proof_size = PyBytes_Size(proof);
     if (proof_size != BYTES_PER_PROOF) {
+      release_list_item(proof);
       ret = PyErr_Format(PyExc_ValueError,
                          "expected proof to be BYTES_PER_PROOF bytes");
       goto out;
     }
     /* The proof is good, copy it to our array */
     memcpy(&proofs[i], PyBytes_AsString(proof), BYTES_PER_PROOF);
+    release_list_item(proof);
   }
 
   /* Call our C function with our inputs */
@@ -806,4 +864,14 @@ static PyMethodDef ckzgmethods[] = {
 static struct PyModuleDef ckzg = {PyModuleDef_HEAD_INIT, "ckzg", NULL, -1,
                                   ckzgmethods};
 
-PyMODINIT_FUNC PyInit_ckzg(void) { return PyModule_Create(&ckzg); }
+PyMODINIT_FUNC PyInit_ckzg(void) {
+  PyObject *module = PyModule_Create(&ckzg);
+  if (module == NULL)
+    return NULL;
+
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+  return module;
+}

--- a/bindings/python/tests.py
+++ b/bindings/python/tests.py
@@ -1,7 +1,17 @@
+from concurrent.futures import ThreadPoolExecutor
 import glob
-import yaml
+import os
+import sys
+import sysconfig
+from threading import Barrier
 
 import ckzg
+import yaml
+
+
+GIL_ENABLED_AFTER_CKZG_IMPORT = (
+    sys._is_gil_enabled() if sysconfig.get_config_var("Py_GIL_DISABLED") else None
+)
 
 ###############################################################################
 # Constants
@@ -28,6 +38,12 @@ VERIFY_CELL_KZG_PROOF_BATCH_TESTS = "../../tests/verify_cell_kzg_proof_batch/*/*
 
 def bytes_from_hex(hexstring):
     return bytes.fromhex(hexstring.replace("0x", ""))
+
+
+def blob_to_kzg_commitment_concurrently(args):
+    barrier, blob, ts = args
+    barrier.wait()
+    return ckzg.blob_to_kzg_commitment(blob, ts)
 
 
 ###############################################################################
@@ -253,12 +269,42 @@ def test_verify_cell_kzg_proof_batch(ts):
         assert valid == expected_valid, f"{test_file}\n{valid=}\n{expected_valid=}"
 
 
+def test_free_threaded_module_support():
+    if sysconfig.get_config_var("Py_GIL_DISABLED"):
+        assert not GIL_ENABLED_AFTER_CKZG_IMPORT
+
+
+def test_thread_safety(ts):
+    for test_file in glob.glob(BLOB_TO_KZG_COMMITMENT_TESTS):
+        with open(test_file, "r") as f:
+            test = yaml.safe_load(f)
+        if test["output"] is not None:
+            break
+    else:
+        raise AssertionError("no valid blob-to-KZG-commitment test case found")
+
+    blob = bytes_from_hex(test["input"]["blob"])
+    expected_commitment = bytes_from_hex(test["output"])
+    workers = min(32, max(2, (os.cpu_count() or 1) * 2))
+    barrier = Barrier(workers)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        commitments = executor.map(
+            blob_to_kzg_commitment_concurrently,
+            [(barrier, blob, ts)] * workers,
+        )
+
+    assert all(commitment == expected_commitment for commitment in commitments)
+
+
 ###############################################################################
 # Main Logic
 ###############################################################################
 
 if __name__ == "__main__":
     ts = ckzg.load_trusted_setup("../../src/trusted_setup.txt", 0)
+
+    test_free_threaded_module_support()
 
     test_blob_to_kzg_commitment(ts)
     test_compute_kzg_proof(ts)
@@ -271,5 +317,6 @@ if __name__ == "__main__":
     test_compute_cells_and_kzg_proofs(ts)
     test_recover_cells_and_kzg_proofs(ts)
     test_verify_cell_kzg_proof_batch(ts)
+    test_thread_safety(ts)
 
     print("tests passed")

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from shutil import which
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from subprocess import check_call
+from sysconfig import get_config_var
 
 
 def get_make():
@@ -50,7 +51,11 @@ def main():
                 sources=["bindings/python/ckzg_wrap.c", "src/ckzg.c"],
                 include_dirs=["inc", "src"],
                 library_dirs=["lib"],
-                libraries=["blst"]
+                libraries=["blst"],
+                define_macros=(
+                    [("Py_GIL_DISABLED", "1")]
+                    if get_config_var("Py_GIL_DISABLED") else []
+                ),
             )
         ],
         cmdclass={


### PR DESCRIPTION
Mark the extension as safe to run without the GIL and use strong references when reading mutable list inputs in free-threaded builds, while preserving borrowed-reference performance in regular builds.

Propagate Py_GIL_DISABLED through setuptools for Windows builds and exercise Python 3.14t in CI, including the Windows sdist path. Add checks that importing ckzg keeps the GIL disabled and that shared KZG settings can be used concurrently.