### PR TITLE
Remove redundant -c flag from static analysis

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -246,7 +246,7 @@ analyze: blst $(SOURCE_FILES)
 	@rm -rf analysis-report
 	@for src in $(SOURCE_FILES); do \
 		echo "[+] analyzing $$src..."; \
-		$(CC) --analyze -Xanalyzer -analyzer-output=html -o analysis-report $(CFLAGS) -c $$src; \
+		$(CC) --analyze -Xanalyzer -analyzer-output=html -o analysis-report $(CFLAGS) $$src; \
 		[ -d analysis-report ] && exit 1; true; \
 	done
 


### PR DESCRIPTION
The `make analyze` target currently passes `-c` to Clang together with
`--analyze`. The compile-only flag is ignored in static analysis mode, causing
the following warning to be printed for every source file:

```text
clang: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
```

Remove the redundant flag to keep the static analysis output clean. This does not change which files are analyzed or how analyzer reports are generated.


Testing:

- make -C src analyze
- make -C src test (93 tests passed)