### PR TITLE
Migrate to NuGet trusted publishing

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -103,6 +103,9 @@ jobs:
     name: Build .NET wrapper
     runs-on: ubuntu-latest
     needs: test-ckzg-dotnet
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -129,6 +132,12 @@ jobs:
       with:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
+    - name: NuGet login
+      uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Publish package
       if: github.ref == 'refs/heads/main'
-      run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg -k ${{ secrets.CSHARP_NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push bindings/csharp/nupkgs/*.nupkg \
+        -k "${{ steps.login.outputs.NUGET_API_KEY }}" -s https://www.nuget.org/api/v2/package

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -133,6 +133,7 @@ jobs:
         name: Ckzg.Bindings-${{ inputs.version || env.binding_build_number_based_version }}
         path: bindings/csharp/nupkgs/Ckzg.Bindings.*.nupkg
     - name: NuGet login
+      if: github.ref == 'refs/heads/main'
       uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: login
       with:


### PR DESCRIPTION
Because of the upcoming changes to NuGet API key lifetime starting Aug 17, migrated the C# NuGet package to trusted publishing. For the details, see [here](https://devblogs.microsoft.com/dotnet/strengthening-nuget-supply-chain-security-reducing-api-key-lifetime/).

This requires a new repository secret `NUGET_USER`. I'll share the details privately with @jtraglia 