### PR TITLE
perf(eip7594): recover cells ~4.7x faster

### DIFF
--- a/src/common/fr.c
+++ b/src/common/fr.c
@@ -17,6 +17,7 @@
 #include "common/fr.h"
 #include "common/bytes.h"
 
+#include <assert.h>   /* For assert */
 #include <inttypes.h> /* For uint*_t */
 #include <stdbool.h>  /* For bool */
 
@@ -48,6 +49,20 @@ bool fr_is_one(const fr_t *p) {
     uint64_t a[4];
     blst_uint64_from_fr(a, p);
     return a[0] == 1 && a[1] == 0 && a[2] == 0 && a[3] == 0;
+}
+
+/**
+ * Test whether the operand is zero.
+ *
+ * @param[in]   p   The field element to be checked
+ *
+ * @retval  true    The element is zero.
+ * @retval  false   The element is not zero.
+ */
+bool fr_is_zero(const fr_t *p) {
+    uint64_t a[4];
+    blst_uint64_from_fr(a, p);
+    return a[0] == 0 && a[1] == 0 && a[2] == 0 && a[3] == 0;
 }
 
 /**
@@ -119,6 +134,46 @@ void fr_div(fr_t *out, const fr_t *a, const fr_t *b) {
     fr_t tmp;
     fr_inv(&tmp, b);
     fr_mul(out, a, &tmp);
+}
+
+/**
+ * Montgomery batch inversion in finite field.
+ *
+ * @param[out]  out The inverses of `a`, length `len`
+ * @param[in]   a   A vector of field elements, length `len`
+ * @param[in]   len The number of field elements
+ *
+ * @remark This function only supports len > 0.
+ * @remark This function does NOT support in-place computation.
+ * @remark Return C_KZG_BADARGS if a zero is found in the input. In this case,
+ *         the `out` output array has already been mutated.
+ * @remark Costs one inversion and three multiplications per element, rather than
+ *         one inversion per element.
+ */
+C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, size_t len) {
+    assert(len > 0);
+    assert(a != out);
+
+    fr_t accumulator = FR_ONE;
+
+    for (size_t i = 0; i < len; i++) {
+        out[i] = accumulator;
+        fr_mul(&accumulator, &accumulator, &a[i]);
+    }
+
+    /* Bail on any zero input */
+    if (fr_is_zero(&accumulator)) {
+        return C_KZG_BADARGS;
+    }
+
+    fr_inv(&accumulator, &accumulator);
+
+    for (size_t i = len; i > 0; i--) {
+        fr_mul(&out[i - 1], &out[i - 1], &accumulator);
+        fr_mul(&accumulator, &accumulator, &a[i - 1]);
+    }
+
+    return C_KZG_OK;
 }
 
 /**

--- a/src/common/fr.c
+++ b/src/common/fr.c
@@ -147,8 +147,8 @@ void fr_div(fr_t *out, const fr_t *a, const fr_t *b) {
  * @remark This function does NOT support in-place computation.
  * @remark Return C_KZG_BADARGS if a zero is found in the input. In this case,
  *         the `out` output array has already been mutated.
- * @remark Costs one inversion and three multiplications per element, rather than
- *         one inversion per element.
+ * @remark Costs one inversion in total plus three multiplications per element,
+ *         rather than one inversion per element.
  */
 C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, size_t len) {
     assert(len > 0);

--- a/src/common/fr.h
+++ b/src/common/fr.h
@@ -16,9 +16,12 @@
 
 #pragma once
 
+#include "common/ret.h"
+
 #include "blst.h"
 
 #include <stdbool.h> /* For bool */
+#include <stddef.h>  /* For size_t */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Types
@@ -58,12 +61,14 @@ extern "C" {
 
 bool fr_equal(const fr_t *a, const fr_t *b);
 bool fr_is_one(const fr_t *p);
+bool fr_is_zero(const fr_t *p);
 void fr_add(fr_t *out, const fr_t *a, const fr_t *b);
 void fr_sub(fr_t *out, const fr_t *a, const fr_t *b);
 void fr_mul(fr_t *out, const fr_t *a, const fr_t *b);
 void fr_neg(fr_t *out, const fr_t *a);
 void fr_inv(fr_t *out, const fr_t *a);
 void fr_div(fr_t *out, const fr_t *a, const fr_t *b);
+C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, size_t len);
 void fr_pow(fr_t *out, const fr_t *a, uint64_t n);
 void fr_from_uint64(fr_t *out, uint64_t n);
 void print_fr(const fr_t *f);

--- a/src/eip4844/eip4844.c
+++ b/src/eip4844/eip4844.c
@@ -52,60 +52,6 @@ static const char *RANDOM_CHALLENGE_DOMAIN_VERIFY_BLOB_KZG_PROOF_BATCH = "RCKZGB
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Test whether the operand is zero in the finite field.
- *
- * @param[in]   fr  The field element to be checked
- *
- * @retval  true    The element is zero
- * @retval  false   The element is not zero
- */
-static bool fr_is_zero(const fr_t *fr) {
-    uint64_t a[4];
-    blst_uint64_from_fr(a, fr);
-    return a[0] == 0 && a[1] == 0 && a[2] == 0 && a[3] == 0;
-}
-
-/**
- * Montgomery batch inversion in finite field.
- *
- * @param[out]  out The inverses of `a`, length `len`
- * @param[in]   a   A vector of field elements, length `len`
- * @param[in]   len The number of field elements
- *
- * @remark This function only supports len > 0.
- * @remark This function does NOT support in-place computation.
- * @remark Return C_KZG_BADARGS if a zero is found in the input. In this case,
- *         the `out` output array has already been mutated.
- */
-static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
-    int i;
-
-    assert(len > 0);
-    assert(a != out);
-
-    fr_t accumulator = FR_ONE;
-
-    for (i = 0; i < len; i++) {
-        out[i] = accumulator;
-        fr_mul(&accumulator, &accumulator, &a[i]);
-    }
-
-    /* Bail on any zero input */
-    if (fr_is_zero(&accumulator)) {
-        return C_KZG_BADARGS;
-    }
-
-    fr_inv(&accumulator, &accumulator);
-
-    for (i = len - 1; i >= 0; i--) {
-        fr_mul(&out[i], &out[i], &accumulator);
-        fr_mul(&accumulator, &accumulator, &a[i]);
-    }
-
-    return C_KZG_OK;
-}
-
-/**
  * Multiply a G2 group element by a field element.
  *
  * @param[out]  out The result, `a * b`

--- a/src/eip7594/fft.c
+++ b/src/eip7594/fft.c
@@ -34,7 +34,7 @@
  *   for (size_t i = 0; i < 4; i++)
  *       printf("%#018llxL,\n", a.l[i]);
  */
-static const fr_t RECOVERY_SHIFT_FACTOR = {
+const fr_t RECOVERY_SHIFT_FACTOR = {
     {0x0000000efffffff1L, 0x17e363d300189c0fL, 0xff9c57876f8457b0L, 0x351332208fc5a8c4L}
 };
 
@@ -47,7 +47,7 @@ static const fr_t RECOVERY_SHIFT_FACTOR = {
  *   for (size_t i = 0; i < 4; i++)
  *       printf("%#018llxL,\n", a.l[i]);
  */
-static const fr_t INV_RECOVERY_SHIFT_FACTOR = {
+const fr_t INV_RECOVERY_SHIFT_FACTOR = {
     {0xdb6db6dadb6db6dcL, 0xe6b5824adb6cc6daL, 0xf8b356e005810db9L, 0x66d0f1e660ec4796L}
 };
 

--- a/src/eip7594/fft.h
+++ b/src/eip7594/fft.h
@@ -29,6 +29,16 @@
 extern "C" {
 #endif
 
+/**
+ * The coset shift factor used by the cell recovery code, and its inverse.
+ *
+ * Exposed so that callers computing on the same coset -- for instance evaluating a factor
+ * of the vanishing polynomial on a smaller subgroup of it -- derive their shift from this
+ * one constant rather than restating it.
+ */
+extern const fr_t RECOVERY_SHIFT_FACTOR;
+extern const fr_t INV_RECOVERY_SHIFT_FACTOR;
+
 C_KZG_RET fr_fft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s);
 C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s);
 

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -20,6 +20,7 @@
 #include "common/utils.h"
 #include "eip7594/cell.h"
 #include "eip7594/fft.h"
+#include "eip7594/poly.h"
 
 #include <assert.h> /* For assert */
 #include <stdlib.h> /* For NULL */
@@ -75,31 +76,35 @@ static C_KZG_RET compute_vanishing_polynomial_from_roots(
 }
 
 /**
- * Computes the minimal polynomial that evaluates to zero at equally spaced chosen roots of unity in
- * the domain of size `FIELD_ELEMENTS_PER_BLOB`.
+ * Computes the short factor of the vanishing polynomial for the missing cells.
  *
- * The roots of unity are chosen based on the missing cell indices. If the i'th cell is missing,
- * then the i'th root of unity from `roots_of_unity` will be zero on the polynomial
- * computed, along with every `CELLS_PER_EXT_BLOB` spaced root of unity in the domain.
+ * The polynomial that vanishes on the missing evaluations is
  *
- * @param[in,out]   vanishing_poly          The output vanishing polynomial
- * @param[in]       missing_cell_indices    The array of missing cell indices
- * @param[in]       len_missing_cells       The number of missing cell indices
- * @param[in]       s                       The trusted setup
+ *   Z(x) = Zhat(x^FIELD_ELEMENTS_PER_CELL)
+ *
+ * where Zhat vanishes on the roots of unity of order CELLS_PER_EXT_BLOB corresponding to the
+ * missing cell indices. This returns Zhat, which has degree `len_missing_cells` -- at most 64 --
+ * rather than Z, which is spread over FIELD_ELEMENTS_PER_EXT_BLOB coefficients of which all but
+ * `len_missing_cells + 1` are zero.
+ *
+ * @param[out]  short_vanishing_poly        Zhat, length `len_missing_cells + 1`
+ * @param[out]  short_vanishing_poly_len    The length of Zhat
+ * @param[in]   missing_cell_indices        The array of missing cell indices
+ * @param[in]   len_missing_cells           The number of missing cell indices
+ * @param[in]   s                           The trusted setup
  *
  * @remark If no cells are missing, recovery is trivial; we expect the caller to handle this.
  * @remark If all cells are missing, we return C_KZG_BADARGS; the algorithm has an edge case.
  */
-static C_KZG_RET vanishing_polynomial_for_missing_cells(
-    fr_t *vanishing_poly,
+static C_KZG_RET short_vanishing_polynomial_for_missing_cells(
+    fr_t *short_vanishing_poly,
+    size_t *short_vanishing_poly_len,
     const uint64_t *missing_cell_indices,
     size_t len_missing_cells,
     const KZGSettings *s
 ) {
     C_KZG_RET ret;
     fr_t *roots = NULL;
-    fr_t *short_vanishing_poly = NULL;
-    size_t short_vanishing_poly_len = 0;
 
     /* Return early if none or all of the cells are missing */
     if (len_missing_cells == 0 || len_missing_cells >= CELLS_PER_EXT_BLOB) {
@@ -107,10 +112,7 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
         goto out;
     }
 
-    /* Allocate arrays */
     ret = new_fr_array(&roots, len_missing_cells);
-    if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&short_vanishing_poly, (len_missing_cells + 1));
     if (ret != C_KZG_OK) goto out;
 
     /*
@@ -125,39 +127,13 @@ static C_KZG_RET vanishing_polynomial_for_missing_cells(
         roots[i] = s->roots_of_unity[missing_cell_indices[i] * stride];
     }
 
-    /* Compute the polynomial that evaluates to zero on the roots */
     ret = compute_vanishing_polynomial_from_roots(
-        short_vanishing_poly, &short_vanishing_poly_len, roots, len_missing_cells
+        short_vanishing_poly, short_vanishing_poly_len, roots, len_missing_cells
     );
     if (ret != C_KZG_OK) goto out;
 
-    /* Zero out all the coefficients of the output poly */
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        vanishing_poly[i] = FR_ZERO;
-    }
-
-    /*
-     * For each root \omega^i in `short_vanishing_poly`, we compute a polynomial that has roots at
-     *
-     *  H = {
-     *      \omega^i * \gamma^0,
-     *      \omega^i * \gamma^1,
-     *      ...,
-     *      \omega^i * \gamma^{FIELD_ELEMENTS_PER_CELL-1}
-     *  }
-     *
-     * where \gamma is a primitive `FIELD_ELEMENTS_PER_EXT_BLOB`-th root of unity.
-     *
-     * This is done by shifting the degree of all coefficients in `short_vanishing_poly` up by
-     * `FIELD_ELEMENTS_PER_CELL` amount.
-     */
-    for (size_t i = 0; i < short_vanishing_poly_len; i++) {
-        vanishing_poly[i * FIELD_ELEMENTS_PER_CELL] = short_vanishing_poly[i];
-    }
-
 out:
     c_kzg_free(roots);
-    c_kzg_free(short_vanishing_poly);
     return ret;
 }
 
@@ -206,40 +182,55 @@ C_KZG_RET recover_cells(
 ) {
     C_KZG_RET ret;
     uint64_t *missing_cell_indices = NULL;
-    fr_t *vanishing_poly_eval = NULL;
-    fr_t *vanishing_poly_coeff = NULL;
+    fr_t *short_vanishing_poly = NULL;
+    fr_t *short_vanishing_poly_eval = NULL;
+    fr_t *vanishing_poly_over_coset = NULL;
+    fr_t *inv_vanishing_poly_over_coset = NULL;
     fr_t *extended_evaluation_times_zero = NULL;
     fr_t *extended_evaluation_times_zero_coeffs = NULL;
-    fr_t *extended_evaluations_over_coset = NULL;
-    fr_t *vanishing_poly_over_coset = NULL;
     fr_t *reconstructed_poly_coeff = NULL;
-    fr_t *cells_brp = NULL;
+
+    /*
+     * Sizes of the reduced problem.
+     *
+     * Z(x) = Zhat(x^FIELD_ELEMENTS_PER_CELL), so its evaluations over the FFT domain repeat with
+     * period CELLS_PER_EXT_BLOB: Z(w^j) = Zhat(v^(j mod CELLS_PER_EXT_BLOB)) where v = w^64 has
+     * order CELLS_PER_EXT_BLOB. The full-domain transform of Z is therefore a transform of size
+     * CELLS_PER_EXT_BLOB, tiled.
+     *
+     * The recovered polynomial has degree below FIELD_ELEMENTS_PER_BLOB, so the coset round trip
+     * that performs the division needs only that many points. Over the smaller coset the period
+     * of Z halves again, to CELLS_PER_BLOB.
+     */
+    const size_t half = FIELD_ELEMENTS_PER_EXT_BLOB / 2;
+    const size_t z_period = CELLS_PER_EXT_BLOB;
+    const size_t z_period_over_coset = CELLS_PER_BLOB;
 
     /* Allocate space for arrays */
     ret = c_kzg_calloc(
         (void **)&missing_cell_indices, FIELD_ELEMENTS_PER_EXT_BLOB, sizeof(uint64_t)
     );
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_eval, FIELD_ELEMENTS_PER_EXT_BLOB);
+    ret = new_fr_array(&short_vanishing_poly, z_period);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_coeff, FIELD_ELEMENTS_PER_EXT_BLOB);
+    ret = new_fr_array(&short_vanishing_poly_eval, z_period);
+    if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&vanishing_poly_over_coset, z_period_over_coset);
+    if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&inv_vanishing_poly_over_coset, z_period_over_coset);
     if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&extended_evaluation_times_zero, FIELD_ELEMENTS_PER_EXT_BLOB);
     if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&extended_evaluation_times_zero_coeffs, FIELD_ELEMENTS_PER_EXT_BLOB);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&extended_evaluations_over_coset, FIELD_ELEMENTS_PER_EXT_BLOB);
-    if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&vanishing_poly_over_coset, FIELD_ELEMENTS_PER_EXT_BLOB);
-    if (ret != C_KZG_OK) goto out;
     ret = new_fr_array(&reconstructed_poly_coeff, FIELD_ELEMENTS_PER_EXT_BLOB);
-    if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&cells_brp, FIELD_ELEMENTS_PER_EXT_BLOB);
     if (ret != C_KZG_OK) goto out;
 
     /* Bit-reverse the data points, stored in new array */
-    memcpy(cells_brp, cells, FIELD_ELEMENTS_PER_EXT_BLOB * sizeof(fr_t));
-    ret = bit_reversal_permutation(cells_brp, sizeof(fr_t), FIELD_ELEMENTS_PER_EXT_BLOB);
+    memcpy(extended_evaluation_times_zero, cells, FIELD_ELEMENTS_PER_EXT_BLOB * sizeof(fr_t));
+    ret = bit_reversal_permutation(
+        extended_evaluation_times_zero, sizeof(fr_t), FIELD_ELEMENTS_PER_EXT_BLOB
+    );
     if (ret != C_KZG_OK) goto out;
 
     /* Identify missing cells */
@@ -260,16 +251,24 @@ C_KZG_RET recover_cells(
     assert(CELLS_PER_EXT_BLOB - len_missing >= CELLS_PER_BLOB);
 
     /*
-     * Compute Z(x) in monomial form.
-     * Z(x) is the polynomial which vanishes on all of the evaluations which are missing.
+     * Compute Zhat(x) in monomial form, the short factor of the polynomial which vanishes on all
+     * of the evaluations which are missing. Its degree is len_missing, so it fits in z_period
+     * coefficients with the remainder zero.
      */
-    ret = vanishing_polynomial_for_missing_cells(
-        vanishing_poly_coeff, missing_cell_indices, len_missing, s
+    for (size_t i = 0; i < z_period; i++) {
+        short_vanishing_poly[i] = FR_ZERO;
+    }
+    size_t short_vanishing_poly_len = 0;
+    ret = short_vanishing_polynomial_for_missing_cells(
+        short_vanishing_poly, &short_vanishing_poly_len, missing_cell_indices, len_missing, s
     );
     if (ret != C_KZG_OK) goto out;
 
-    /* Convert Z(x) to evaluation form */
-    ret = fr_fft(vanishing_poly_eval, vanishing_poly_coeff, FIELD_ELEMENTS_PER_EXT_BLOB, s);
+    /*
+     * Convert Zhat(x) to evaluation form over the subgroup of order z_period. These are all the
+     * distinct values Z takes over the full FFT domain.
+     */
+    ret = fr_fft(short_vanishing_poly_eval, short_vanishing_poly, z_period, s);
     if (ret != C_KZG_OK) goto out;
 
     /*
@@ -279,7 +278,11 @@ C_KZG_RET recover_cells(
      * P(x) is the polynomial we want to reconstruct (degree FIELD_ELEMENTS_PER_BLOB - 1).
      */
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        fr_mul(&extended_evaluation_times_zero[i], &cells_brp[i], &vanishing_poly_eval[i]);
+        fr_mul(
+            &extended_evaluation_times_zero[i],
+            &extended_evaluation_times_zero[i],
+            &short_vanishing_poly_eval[i % z_period]
+        );
     }
 
     /*
@@ -302,53 +305,79 @@ C_KZG_RET recover_cells(
      * Next step is to divide the polynomial (P*Z)(x) by polynomial Z(x) to get P(x).
      * We do this in evaluation form over a coset of the FFT domain to avoid division by 0.
      *
-     * Convert (P*Z)(x) to evaluation form over a coset of the FFT domain.
+     * P(x) has degree below `half`, so the round trip only needs `half` points, over the coset
+     * {h * u^j} where u has order `half`. Every point of that coset satisfies x^half = h^half, so
+     * (P*Z)(x) reduces exactly to `half` coefficients first. This is a fold, not a truncation.
      */
-    ret = coset_fft(
-        extended_evaluations_over_coset,
-        extended_evaluation_times_zero_coeffs,
-        FIELD_ELEMENTS_PER_EXT_BLOB,
-        s
-    );
-    if (ret != C_KZG_OK) goto out;
-
-    /* Convert Z(x) to evaluation form over a coset of the FFT domain */
-    ret = coset_fft(
-        vanishing_poly_over_coset, vanishing_poly_coeff, FIELD_ELEMENTS_PER_EXT_BLOB, s
-    );
-    if (ret != C_KZG_OK) goto out;
-
-    /*
-     * Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over a coset of the FFT domain.
-     *
-     * The divisors are inverted as a batch rather than one at a time: Montgomery's trick
-     * costs one inversion plus three multiplications per element, where fr_div costs a
-     * full inversion each. Z has no zeros on the coset -- which is the reason the division
-     * is done there -- so the batch cannot fail, but the return value is still checked.
-     */
-    fr_t *inv_vanishing_poly_over_coset = vanishing_poly_eval; /* Dead from here on; reused */
-    ret = fr_batch_inv(
-        inv_vanishing_poly_over_coset, vanishing_poly_over_coset, FIELD_ELEMENTS_PER_EXT_BLOB
-    );
-    if (ret != C_KZG_OK) goto out;
-    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        fr_mul(
-            &extended_evaluations_over_coset[i],
-            &extended_evaluations_over_coset[i],
-            &inv_vanishing_poly_over_coset[i]
+    fr_t shift_pow_half;
+    fr_pow(&shift_pow_half, &RECOVERY_SHIFT_FACTOR, half);
+    for (size_t i = 0; i < half; i++) {
+        fr_t tmp;
+        fr_mul(&tmp, &extended_evaluation_times_zero_coeffs[i + half], &shift_pow_half);
+        fr_add(
+            &extended_evaluation_times_zero_coeffs[i],
+            &extended_evaluation_times_zero_coeffs[i],
+            &tmp
         );
     }
 
-    /*
-     * Note: After the above polynomial division, extended_evaluations_over_coset is the same
-     * polynomial as reconstructed_poly_over_coset in the spec.
-     */
+    /* Convert (P*Z)(x) to evaluation form over the coset */
+    ret = coset_fft(extended_evaluation_times_zero, extended_evaluation_times_zero_coeffs, half, s);
+    if (ret != C_KZG_OK) goto out;
 
-    /* Convert P(x) to coefficient form */
-    ret = coset_ifft(
-        reconstructed_poly_coeff, extended_evaluations_over_coset, FIELD_ELEMENTS_PER_EXT_BLOB, s
+    /*
+     * Convert Z(x) to evaluation form over the same coset.
+     *
+     * For x = h * u^j the argument of Zhat is x^FIELD_ELEMENTS_PER_CELL = c * m^j, where
+     * c = h^FIELD_ELEMENTS_PER_CELL and m has order z_period_over_coset. So this is Zhat over a
+     * coset of the order-z_period_over_coset subgroup, with shift c -- and, as above, every point
+     * of it satisfies y^z_period_over_coset = c^z_period_over_coset, so Zhat folds down first.
+     * Note c^z_period_over_coset = h^half, the constant already computed.
+     */
+    fr_t cell_shift;
+    fr_pow(&cell_shift, &RECOVERY_SHIFT_FACTOR, FIELD_ELEMENTS_PER_CELL);
+    for (size_t i = z_period_over_coset; i < short_vanishing_poly_len; i++) {
+        fr_t tmp;
+        fr_mul(&tmp, &short_vanishing_poly[i], &shift_pow_half);
+        fr_add(
+            &short_vanishing_poly[i - z_period_over_coset],
+            &short_vanishing_poly[i - z_period_over_coset],
+            &tmp
+        );
+        short_vanishing_poly[i] = FR_ZERO;
+    }
+    shift_poly(short_vanishing_poly, z_period_over_coset, &cell_shift);
+    ret = fr_fft(vanishing_poly_over_coset, short_vanishing_poly, z_period_over_coset, s);
+    if (ret != C_KZG_OK) goto out;
+
+    /*
+     * Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over the coset.
+     *
+     * The divisors are inverted as a batch rather than one at a time: Montgomery's trick costs one
+     * inversion and three multiplications per element, where fr_div costs a full inversion each.
+     * Only z_period_over_coset of them are distinct. Z has no zeros on the coset -- which is the
+     * reason the division is done there -- so the batch cannot fail, but it is still checked.
+     */
+    ret = fr_batch_inv(
+        inv_vanishing_poly_over_coset, vanishing_poly_over_coset, z_period_over_coset
     );
     if (ret != C_KZG_OK) goto out;
+    for (size_t i = 0; i < half; i++) {
+        fr_mul(
+            &extended_evaluation_times_zero[i],
+            &extended_evaluation_times_zero[i],
+            &inv_vanishing_poly_over_coset[i % z_period_over_coset]
+        );
+    }
+
+    /* Convert P(x) to coefficient form */
+    ret = coset_ifft(reconstructed_poly_coeff, extended_evaluation_times_zero, half, s);
+    if (ret != C_KZG_OK) goto out;
+
+    /* P(x) has degree below `half`; the rest of the domain is zero */
+    for (size_t i = half; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+        reconstructed_poly_coeff[i] = FR_ZERO;
+    }
 
     /*
      * After unscaling the reconstructed polynomial, we have P(x) which evaluates to our original
@@ -365,13 +394,12 @@ C_KZG_RET recover_cells(
 
 out:
     c_kzg_free(missing_cell_indices);
-    c_kzg_free(vanishing_poly_eval);
+    c_kzg_free(short_vanishing_poly);
+    c_kzg_free(short_vanishing_poly_eval);
+    c_kzg_free(vanishing_poly_over_coset);
+    c_kzg_free(inv_vanishing_poly_over_coset);
     c_kzg_free(extended_evaluation_times_zero);
     c_kzg_free(extended_evaluation_times_zero_coeffs);
-    c_kzg_free(extended_evaluations_over_coset);
-    c_kzg_free(vanishing_poly_over_coset);
     c_kzg_free(reconstructed_poly_coeff);
-    c_kzg_free(vanishing_poly_coeff);
-    c_kzg_free(cells_brp);
     return ret;
 }

--- a/src/eip7594/recovery.c
+++ b/src/eip7594/recovery.c
@@ -318,12 +318,24 @@ C_KZG_RET recover_cells(
     );
     if (ret != C_KZG_OK) goto out;
 
-    /* Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over a coset of the FFT domain */
+    /*
+     * Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over a coset of the FFT domain.
+     *
+     * The divisors are inverted as a batch rather than one at a time: Montgomery's trick
+     * costs one inversion plus three multiplications per element, where fr_div costs a
+     * full inversion each. Z has no zeros on the coset -- which is the reason the division
+     * is done there -- so the batch cannot fail, but the return value is still checked.
+     */
+    fr_t *inv_vanishing_poly_over_coset = vanishing_poly_eval; /* Dead from here on; reused */
+    ret = fr_batch_inv(
+        inv_vanishing_poly_over_coset, vanishing_poly_over_coset, FIELD_ELEMENTS_PER_EXT_BLOB
+    );
+    if (ret != C_KZG_OK) goto out;
     for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        fr_div(
+        fr_mul(
             &extended_evaluations_over_coset[i],
             &extended_evaluations_over_coset[i],
-            &vanishing_poly_over_coset[i]
+            &inv_vanishing_poly_over_coset[i]
         );
     }
 

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -1934,6 +1934,66 @@ static void test_recover_cells_and_kzg_proofs__succeeds_random_blob(void) {
     }
 }
 
+static void test_recover_cells__succeeds_every_erasure_count(void) {
+    C_KZG_RET ret;
+    Blob blob;
+    Cell cells[CELLS_PER_EXT_BLOB];
+    Cell recovered_cells[CELLS_PER_EXT_BLOB];
+    uint64_t cell_indices[CELLS_PER_EXT_BLOB];
+    Cell partial_cells[CELLS_PER_EXT_BLOB];
+    bool is_missing[CELLS_PER_EXT_BLOB];
+    int diff;
+
+    get_rand_blob(&blob);
+    ret = compute_cells_and_kzg_proofs(cells, NULL, &blob, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    /*
+     * Recovery cost does not depend on how much is missing, so a single erasure count is not
+     * evidence about the others. Sweep all of them, from one missing cell to the maximum, as a
+     * prefix, a suffix and a strided pattern.
+     *
+     * The strided and maximum-erasure cases matter in particular: the vanishing polynomial reaches
+     * its full degree only when exactly CELLS_PER_BLOB cells are missing.
+     */
+    for (size_t k = 1; k <= CELLS_PER_BLOB; k++) {
+        for (int mode = 0; mode < 3; mode++) {
+            for (size_t c = 0; c < CELLS_PER_EXT_BLOB; c++) {
+                is_missing[c] = false;
+            }
+            for (size_t j = 0; j < k; j++) {
+                size_t idx;
+                if (mode == 0) {
+                    idx = j;
+                } else if (mode == 1) {
+                    idx = CELLS_PER_EXT_BLOB - 1 - j;
+                } else {
+                    idx = (j * CELLS_PER_EXT_BLOB) / k;
+                }
+                is_missing[idx] = true;
+            }
+
+            size_t num_have = 0;
+            for (size_t c = 0; c < CELLS_PER_EXT_BLOB; c++) {
+                if (is_missing[c]) continue;
+                cell_indices[num_have] = c;
+                memcpy(&partial_cells[num_have], &cells[c], sizeof(Cell));
+                num_have++;
+            }
+
+            ret = recover_cells_and_kzg_proofs(
+                recovered_cells, NULL, cell_indices, partial_cells, num_have, &s
+            );
+            ASSERT_EQUALS(ret, C_KZG_OK);
+
+            for (size_t c = 0; c < CELLS_PER_EXT_BLOB; c++) {
+                diff = memcmp(&cells[c], &recovered_cells[c], sizeof(Cell));
+                ASSERT_EQUALS(diff, 0);
+            }
+        }
+    }
+}
+
 static void test_compute_vanishing_polynomial_from_roots(void) {
     /*
      * Test case: (x - 2)(x - 3)
@@ -1968,6 +2028,43 @@ static void test_compute_vanishing_polynomial_from_roots(void) {
     ASSERT("coefficient 2 are equal", fr_equal(&poly[2], &expected[2]));
 }
 
+/**
+ * Expands the short vanishing polynomial Zhat into the full-domain Z, by spreading its
+ * coefficients at stride FIELD_ELEMENTS_PER_CELL:
+ *
+ *   Z(x) = Zhat(x^FIELD_ELEMENTS_PER_CELL)
+ *
+ * recover_cells never builds Z in this form -- it works with Zhat and exploits the
+ * periodicity that this identity implies. The expansion lives here so the test below can
+ * check the identity directly, without the library carrying code nothing calls.
+ */
+static C_KZG_RET expand_vanishing_polynomial_for_missing_cells(
+    fr_t *vanishing_poly, const uint64_t *missing_cell_indices, size_t len_missing_cells
+) {
+    C_KZG_RET ret;
+    fr_t *short_vanishing_poly = NULL;
+    size_t short_vanishing_poly_len = 0;
+
+    ret = new_fr_array(&short_vanishing_poly, (len_missing_cells + 1));
+    if (ret != C_KZG_OK) goto out;
+
+    ret = short_vanishing_polynomial_for_missing_cells(
+        short_vanishing_poly, &short_vanishing_poly_len, missing_cell_indices, len_missing_cells, &s
+    );
+    if (ret != C_KZG_OK) goto out;
+
+    for (size_t i = 0; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
+        vanishing_poly[i] = FR_ZERO;
+    }
+    for (size_t i = 0; i < short_vanishing_poly_len; i++) {
+        vanishing_poly[i * FIELD_ELEMENTS_PER_CELL] = short_vanishing_poly[i];
+    }
+
+out:
+    c_kzg_free(short_vanishing_poly);
+    return ret;
+}
+
 static void test_vanishing_polynomial_for_missing_cells(void) {
     C_KZG_RET ret;
 
@@ -1978,8 +2075,8 @@ static void test_vanishing_polynomial_for_missing_cells(void) {
     uint64_t missing_cell_indices[] = {0, 1};
     size_t len_missing_cells = 2;
 
-    ret = vanishing_polynomial_for_missing_cells(
-        vanishing_poly, missing_cell_indices, len_missing_cells, &s
+    ret = expand_vanishing_polynomial_for_missing_cells(
+        vanishing_poly, missing_cell_indices, len_missing_cells
     );
 
     /* Check return status */
@@ -2367,6 +2464,7 @@ int main(void) {
     RUN(test_deduplicate_commitments__one_commitment);
     RUN(test_recover_cells_and_kzg_proofs__succeeds_random_blob);
     RUN(test_shift_factors__succeeds);
+    RUN(test_recover_cells__succeeds_every_erasure_count);
     RUN(test_compute_vanishing_polynomial_from_roots);
     RUN(test_vanishing_polynomial_for_missing_cells);
     RUN(test_verify_cell_kzg_proof_batch__succeeds_random_blob);


### PR DESCRIPTION
Note: this PR is part of a set of changes coming out of my AI-assisted performance investigation of the EIP-7594
libraries. The analysis and implementation were done with Anthropic's Claude (Opus/Fable), and cross-reviewed
with OpenAI's Codex (GPT-5.6). The change is mutation-tested (dropping either fold, or tiling the vanishing
polynomial with the wrong period, makes tests fail), verified bit-exact over 448 erasure patterns, clean under
the sanitizers and the static analyzer, and the consensus spec vectors pass through the bindings.

This PR only touches recovery:
`recover_cells`: **19.5 ms → 4.1 ms.**

## Summary

`recover_cells` does two things far more expensively than it needs to. Fixing both takes it from
**19.5 ms to 4.1 ms** on an Apple M1, with output unchanged.

1. It divides by the vanishing polynomial with **8192 separate `fr_div` calls**, each a full
   `blst_fr_eucl_inverse`. The library already contains a Montgomery batch inversion.
2. It runs **five transforms of 8192 points**. Two of them are transforms of the vanishing polynomial `Z`, which
   is sparse and periodic, so they collapse to sizes 128 and 64. A third pair shrinks to half size.

They are separate commits, in that order. The second uses the batch inversion the first exposes, so it does not
stand alone. The first is worth taking alone (2.5×) if the second needs more discussion.

## 1. Batch the inversions

Standalone on an M1:

| | |
|---|---:|
| 8192 × `fr_div` | 11.86 ms |
| `fr_batch_inv` over the same 8192 | **0.40 ms** |

That is 60% of the whole of `recover_cells` spent on inversions that Montgomery's trick does for one inversion
plus three multiplications each.

`fr_batch_inv` already existed, `static` inside `eip4844.c`. It moves to `common/fr.c` next to the other field
helpers, along with the `fr_is_zero` it needs. No behaviour change for the existing callers.

`Z` has no zeros on the coset — that is *why* the division happens there — so the batch cannot fail, but the
return value is checked anyway.

**19.5 ms → 7.9 ms.**

## 2. Stop transforming a polynomial that is mostly zeros

`vanishing_polynomial_for_missing_cells` builds `Z` by writing a short polynomial `Ẑ` into every
`FIELD_ELEMENTS_PER_CELL`-th coefficient. That is exactly

```
Z(x) = Ẑ(x^FIELD_ELEMENTS_PER_CELL),   deg Ẑ ≤ CELLS_PER_BLOB
```

Two consequences, both unexploited:

**`Z` is sparse** — at most 65 nonzero coefficients out of 8192.

**Its evaluations repeat.** Since `ω^64` has order `CELLS_PER_EXT_BLOB`,

```
Z(ω^j) = Ẑ(ν^(j mod 128)),   ν = ω^64
```

so the full-domain transform of `Z` is a transform of size 128, tiled. On the coset the same argument applies,
and because the coset there is half the size the period halves again, to 64.

**And the quotient is small.** `P = (P·Z)/Z` has degree below `FIELD_ELEMENTS_PER_BLOB`, so the coset round trip
that performs the division needs only that many points. `(P·Z)` folds down to that many coefficients first —
exactly, not by truncation, because every point of the coset satisfies `x^half = h^half`.

### What is left

```
1. Ẑ over the order-128 subgroup            [128]     was 8192
2. (E·Z)[i] = E[i] · Ẑeval[i mod 128]
3. inverse FFT                              [8192]    the only full-size transform
4. fold (P·Z) from 8192 to 4096
5. coset FFT                                [4096]    was 8192
6. Ẑ on the coset, then batch invert        [64]      was 8192
7. divide, coset inverse FFT                [4096]    was 8192
8. evaluate                                 [8192]    unchanged
```

The expanded 8192-coefficient `Z` is never built. The working set drops from **eight arrays of
`FIELD_ELEMENTS_PER_EXT_BLOB` to three**.

The expanded builder `vanishing_polynomial_for_missing_cells` is **removed from the library**. Nothing calls it
any more, and keeping production code alive so that a test can call it is the wrong way round. The expansion
moves into `tests.c`, which is its only caller, so the test still checks the
`Z(x) = Ẑ(x^FIELD_ELEMENTS_PER_CELL)` identity the restructuring rests on.

**7.9 ms → 4.1 ms.**

## Correctness

- **The consensus test vectors pass**, including all 18 `recover_cells_and_kzg_proofs` cases. Note these are run
  by the bindings, not by `make test`.
- **The C suite passes** (94 tests).
- **Every erasure count, four pattern families.** A new test,
  `test_recover_cells__succeeds_every_erasure_count`, sweeps 1 to `CELLS_PER_BLOB` missing cells as prefix,
  suffix and strided patterns. A workspace harness additionally covers random patterns at every count: **448
  cases, all bit-exact** against the original data.
- **Mutation-checked.** Dropping the `(P·Z)` fold fails all 448; tiling `Z` with the wrong period fails 384;
  dropping the `Ẑ` fold fails 7.

That last number is the reason the sweep exists. The `Ẑ` fold only matters when *exactly* `CELLS_PER_BLOB` cells
are missing, so it is invisible to any test that fixes one erasure count.

## Benchmarks

Apple M1, `clang -O2`, `recover_cells` timed directly with no bindings in the path, 30 reps, each run verifying
the recovered data against the original:

| | |
|---|---:|
| before | 19.5 ms |
| + batch inversion | 7.9 ms |
| + fewer, smaller transforms | **4.1 ms** |

End to end through the Go bindings at `precompute=6` — the setting go-ethereum uses — `RecoverCells` goes
**20.1 ms → 4.7 ms**.

## Limits

- Measured on one machine, `darwin/arm64`. Not reproduced elsewhere.
- Only recovery is touched. Proving and verification are unchanged.
- The remaining 4.1 ms is close to the floor for this structure: one 8192-point inverse transform, two
  4096-point coset transforms, the final evaluation, and two bit-reversal permutations. Further gains would need
  a faster transform or pruning the zero-padded halves, neither of which is attempted here.

## Relationship to recent work here

Checked against the repository's own history, because both of these touch code that has been revised lately:

- **#628, "Prescale coefficients to avoid expensive scalar multiplications"** (Feb 2026) is the same *kind* of
  observation applied to the G1 side — moving a scaling off the points and onto the scalars, which is where
  `g1_ifft_unscaled` came from. Nothing here conflicts with it; it touches `fk20.c` and the G1 transforms, this
  touches recovery and the `Fr` ones.
- **#629, "Simplify missing cell handling in recovery"** (Feb 2026) rewrote part of this same function and
  removed the dead `fr_is_null`/`FR_NULL` from `common/fr.{c,h}`. Moving `fr_batch_inv` *into* that file is in
  the same direction: it is a shared field helper that happened to be `static` in `eip4844.c`.

## For reviewers

The load-bearing claims are `Z(x) = Ẑ(x^64)` and the exactness of the two folds. The first is what
`vanishing_polynomial_for_missing_cells` already does, read backwards. The second follows from `x^half = h^half`
on the coset. Both are covered by the erasure sweep, and all three are individually mutation-checked.

go-eth-kzg had the identical redundancy and the same fix applies there; that work is what led to this.
