### PR TITLE
Add function to recover cells (and not proofs) to bindings

### DIFF
--- a/bindings/csharp/Ckzg.Bindings/Ckzg.cs
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.cs
@@ -248,6 +248,36 @@ public static partial class Ckzg
     }
 
     /// <summary>
+    ///     Given some cells for a blob, recover all cells.
+    /// </summary>
+    /// <param name="recoveredCells">Recovered cells as a flattened byte array</param>
+    /// <param name="cellIndices">Cell indices as a flattened UInt64 array</param>
+    /// <param name="cells">Cells as a flattened byte array</param>
+    /// <param name="numCells">The number of cells provided</param>
+    /// <param name="ckzgSetup">Trusted setup settings</param>
+    /// <exception cref="ArgumentException">Thrown when length of an argument is not correct or settings are not correct</exception>
+    /// <exception cref="ApplicationException">Thrown when the library returns unexpected Error code</exception>
+    /// <exception cref="InsufficientMemoryException">Thrown when the library has no enough memory to process</exception>
+    public static unsafe void RecoverCells(Span<byte> recoveredCells,
+            ReadOnlySpan<UInt64> cellIndices, ReadOnlySpan<byte> cells, int numCells, IntPtr ckzgSetup)
+    {
+        ThrowOnUninitializedTrustedSetup(ckzgSetup);
+        ThrowOnInvalidLength(recoveredCells, nameof(recoveredCells), BytesPerCell * CellsPerExtBlob);
+        ThrowOnInvalidLength(cellIndices, nameof(cellIndices), numCells);
+        ThrowOnInvalidLength(cells, nameof(cells), BytesPerCell * numCells);
+
+        fixed (byte* recoveredCellsPtr = recoveredCells, cellsPtr = cells)
+        {
+            fixed(UInt64* cellIndicesPtr = cellIndices)
+            {
+                KzgResult result = RecoverCellsAndKzgProofs(recoveredCellsPtr, null, cellIndicesPtr,
+                    cellsPtr, (UInt64)numCells, ckzgSetup);
+                ThrowOnError(result);
+            }
+        }
+    }
+
+    /// <summary>
     ///     Given some cells for a blob, recover all cells/proofs.
     /// </summary>
     /// <param name="recoveredCells">Recovered cells as a flattened byte array</param>

--- a/bindings/csharp/Ckzg.Test/ReferenceTests.cs
+++ b/bindings/csharp/Ckzg.Test/ReferenceTests.cs
@@ -468,6 +468,31 @@ public class ReferenceTests
 
     #endregion
 
+    #region RecoverCells
+
+    [Test, TestCaseSource(nameof(GetRecoverCellsAndKzgProofsTests))]
+    public void TestRecoverCells(RecoverCellsAndKzgProofsTest test)
+    {
+        byte[] recoveredCells = new byte[CellsPerExtBlob * Ckzg.BytesPerCell];
+        UInt64[] cellIndices = test.Input.CellIndices.ToArray();
+        byte[] cells = GetFlatBytes(test.Input.Cells);
+        int numCells = cells.Length / Ckzg.BytesPerCell;
+
+        try
+        {
+            Ckzg.RecoverCells(recoveredCells, cellIndices, cells, numCells, _ts);
+            Assert.That(test.Output, Is.Not.EqualTo(null));
+            byte[] expectedCells = GetFlatBytes(test.Output.ElementAt(0));
+            Assert.That(recoveredCells, Is.EqualTo(expectedCells));
+        }
+        catch
+        {
+            Assert.That(test.Output, Is.EqualTo(null));
+        }
+    }
+
+    #endregion
+
     #region RecoverCellsAndKzgProofs
 
     public class RecoverCellsAndKzgProofsInput

--- a/bindings/elixir/lib/kzg.ex
+++ b/bindings/elixir/lib/kzg.ex
@@ -234,6 +234,26 @@ defmodule KZG do
   end
 
   @doc """
+  Recovers missing cells given cell indices and available cells.
+
+  ## Parameters
+
+    - `cell_indices` is a list of non-negative integers (cell indices).
+    - `cells` is a list of binary cells.
+    - `settings` is the trusted settings reference.
+
+  ## Returns
+
+    - `{:ok, cells_list}` on success, where `cells_list` is a list of binary cells.
+    - `{:error, reason}` on error.
+  """
+  @spec recover_cells([non_neg_integer()], [binary], settings) ::
+          {:ok, [binary()]} | {:error, atom()}
+  def recover_cells(_cell_indices, _cells, _settings) do
+    :erlang.nif_error(:not_loaded)
+  end
+
+  @doc """
   Recovers missing cells and their proofs given cell indices and available cells.
 
   ## Parameters

--- a/bindings/elixir/native/src/ckzg_wrap.c
+++ b/bindings/elixir/native/src/ckzg_wrap.c
@@ -568,6 +568,123 @@ out:
     return msg;
 }
 
+static ERL_NIF_TERM recover_cells_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    ERL_NIF_TERM *cells_list = NULL;
+    Cell *cells = NULL, *recovered_cells = NULL;
+    uint64_t *cell_indices = NULL;
+    ERL_NIF_TERM msg;
+
+    if (argc != 3) {
+        msg = make_error(env, ckzg_atoms.incorrect_arg_count);
+        goto out;
+    }
+
+    unsigned int cell_indices_len;
+    if (!enif_get_list_length(env, argv[0], &cell_indices_len)) {
+        msg = make_error(env, ckzg_atoms.cell_indices_not_list);
+        goto out;
+    }
+
+    unsigned int cells_len;
+    if (!enif_get_list_length(env, argv[1], &cells_len)) {
+        msg = make_error(env, ckzg_atoms.cells_not_list);
+        goto out;
+    }
+
+    if (cells_len != cell_indices_len) {
+        msg = make_error(env, ckzg_atoms.expected_same_array_size);
+        goto out;
+    }
+
+    KZGSettings *settings;
+    if (!enif_get_resource(env, argv[2], KZGSETTINGS_RES_TYPE, (void **)&settings)) {
+        msg = make_error(env, ckzg_atoms.failed_get_settings_resource);
+        goto out;
+    }
+
+    cell_indices = enif_alloc(cell_indices_len * sizeof(uint64_t));
+    if (cell_indices == NULL) {
+        msg = make_error(env, ckzg_atoms.out_of_memory);
+        goto out;
+    }
+
+    ERL_NIF_TERM head;
+    ERL_NIF_TERM tail = argv[0];
+
+    for (int i = 0; enif_get_list_cell(env, tail, &head, &tail); i++) {
+        ErlNifUInt64 current_u;
+        if (!enif_get_uint64(env, head, &current_u)) {
+            msg = make_error(env, ckzg_atoms.cell_indices_value_not_uint64);
+            goto out;
+        }
+
+        cell_indices[i] = (uint64_t)current_u;
+    }
+
+    cells = enif_alloc(cells_len * BYTES_PER_CELL);
+    if (cells == NULL) {
+        msg = make_error(env, ckzg_atoms.out_of_memory);
+        goto out;
+    }
+
+    tail = argv[1];
+    for (int i = 0; enif_get_list_cell(env, tail, &head, &tail); i++) {
+        ErlNifBinary current_b;
+        if (!enif_inspect_binary(env, head, &current_b)) {
+            msg = make_error(env, ckzg_atoms.cells_value_not_binary);
+            goto out;
+        }
+
+        if (current_b.size != BYTES_PER_CELL) {
+            msg = make_error(env, ckzg_atoms.invalid_cell_length);
+            goto out;
+        }
+
+        memcpy(&cells[i], current_b.data, BYTES_PER_CELL);
+    }
+
+    recovered_cells = enif_alloc(CELLS_PER_EXT_BLOB * BYTES_PER_CELL);
+    if (recovered_cells == NULL) {
+        msg = make_error(env, ckzg_atoms.out_of_memory);
+        goto out;
+    }
+
+    C_KZG_RET ret = recover_cells_and_kzg_proofs(
+        recovered_cells, NULL, cell_indices, cells, cells_len, settings
+    );
+    if (ret != C_KZG_OK) {
+        msg = make_kzg_error(env, ret);
+        goto out;
+    }
+
+    cells_list = enif_alloc(sizeof(ERL_NIF_TERM) * CELLS_PER_EXT_BLOB);
+    if (cells_list == NULL) {
+        msg = make_error(env, ckzg_atoms.out_of_memory);
+        goto out;
+    }
+
+    for (int i = 0; i < CELLS_PER_EXT_BLOB; i++) {
+        ErlNifBinary cell_bytes;
+        if (!enif_alloc_binary(BYTES_PER_CELL, &cell_bytes)) {
+            msg = make_error(env, ckzg_atoms.out_of_memory);
+            goto out;
+        }
+
+        memcpy(cell_bytes.data, &recovered_cells[i], BYTES_PER_CELL);
+        cells_list[i] = enif_make_binary(env, &cell_bytes);
+    }
+
+    ERL_NIF_TERM cells_term = enif_make_list_from_array(env, cells_list, CELLS_PER_EXT_BLOB);
+    msg = make_success(env, cells_term);
+
+out:
+    enif_free(cell_indices);
+    enif_free(cells);
+    enif_free(recovered_cells);
+    enif_free(cells_list);
+    return msg;
+}
+
 static ERL_NIF_TERM recover_cells_and_kzg_proofs_nif(
     ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
 ) {
@@ -880,6 +997,7 @@ static ErlNifFunc nif_funcs[] = {
      2,
      compute_cells_and_kzg_proofs_nif,
      ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"recover_cells", 3, recover_cells_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"recover_cells_and_kzg_proofs",
      3,
      recover_cells_and_kzg_proofs_nif,

--- a/bindings/elixir/test/ckzg_test.exs
+++ b/bindings/elixir/test/ckzg_test.exs
@@ -233,6 +233,31 @@ defmodule KZGTest do
     end
   end
 
+  test "recover_cells/3 tests", %{setup: setup} do
+    assert @recover_cells_and_kzg_proofs_tests != []
+
+    for file <- @recover_cells_and_kzg_proofs_tests do
+      {:ok, test_data} = YamlElixir.read_from_file(file)
+
+      cell_indices = test_data["input"]["cell_indices"]
+      cells = Enum.map(test_data["input"]["cells"], &bytes_from_hex/1)
+
+      case KZG.recover_cells(cell_indices, cells, setup) do
+        {:error, _} ->
+          assert test_data["output"] == nil
+
+        {:ok, recovered_cells} ->
+          expected_cells =
+            test_data["output"]
+            |> List.first()
+            |> Enum.map(&bytes_from_hex/1)
+
+          assert recovered_cells == expected_cells,
+                 "#{file}\nRecovered cells #{inspect(recovered_cells)} do not match expected #{inspect(expected_cells)}"
+      end
+    end
+  end
+
   test "recover_cells_and_kzg_proofs/3 tests", %{setup: setup} do
     assert @recover_cells_and_kzg_proofs_tests != []
 

--- a/bindings/go/main_test.go
+++ b/bindings/go/main_test.go
@@ -601,6 +601,59 @@ func TestVerifyCellKZGProofBatch(t *testing.T) {
 	}
 }
 
+func TestRecoverCells(t *testing.T) {
+	type Test struct {
+		Input struct {
+			CellIndices []uint64 `yaml:"cell_indices"`
+			Cells       []string `yaml:"cells"`
+		}
+		Output *[][]string `yaml:"output"`
+	}
+
+	tests, err := filepath.Glob(recoverCellsAndKZGProofsTests)
+	require.NoError(t, err)
+	require.True(t, len(tests) > 0)
+
+	for _, testPath := range tests {
+		t.Run(testPath, func(t *testing.T) {
+			testFile, err := os.Open(testPath)
+			require.NoError(t, err)
+			test := Test{}
+			err = yaml.NewDecoder(testFile).Decode(&test)
+			require.NoError(t, testFile.Close())
+			require.NoError(t, err)
+
+			cellIndices := test.Input.CellIndices
+
+			var cells []Cell
+			for _, c := range test.Input.Cells {
+				var cell Cell
+				err = cell.UnmarshalText([]byte(c))
+				if err != nil {
+					require.Nil(t, test.Output)
+					return
+				}
+				cells = append(cells, cell)
+			}
+
+			recoveredCells, err := RecoverCells(cellIndices, cells)
+			if err == nil {
+				require.NotNil(t, test.Output)
+				var expectedCells []Cell
+				for _, cellStr := range (*test.Output)[0] {
+					var cell Cell
+					err := cell.UnmarshalText([]byte(cellStr))
+					require.NoError(t, err)
+					expectedCells = append(expectedCells, cell)
+				}
+				require.Equal(t, expectedCells, recoveredCells[:])
+			} else {
+				require.Nil(t, test.Output)
+			}
+		})
+	}
+}
+
 func TestRecoverCellsAndKZGProofs(t *testing.T) {
 	type Test struct {
 		Input struct {

--- a/bindings/java/ckzg_jni.c
+++ b/bindings/java/ckzg_jni.c
@@ -586,6 +586,48 @@ Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgProofs(JNIEnv *env,
   return result;
 }
 
+JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_recoverCells(
+    JNIEnv *env, jclass thisCls, jlongArray cell_indices, jbyteArray cells) {
+  if (settings == NULL) {
+    throw_exception(env, TRUSTED_SETUP_NOT_LOADED);
+    return NULL;
+  }
+
+  size_t count = (size_t)(*env)->GetArrayLength(env, cell_indices);
+  size_t cells_size = (size_t)(*env)->GetArrayLength(env, cells);
+  if (cells_size != count * BYTES_PER_CELL) {
+    throw_invalid_size_exception(env, "Invalid cells size.", cells_size,
+                                 count * BYTES_PER_CELL);
+    return NULL;
+  }
+
+  jbyteArray recovered_cells =
+      (*env)->NewByteArray(env, CELLS_PER_EXT_BLOB * BYTES_PER_CELL);
+  Cell *recovered_cells_native =
+      (Cell *)(*env)->GetByteArrayElements(env, recovered_cells, NULL);
+  uint64_t *cell_indices_native =
+      (uint64_t *)(*env)->GetLongArrayElements(env, cell_indices, NULL);
+  Cell *cells_native = (Cell *)(*env)->GetByteArrayElements(env, cells, NULL);
+
+  C_KZG_RET ret = recover_cells_and_kzg_proofs(recovered_cells_native, NULL,
+                                               cell_indices_native,
+                                               cells_native, count, settings);
+
+  (*env)->ReleaseByteArrayElements(env, recovered_cells,
+                                   (jbyte *)recovered_cells_native, 0);
+  (*env)->ReleaseLongArrayElements(env, cell_indices,
+                                   (jlong *)cell_indices_native, JNI_ABORT);
+  (*env)->ReleaseByteArrayElements(env, cells, (jbyte *)cells_native,
+                                   JNI_ABORT);
+
+  if (ret != C_KZG_OK) {
+    throw_c_kzg_exception(env, ret, "There was an error in recoverCells.");
+    return NULL;
+  }
+
+  return recovered_cells;
+}
+
 JNIEXPORT jobject JNICALL
 Java_ethereum_ckzg4844_CKZG4844JNI_recoverCellsAndKzgProofs(
     JNIEnv *env, jclass thisCls, jlongArray cell_indices, jbyteArray cells) {

--- a/bindings/java/ckzg_jni.h
+++ b/bindings/java/ckzg_jni.h
@@ -121,6 +121,14 @@ JNIEXPORT jobject JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_computeCellsAndKzgP
 
 /*
  * Class:     ethereum_ckzg4844_CKZG4844JNI
+ * Method:    recoverCells
+ * Signature: ([J[B)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_ethereum_ckzg4844_CKZG4844JNI_recoverCells
+  (JNIEnv *, jclass, jlongArray, jbyteArray);
+
+/*
+ * Class:     ethereum_ckzg4844_CKZG4844JNI
  * Method:    recoverCellsAndKzgProofs
  * Signature: ([J[B)Lethereum/ckzg4844/CellsAndProofs;
  */

--- a/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
+++ b/bindings/java/src/main/java/ethereum/ckzg4844/CKZG4844JNI.java
@@ -233,6 +233,16 @@ public class CKZG4844JNI {
   public static native CellsAndProofs computeCellsAndKzgProofs(byte[] blob);
 
   /**
+   * Given at least 50% of cells, reconstruct the missing cells.
+   *
+   * @param cellIndices the identifiers for the cells you have
+   * @param cells the cells you have
+   * @return all cells for that blob
+   * @throws CKZGException if there is a crypto error
+   */
+  public static native byte[] recoverCells(long[] cellIndices, byte[] cells);
+
+  /**
    * Given at least 50% of cells, reconstruct the missing cells/proofs.
    *
    * @param cellIndices the identifiers for the cells you have

--- a/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
+++ b/bindings/java/src/test/java/ethereum/ckzg4844/CKZG4844JNITest.java
@@ -146,6 +146,18 @@ public class CKZG4844JNITest {
 
   @ParameterizedTest
   @MethodSource("getRecoverCellsAndKzgProofsTests")
+  public void recoverCellsTests(final RecoverCellsAndKzgProofsTest test) {
+    try {
+      final byte[] recoveredCells =
+          CKZG4844JNI.recoverCells(test.getInput().getCellIndices(), test.getInput().getCells());
+      assertArrayEquals(test.getOutput().getCells(), recoveredCells);
+    } catch (CKZGException ex) {
+      assertNull(test.getOutput());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("getRecoverCellsAndKzgProofsTests")
   public void recoverCellsAndKzgProofsTests(final RecoverCellsAndKzgProofsTest test) {
     try {
       final CellsAndProofs recoveredCellsAndProofs =
@@ -213,6 +225,20 @@ public class CKZG4844JNITest {
     final ProofAndY proofAndY = CKZG4844JNI.computeKzgProof(blob, z_bytes);
     assertEquals(BYTES_PER_PROOF, proofAndY.getProof().length);
     assertEquals(CKZG4844JNI.BYTES_PER_FIELD_ELEMENT, proofAndY.getY().length);
+    CKZG4844JNI.freeTrustedSetup();
+  }
+
+  @Test
+  public void checkRecoverCells() {
+    loadTrustedSetup();
+    final byte[] blob = TestUtils.createRandomBlob();
+    final CellsAndProofs cellsAndProofs = CKZG4844JNI.computeCellsAndKzgProofs(blob);
+    final byte[] cells = cellsAndProofs.getCells();
+    final byte[] partialCells = new byte[BYTES_PER_CELL * CELLS_PER_EXT_BLOB / 2];
+    System.arraycopy(cells, 0, partialCells, 0, partialCells.length);
+    final long[] cellIndices = LongStream.range(0, CELLS_PER_EXT_BLOB / 2).toArray();
+    final byte[] recoveredCells = CKZG4844JNI.recoverCells(cellIndices, partialCells);
+    assertArrayEquals(cells, recoveredCells);
     CKZG4844JNI.freeTrustedSetup();
   }
 

--- a/bindings/nim/kzg.nim
+++ b/bindings/nim/kzg.nim
@@ -277,6 +277,26 @@ proc computeCellsAndKzgProofs*(blob: KzgBlob): Result[KzgCellsAndKzgProofs, stri
     gCtx.settings)
   verify(res, ret)
 
+proc recoverCells*(cellIndices: openArray[uint64],
+                   cells: openArray[KzgCell]): Result[KzgCells, string] {.gcsafe.} =
+  if not gCtx.initialized:
+    return err(TrustedSetupNotLoadedErr)
+  if cells.len != cellIndices.len:
+    return err($KZG_BADARGS)
+  if cells.len == 0:
+    return err($KZG_BADARGS)
+
+  var ret: KzgCells
+  var recoveredCellsPtr: ptr KzgCell = ret[0].getPtr
+  let res = recover_cells_and_kzg_proofs(
+    recoveredCellsPtr,
+    nil,
+    cellIndices[0].getPtr,
+    cells[0].getPtr,
+    cells.len.uint64,
+    gCtx.settings)
+  verify(res, ret)
+
 proc recoverCellsAndKzgProofs*(cellIndices: openArray[uint64],
                    cells: openArray[KzgCell]): Result[KzgCellsAndKzgProofs, string] {.gcsafe.} =
   if not gCtx.initialized:

--- a/bindings/nim/tests/tests.nim
+++ b/bindings/nim/tests/tests.nim
@@ -158,7 +158,12 @@ suite "yaml tests":
     let
       cellIndices = uint64.fromIntList(n["input"]["cell_indices"])
       cells = KzgCell.fromHexList(n["input"]["cells"])
+      cellsRes = recoverCells(cellIndices, cells)
       res = recoverCellsAndKzgProofs(cellIndices, cells)
+
+    checkRes(cellsRes):
+      let expectedCells = KzgCell.fromHexList(n["output"][0])
+      check expectedCells == cellsRes.get
 
     checkRes(res):
       let expectedCells = KzgCell.fromHexList(n["output"][0])

--- a/bindings/node.js/README.md
+++ b/bindings/node.js/README.md
@@ -186,6 +186,23 @@ verifyBlobKzgProofBatch(
 export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
 ```
 
+### `recoverCells`
+
+```ts
+/**
+ * Given at least 50% of cells, reconstruct the missing ones.
+ *
+ * @param[in] {number[]}  cellIndices - The identifiers for the cells you have
+ * @param[in] {Cell[]}    cells - The cells you have
+ *
+ * @return {Cell[]} - An array of cells
+ *
+ * @throws {Error} - Invalid input, failure to allocate or error recovering
+ * cells
+ */
+export function recoverCells(cellIndices: number[], cells: Cell[]): Cell[];
+```
+
 ### `recoverCellsAndKzgProofs`
 
 ```ts

--- a/bindings/node.js/lib/kzg.d.ts
+++ b/bindings/node.js/lib/kzg.d.ts
@@ -157,6 +157,19 @@ export function computeCells(blob: Blob): Cell[];
 export function computeCellsAndKzgProofs(blob: Blob): [Cell[], KZGProof[]];
 
 /**
+ * Given at least 50% of cells, reconstruct the missing cells.
+ *
+ * @param[in] {number[]}  cellIndices - The identifiers for the cells you have
+ * @param[in] {Cell[]}    cells - The cells you have
+ *
+ * @return {Cell[]} - An array of cells
+ *
+ * @throws {Error} - Invalid input, failure to allocate or error recovering
+ * cells
+ */
+export function recoverCells(cellIndices: number[], cells: Cell[]): Cell[];
+
+/**
  * Given at least 50% of cells, reconstruct the missing cells/proofs.
  *
  * @param[in] {number[]}  cellIndices - The identifiers for the cells you have

--- a/bindings/node.js/src/kzg.cxx
+++ b/bindings/node.js/src/kzg.cxx
@@ -692,6 +692,119 @@ out:
 }
 
 /**
+ * Given at least 50% of cells, reconstruct the missing cells.
+ *
+ * @param[in] {number[]}  cellIndices - The identifiers for the cells you have
+ * @param[in] {Cell[]}    cells - The cells you have
+ *
+ * @return {Cell[]} - An array of cells
+ *
+ * @throws {Error} - Invalid input, failure to allocate or error recovering
+ * cells
+ */
+Napi::Value RecoverCells(const Napi::CallbackInfo &info) {
+    C_KZG_RET ret;
+    uint64_t *cell_indices = NULL;
+    Cell *cells = NULL;
+    Cell *recovered_cells = NULL;
+    Napi::Array cellArray;
+    uint64_t num_cells;
+
+    Napi::Env env = info.Env();
+    Napi::Value result = env.Null();
+    if (!info[0].IsArray()) {
+        Napi::Error::New(env, "CellIndices must be an array")
+            .ThrowAsJavaScriptException();
+        return result;
+    }
+    if (!info[1].IsArray()) {
+        Napi::Error::New(env, "Cells must be an array")
+            .ThrowAsJavaScriptException();
+        return result;
+    }
+    KZGSettings *kzg_settings = get_kzg_settings(env, info);
+    if (kzg_settings == nullptr) {
+        return env.Null();
+    }
+
+    Napi::Array cell_indices_param = info[0].As<Napi::Array>();
+    Napi::Array cells_param = info[1].As<Napi::Array>();
+
+    if (cell_indices_param.Length() != cells_param.Length()) {
+        Napi::Error::New(
+            env, "There must equal lengths of cellIndices and cells"
+        )
+            .ThrowAsJavaScriptException();
+        goto out;
+    }
+
+    num_cells = cells_param.Length();
+    cell_indices = (uint64_t *)calloc(num_cells, sizeof(uint64_t));
+    if (cell_indices == nullptr) {
+        Napi::Error::New(env, "Error while allocating memory for cell_indices")
+            .ThrowAsJavaScriptException();
+        goto out;
+    }
+    cells = (Cell *)calloc(num_cells, BYTES_PER_CELL);
+    if (cells == nullptr) {
+        Napi::Error::New(env, "Error while allocating memory for cells")
+            .ThrowAsJavaScriptException();
+        goto out;
+    }
+    recovered_cells = (Cell *)calloc(CELLS_PER_EXT_BLOB, BYTES_PER_CELL);
+    if (recovered_cells == nullptr) {
+        Napi::Error::New(
+            env, "Error while allocating memory for recovered cells"
+        )
+            .ThrowAsJavaScriptException();
+        goto out;
+    }
+
+    for (uint64_t i = 0; i < num_cells; i++) {
+        // add HandleScope here to release reference to temp values
+        // after each iteration since data is being memcpy
+        Napi::HandleScope scope{env};
+
+        cell_indices[i] = get_cell_index(env, cell_indices_param[i]);
+        Cell *cell = get_cell(env, cells_param[i]);
+        if (cell == nullptr) {
+            goto out;
+        }
+        memcpy(&cells[i], cell, BYTES_PER_CELL);
+    }
+
+    ret = recover_cells_and_kzg_proofs(
+        recovered_cells, NULL, cell_indices, cells, num_cells, kzg_settings
+    );
+    if (ret != C_KZG_OK) {
+        std::ostringstream msg;
+        msg << "Error in recoverCells: " << from_c_kzg_ret(ret);
+        Napi::Error::New(env, msg.str()).ThrowAsJavaScriptException();
+        goto out;
+    }
+
+    cellArray = Napi::Array::New(env, CELLS_PER_EXT_BLOB);
+    for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++) {
+        cellArray.Set(
+            i,
+            Napi::Buffer<uint8_t>::Copy(
+                env,
+                reinterpret_cast<uint8_t *>(&recovered_cells[i]),
+                BYTES_PER_CELL
+            )
+        );
+    }
+
+    result = cellArray;
+
+out:
+    free(cell_indices);
+    free(cells);
+    free(recovered_cells);
+    return result;
+}
+
+/**
  * Given at least 50% of cells, reconstruct the missing cells/proofs.
  *
  * @param[in] {number[]}  cellIndices - The identifiers for the cells you have
@@ -1006,6 +1119,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     );
     exports["computeCellsAndKzgProofs"] = Napi::Function::New(
         env, ComputeCellsAndKzgProofs, "computeCellsAndKzgProofs"
+    );
+    exports["recoverCells"] = Napi::Function::New(
+        env, RecoverCells, "recoverCells"
     );
     exports["recoverCellsAndKzgProofs"] = Napi::Function::New(
         env, RecoverCellsAndKzgProofs, "recoverCellsAndKzgProofs"

--- a/bindings/node.js/test/kzg.test.ts
+++ b/bindings/node.js/test/kzg.test.ts
@@ -29,6 +29,7 @@ const {
   computeCells,
   computeCellsAndKzgProofs,
   verifyCellKzgProofBatch,
+  recoverCells,
   recoverCellsAndKzgProofs,
 } = kzg;
 
@@ -421,6 +422,34 @@ describe("C-KZG", () => {
         expect(proofs.length).toBe(expectedProofs.length);
         for (let i = 0; i < proofs.length; i++) {
           assertBytesEqual(proofs[i], expectedProofs[i]);
+        }
+      });
+    });
+
+    it("reference tests for recoverCells should pass", () => {
+      const tests = globSync(RECOVER_CELLS_AND_KZG_PROOFS_TESTS);
+      expect(tests.length).toBeGreaterThan(0);
+
+      tests.forEach((testFile: string) => {
+        const test: RecoverCellsAndKzgProofsTest = yaml.load(readFileSync(testFile, "ascii"));
+
+        let recoveredCells;
+        const cellIndices = test.input.cell_indices;
+        const cells = test.input.cells.map(bytesFromHex);
+
+        try {
+          recoveredCells = recoverCells(cellIndices, cells);
+        } catch {
+          expect(test.output).toBeNull();
+          return;
+        }
+
+        expect(test.output).not.toBeNull();
+        expect(test.output.length).toBe(2);
+        const expectedCells = test.output[0].map(bytesFromHex);
+        expect(recoveredCells.length).toBe(expectedCells.length);
+        for (let i = 0; i < recoveredCells.length; i++) {
+          assertBytesEqual(recoveredCells[i], expectedCells[i]);
         }
       });
     });

--- a/bindings/python/ckzg_wrap.c
+++ b/bindings/python/ckzg_wrap.c
@@ -447,6 +447,128 @@ out:
   return ret;
 }
 
+static PyObject *recover_cells_wrap(PyObject *self, PyObject *args) {
+  PyObject *input_cell_indices, *input_cells, *s;
+  PyObject *ret = NULL;
+  uint64_t *cell_indices = NULL;
+  Cell *cells = NULL;
+  Cell *recovered_cells = NULL;
+
+  /* Ensure inputs are the right types */
+  if (!PyArg_UnpackTuple(args, "recover_cells", 3, 3, &input_cell_indices,
+                         &input_cells, &s) ||
+      !PyList_Check(input_cell_indices) || !PyList_Check(input_cells) ||
+      !PyCapsule_IsValid(s, "KZGSettings")) {
+    ret = PyErr_Format(PyExc_ValueError, "expected list, list, trusted setup");
+    goto out;
+  }
+
+  /* Ensure cell indices/cells are the same length */
+  Py_ssize_t cell_indices_count = PyList_Size(input_cell_indices);
+  Py_ssize_t cells_count = PyList_Size(input_cells);
+  if (cell_indices_count != cells_count) {
+    ret = PyErr_Format(PyExc_ValueError,
+                       "expected same number of cell_indices and cells");
+    goto out;
+  }
+
+  /* Allocate space for the cell indices */
+  cell_indices = (uint64_t *)calloc(cells_count, sizeof(uint64_t));
+  if (cell_indices == NULL) {
+    ret = PyErr_Format(PyExc_MemoryError,
+                       "Failed to allocate memory for cell indices");
+    goto out;
+  }
+  for (Py_ssize_t i = 0; i < cell_indices_count; i++) {
+    /* Ensure each cell index is an integer */
+    PyObject *cell_index = PyList_GetItem(input_cell_indices, i);
+    if (!PyLong_Check(cell_index)) {
+      ret = PyErr_Format(PyExc_ValueError,
+                         "expected cell index to be an integer");
+      goto out;
+    }
+    /* Convert the cell index to a cell index type (uint64_t) */
+    uint64_t value = PyLong_AsUnsignedLongLong(cell_index);
+    if (PyErr_Occurred()) {
+      ret = PyErr_Format(PyExc_ValueError,
+                         "failed to convert cell index to uint64_t");
+      goto out;
+    }
+    /* The cell index is good, add it to our array */
+    memcpy(&cell_indices[i], &value, sizeof(uint64_t));
+  }
+
+  /* Allocate space for the cells */
+  cells = (Cell *)calloc(cells_count, BYTES_PER_CELL);
+  if (cells == NULL) {
+    ret =
+        PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for cells");
+    goto out;
+  }
+  for (Py_ssize_t i = 0; i < cells_count; i++) {
+    /* Ensure each cell is bytes */
+    PyObject *cell = PyList_GetItem(input_cells, i);
+    if (!PyBytes_Check(cell)) {
+      ret = PyErr_Format(PyExc_ValueError, "expected cell to be bytes");
+      goto out;
+    }
+    /* Ensure each cell is the right size */
+    Py_ssize_t cell_size = PyBytes_Size(cell);
+    if (cell_size != BYTES_PER_CELL) {
+      ret = PyErr_Format(PyExc_ValueError,
+                         "expected cell to be BYTES_PER_CELL bytes");
+      goto out;
+    }
+    /* The cell is good, copy it to our array */
+    memcpy(&cells[i], PyBytes_AsString(cell), BYTES_PER_CELL);
+  }
+
+  /* Allocate space for the recovered cells */
+  recovered_cells = calloc(CELLS_PER_EXT_BLOB, BYTES_PER_CELL);
+  if (recovered_cells == NULL) {
+    ret = PyErr_Format(PyExc_MemoryError,
+                       "Failed to allocate memory for recovered cells");
+    goto out;
+  }
+
+  /* Call our C function with our inputs, skipping proof recovery */
+  if (recover_cells_and_kzg_proofs(
+          recovered_cells, NULL, cell_indices, cells, cells_count,
+          PyCapsule_GetPointer(s, "KZGSettings")) != C_KZG_OK) {
+    ret = PyErr_Format(PyExc_RuntimeError, "recover_cells failed");
+    goto out;
+  }
+
+  /* Convert our result to a list of bytes objects */
+  PyObject *recovered_cells_list = PyList_New(CELLS_PER_EXT_BLOB);
+  if (recovered_cells_list == NULL) {
+    ret = PyErr_Format(PyExc_MemoryError,
+                       "Failed to allocate memory for return list of cells");
+    goto out;
+  }
+  for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++) {
+    /* Convert cell to a bytes object */
+    PyObject *cell_bytes = PyBytes_FromStringAndSize(
+        (const char *)&recovered_cells[i], BYTES_PER_CELL);
+    if (cell_bytes == NULL) {
+      Py_DECREF(cell_bytes);
+      ret = PyErr_Format(PyExc_MemoryError,
+                         "Failed to allocate memory for cell bytes");
+      goto out;
+    }
+    PyList_SetItem(recovered_cells_list, i, cell_bytes);
+  }
+
+  /* Success! */
+  ret = recovered_cells_list;
+
+out:
+  free(cell_indices);
+  free(cells);
+  free(recovered_cells);
+  return ret;
+}
+
 static PyObject *recover_cells_and_kzg_proofs_wrap(PyObject *self,
                                                    PyObject *args) {
   PyObject *input_cell_indices, *input_cells, *s;
@@ -797,6 +919,8 @@ static PyMethodDef ckzgmethods[] = {
      "Compute cells for a blob"},
     {"compute_cells_and_kzg_proofs", compute_cells_and_kzg_proofs_wrap,
      METH_VARARGS, "Compute cells and proofs for a blob"},
+    {"recover_cells", recover_cells_wrap, METH_VARARGS,
+     "Recover missing cells"},
     {"recover_cells_and_kzg_proofs", recover_cells_and_kzg_proofs_wrap,
      METH_VARARGS, "Recover missing cells and proofs"},
     {"verify_cell_kzg_proof_batch", verify_cell_kzg_proof_batch_wrap,

--- a/bindings/python/tests.py
+++ b/bindings/python/tests.py
@@ -207,6 +207,27 @@ def test_compute_cells_and_kzg_proofs(ts):
         assert proofs == expected_proofs, f"{test_file}\n{cells=}\n{expected_proofs=}"
 
 
+def test_recover_cells(ts):
+    test_files = glob.glob(RECOVER_CELLS_AND_KZG_PROOFS_TESTS)
+    assert len(test_files) > 0
+
+    for test_file in test_files:
+        with open(test_file, "r") as f:
+            test = yaml.safe_load(f)
+
+        cell_indices = test["input"]["cell_indices"]
+        cells = list(map(bytes_from_hex, test["input"]["cells"]))
+
+        try:
+            recovered_cells = ckzg.recover_cells(cell_indices, cells, ts)
+        except:
+            assert test["output"] is None
+            continue
+
+        expected_cells = list(map(bytes_from_hex, test["output"][0]))
+        assert recovered_cells == expected_cells, f"{test_file}\n{cells=}\n{expected_cells=}"
+
+
 def test_recover_cells_and_kzg_proofs(ts):
     test_files = glob.glob(RECOVER_CELLS_AND_KZG_PROOFS_TESTS)
     assert len(test_files) > 0
@@ -269,6 +290,7 @@ if __name__ == "__main__":
 
     test_compute_cells(ts)
     test_compute_cells_and_kzg_proofs(ts)
+    test_recover_cells(ts)
     test_recover_cells_and_kzg_proofs(ts)
     test_verify_cell_kzg_proof_batch(ts)
 

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -479,6 +479,40 @@ impl KZGSettings {
         }
     }
 
+    pub fn recover_cells(
+        &self,
+        cell_indices: &[u64],
+        cells: &[Cell],
+    ) -> Result<Box<CellsPerExtBlob>, Error> {
+        if cell_indices.len() != cells.len() {
+            return Err(Error::MismatchLength(format!(
+                "There are {} cell indices and {} cells",
+                cell_indices.len(),
+                cells.len()
+            )));
+        }
+        let mut recovered_cells: Box<[Cell; CELLS_PER_EXT_BLOB]> =
+            vec![Cell::default(); CELLS_PER_EXT_BLOB]
+                .into_boxed_slice()
+                .try_into()
+                .unwrap();
+        unsafe {
+            let res = recover_cells_and_kzg_proofs(
+                recovered_cells.as_mut_ptr(),
+                ptr::null_mut(),
+                cell_indices.as_ptr(),
+                cells.as_ptr(),
+                cells.len() as u64,
+                self,
+            );
+            if let C_KZG_RET::C_KZG_OK = res {
+                Ok(recovered_cells)
+            } else {
+                Err(Error::CError(res))
+            }
+        }
+    }
+
     pub fn recover_cells_and_kzg_proofs(
         &self,
         cell_indices: &[u64],
@@ -1369,6 +1403,38 @@ mod tests {
                     let proofs_as_bytes: Vec<Bytes48> =
                         proofs.iter().map(|p| p.to_bytes()).collect();
                     assert_eq!(proofs_as_bytes, expected_proofs);
+                }
+                _ => assert!(test.get_output().is_none()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_recover_cells() {
+        let trusted_setup_file = Path::new("src/trusted_setup.txt");
+        assert!(trusted_setup_file.exists());
+        let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file, 0).unwrap();
+        let test_files: Vec<PathBuf> = glob::glob(RECOVER_CELLS_AND_KZG_PROOFS_TESTS)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert!(!test_files.is_empty());
+
+        for test_file in test_files.iter() {
+            let yaml_data = fs::read_to_string(test_file).unwrap();
+            let test: recover_cells_and_kzg_proofs::Test =
+                serde_yaml::from_str(&yaml_data).unwrap();
+            let (Ok(cell_indices), Ok(cells)) =
+                (test.input.get_cell_indices(), test.input.get_cells())
+            else {
+                assert!(test.get_output().is_none());
+                continue;
+            };
+
+            match kzg_settings.recover_cells(&cell_indices, &cells) {
+                Ok(recovered_cells) => {
+                    let (expected_cells, _) = test.get_output().unwrap();
+                    assert_eq!(recovered_cells.as_slice(), expected_cells);
                 }
                 _ => assert!(test.get_output().is_none()),
             }

--- a/bindings/zig/src/root.zig
+++ b/bindings/zig/src/root.zig
@@ -196,6 +196,25 @@ pub const Settings = struct {
         ));
     }
 
+    pub fn recoverCells(
+        self: *const Settings,
+        recovered_cells: *[CELLS_PER_EXT_BLOB]Cell,
+        cell_indices: []const u64,
+        cells: []const Cell,
+    ) !void {
+        try self.ensureLoaded();
+        if (cell_indices.len != cells.len) return error.LengthMismatch;
+
+        try checkRet(c.recover_cells_and_kzg_proofs(
+            recovered_cells,
+            null,
+            sliceConstPtr(u64, cell_indices),
+            sliceConstPtr(Cell, cells),
+            cell_indices.len,
+            &self.inner,
+        ));
+    }
+
     pub fn recoverCellsAndKzgProofs(
         self: *const Settings,
         recovered_cells: *[CELLS_PER_EXT_BLOB]Cell,

--- a/bindings/zig/src/tests.zig
+++ b/bindings/zig/src/tests.zig
@@ -309,6 +309,42 @@ test "compute_cells_and_kzg_proofs" {
     }
 }
 
+test "recover_cells" {
+    var s = try loadSettings();
+    defer s.deinit();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = std.testing.io;
+
+    const Test = struct {
+        input: struct {
+            cell_indices: []u64,
+            cells: [][]const u8,
+        },
+        output: ?[2][][]const u8, // [recovered_cells[128], recovered_proofs[128]]
+    };
+
+    for (try collectCases(io, alloc, "recover_cells_and_kzg_proofs")) |path| {
+        const text = try std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .unlimited);
+        const tc = (try std.json.parseFromSlice(Test, alloc, text, .{})).value;
+        var recovered_cells: [ckzg.CELLS_PER_EXT_BLOB]ckzg.Cell = undefined;
+        const result: anyerror!void = blk: {
+            const input_cells = try alloc.alloc(ckzg.Cell, tc.input.cells.len);
+            for (tc.input.cells, input_cells) |hex, *c| c.* = hexToStruct(ckzg.Cell, hex) catch |e| break :blk e;
+            break :blk s.recoverCells(&recovered_cells, tc.input.cell_indices, input_cells);
+        };
+        if (tc.output == null) {
+            if (result) |_| return error.TestExpectedError else |_| {}
+        } else {
+            try result;
+            for (tc.output.?[0], 0..) |hex, i| {
+                try std.testing.expectEqualSlices(u8, &(try hexToStruct(ckzg.Cell, hex)).bytes, &recovered_cells[i].bytes);
+            }
+        }
+    }
+}
+
 test "recover_cells_and_kzg_proofs" {
     var s = try loadSettings();
     defer s.deinit();


### PR DESCRIPTION
I am working on a separate library which uses a GPU to compute cell KZG proofs. In order to use that when recovering cells/proofs, clients will need the ability to recover cells (ie blobs) and *not* the proofs, so that the other library can handle that part. For that reason, this PR introduces a "recover cells" function to all of the bindings.