### PR TITLE
perf(fft): iterative in-place fr_fft with staged twiddle lookup

### DIFF
--- a/src/eip7594/fft.c
+++ b/src/eip7594/fft.c
@@ -58,30 +58,60 @@ static const fr_t INV_RECOVERY_SHIFT_FACTOR = {
 /**
  * Fast Fourier Transform.
  *
- * Recursively divide and conquer.
+ * Iterative decimation-in-time: gather the input in bit-reversed order, then run log2(n) stages
+ * of in-place butterflies over blocks of doubling size. The roots table is in natural order and
+ * spans the full domain, so it already holds every twiddle at every power-of-two stride; each
+ * stage just reads it at a larger step. The first twiddle of every block is w^0 = 1, so that
+ * butterfly is a plain add/sub, saving n - 1 of the (n/2) * log2(n) multiplications.
  *
  * @param[out]  out             The results, length `n`
- * @param[in]   in              The input data, length `n * stride`
- * @param[in]   stride          The input data stride
+ * @param[in]   in              The input data, length `n`
  * @param[in]   roots           Roots of unity, length `n * roots_stride`
  * @param[in]   roots_stride    The stride interval among the roots of unity
  * @param[in]   n               Length of the FFT, must be a power of two
+ *
+ * @remark The input and output arrays must not overlap.
  */
 static void fr_fft_fast(
-    fr_t *out, const fr_t *in, size_t stride, const fr_t *roots, size_t roots_stride, size_t n
+    fr_t *out, const fr_t *in, const fr_t *roots, size_t roots_stride, size_t n
 ) {
-    size_t half = n / 2;
-    if (half > 0) {
-        fr_t y_times_root;
-        fr_fft_fast(out, in, stride * 2, roots, roots_stride * 2, half);
-        fr_fft_fast(out + half, in + stride, stride * 2, roots, roots_stride * 2, half);
-        for (size_t i = 0; i < half; i++) {
-            fr_mul(&y_times_root, &out[i + half], &roots[i * roots_stride]);
-            fr_sub(&out[i + half], &out[i], &y_times_root);
-            fr_add(&out[i], &out[i], &y_times_root);
+    if (n < 2) {
+        if (n == 1) *out = *in;
+        return;
+    }
+
+    /*
+     * Copy the input to the output in bit-reversed order. The read index j visits the
+     * bit-reversed values of i: incrementing i by one corresponds to incrementing j as a
+     * log2(n)-bit counter whose carries propagate from the most significant bit downwards,
+     * which costs O(n) in total rather than reversing every index from scratch.
+     */
+    out[0] = in[0];
+    for (size_t i = 1, j = 0; i < n; i++) {
+        size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) {
+            j ^= bit;
         }
-    } else {
-        *out = *in;
+        j ^= bit;
+        out[i] = in[j];
+    }
+
+    /* One stage per level of the butterfly, for block sizes 2, 4, ..., n */
+    for (size_t m = 2; m <= n; m *= 2) {
+        size_t half = m / 2;
+        size_t twiddle_stride = roots_stride * (n / m);
+        for (size_t k = 0; k < n; k += m) {
+            fr_t y_times_root;
+            /* The j = 0 butterfly has twiddle w^0 = 1, so skip the multiplication */
+            y_times_root = out[k + half];
+            fr_sub(&out[k + half], &out[k], &y_times_root);
+            fr_add(&out[k], &out[k], &y_times_root);
+            for (size_t j = 1; j < half; j++) {
+                fr_mul(&y_times_root, &out[k + j + half], &roots[j * twiddle_stride]);
+                fr_sub(&out[k + j + half], &out[k + j], &y_times_root);
+                fr_add(&out[k + j], &out[k + j], &y_times_root);
+            }
+        }
     }
 }
 
@@ -107,7 +137,7 @@ C_KZG_RET fr_fft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
     }
 
     size_t roots_stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
-    fr_fft_fast(out, in, 1, s->roots_of_unity, roots_stride, n);
+    fr_fft_fast(out, in, s->roots_of_unity, roots_stride, n);
 
     return C_KZG_OK;
 }
@@ -134,7 +164,7 @@ C_KZG_RET fr_ifft(fr_t *out, const fr_t *in, size_t n, const KZGSettings *s) {
     }
 
     size_t stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
-    fr_fft_fast(out, in, 1, s->reverse_roots_of_unity, stride, n);
+    fr_fft_fast(out, in, s->reverse_roots_of_unity, stride, n);
 
     fr_t inv_n;
     fr_from_uint64(&inv_n, n);

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -1685,6 +1685,78 @@ static void test_expand_root_of_unity__fails_wrong_root_of_unity(void) {
 // Tests for reconstruction
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * The recursive divide-and-conquer FFT that fr_fft_fast() replaced, kept as a reference
+ * implementation. Field operations are exact, and the iterative version changes only the
+ * evaluation order and skips multiplications by w^0 = 1, both of which preserve exactness, so its
+ * output must be bit-identical to this one.
+ */
+static void reference_fr_fft_recursive(
+    fr_t *out, const fr_t *in, size_t stride, const fr_t *roots, size_t roots_stride, size_t n
+) {
+    size_t half = n / 2;
+    if (half > 0) {
+        fr_t y_times_root;
+        reference_fr_fft_recursive(out, in, stride * 2, roots, roots_stride * 2, half);
+        reference_fr_fft_recursive(
+            out + half, in + stride, stride * 2, roots, roots_stride * 2, half
+        );
+        for (size_t i = 0; i < half; i++) {
+            fr_mul(&y_times_root, &out[i + half], &roots[i * roots_stride]);
+            fr_sub(&out[i + half], &out[i], &y_times_root);
+            fr_add(&out[i], &out[i], &y_times_root);
+        }
+    } else {
+        *out = *in;
+    }
+}
+
+static void test_fr_fft__matches_recursive_reference(void) {
+    C_KZG_RET ret;
+    /* Static so the four full-size arrays don't overflow the stack frame limit */
+    static fr_t input[FIELD_ELEMENTS_PER_EXT_BLOB];
+    static fr_t expected[FIELD_ELEMENTS_PER_EXT_BLOB];
+    static fr_t actual[FIELD_ELEMENTS_PER_EXT_BLOB];
+    static fr_t roundtrip[FIELD_ELEMENTS_PER_EXT_BLOB];
+    int diff;
+
+    for (size_t n = 1; n <= FIELD_ELEMENTS_PER_EXT_BLOB; n *= 2) {
+        size_t roots_stride = FIELD_ELEMENTS_PER_EXT_BLOB / n;
+
+        for (size_t i = 0; i < n; i++) {
+            get_rand_fr(&input[i]);
+        }
+
+        /* The forward transform must be bit-identical to the recursive reference */
+        reference_fr_fft_recursive(expected, input, 1, s.roots_of_unity, roots_stride, n);
+        ret = fr_fft(actual, input, n, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+        diff = memcmp(expected, actual, n * sizeof(fr_t));
+        ASSERT_EQUALS(diff, 0);
+
+        /* The inverse transform must be bit-identical to the reference plus the 1/n scaling */
+        reference_fr_fft_recursive(expected, input, 1, s.reverse_roots_of_unity, roots_stride, n);
+        fr_t inv_n;
+        fr_from_uint64(&inv_n, n);
+        fr_inv(&inv_n, &inv_n);
+        for (size_t i = 0; i < n; i++) {
+            fr_mul(&expected[i], &expected[i], &inv_n);
+        }
+        ret = fr_ifft(actual, input, n, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+        diff = memcmp(expected, actual, n * sizeof(fr_t));
+        ASSERT_EQUALS(diff, 0);
+
+        /* The inverse transform must invert the forward transform exactly */
+        ret = fr_fft(actual, input, n, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+        ret = fr_ifft(roundtrip, actual, n, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+        diff = memcmp(input, roundtrip, n * sizeof(fr_t));
+        ASSERT_EQUALS(diff, 0);
+    }
+}
+
 static void test_fft(void) {
     // TODO: Breaks with N=4096 or N=128 which are used in the protocol (see
     // issue 444)
@@ -2358,6 +2430,7 @@ int main(void) {
     RUN(test_expand_root_of_unity__succeeds_with_root);
     RUN(test_expand_root_of_unity__fails_not_root_of_unity);
     RUN(test_expand_root_of_unity__fails_wrong_root_of_unity);
+    RUN(test_fr_fft__matches_recursive_reference);
     RUN(test_fft);
     RUN(test_coset_fft);
     RUN(test_deduplicate_commitments__one_duplicate);


### PR DESCRIPTION
Note: this PR is part of a set of changes coming out of my AI-assisted performance investigation of the
EIP-7594 libraries. The analysis and implementation were done with Anthropic's Claude (Opus/Fable), and
cross-reviewed with OpenAI's Codex (GPT-5.6). The change is differential-tested against the previous
implementation, which is kept as a reference in the test suite — byte-for-byte across every power-of-two size
from 1 to 8192 — clean under the sanitizers and the static analyzer, and the consensus spec vectors pass
through the bindings.

This is a small PR, and it only touches the scalar-field FFT:
`compute_cells`: **2.50 ms → 2.32 ms** (−7%); the transform itself: **0.95 ms → 0.82 ms** (−14%) at n=8192.

## Summary

`fr_fft_fast` is the classic recursive formulation: each level recurses twice with doubled strides and writes
out of place, and every butterfly pays a `blst_fr_mul` — including the ones whose twiddle is `w^0 = 1`.

This makes it iterative: one O(n) pass gathers the input in bit-reversed order (an amortized reversed-carry
counter, not a per-element bit reversal — the per-element version measures *slower* than the recursion), then
log2(n) stages of in-place butterflies. **No new tables**: the existing natural-order `roots_of_unity` array
already contains every twiddle at every power-of-two stride, so each stage just reads it at a different step.
The `j = 0` butterfly skips its multiplication, which removes `n − 1` of the `(n/2)·log2(n)` multiplications —
**15.4% of them at n=8192** — and is exact, so output is byte-identical, not merely equivalent.

`fr_ifft` shares the core; its final 1/n scaling is unchanged. The G1 FFT is not touched.

One internal simplification fell out: the recursive helper's `stride` parameter is gone. Its non-recursive
entry calls only ever passed 1 — the strides of 2, 4, … existed only inside the recursion's own even/odd
traversal, which the bit-reversed gather replaces — and the in/out no-overlap contract the callers (recovery,
fk20, eip7594, poly) already satisfied is now documented on the helper.

## What this is and isn't

Motivation for calibration: go-eth-kzg recently delegated its scalar FFT to gnark-crypto's iterative
staged-twiddle implementation, and on the same machine its RS encode runs 1.60 ms against this library's 2.50.
This PR ports the *structural* part of that difference — iteration order, in-place stages, table lookup,
skipped identity multiplications — and that part is worth the ~14% here. The remainder of the gap lives in
gnark's fused add/sub butterfly assembly and per-operation field arithmetic, which cannot be ported without
changes to blst itself, so this PR deliberately does not chase it. The proof-bearing calls
(`compute_cells_and_kzg_proofs`, recovery-plus-proofs) are elliptic-curve-dominated and do not move.

## Correctness

- **Structurally the same butterfly DAG, and differential-tested byte-for-byte.** The equivalence argument is
  that only the scheduling of independent butterflies changes and the skipped multiplications are by the exact
  Montgomery one; the test pins it: the recursive implementation survives as `reference_fr_fft_recursive` in
  `tests.c`, and `test_fr_fft__matches_recursive_reference` compares `fr_fft` and `fr_ifft` against it with
  `memcmp` for every power-of-two size 1..8192, plus an `ifft(fft(x)) == x` roundtrip, with the suite's
  deterministic RNG.
- **The consensus spec vectors pass** through the Go bindings (run with a fresh build cache).
- `make test` 94/94; address and undefined sanitizers pass; `make analyze` clean; clang-format clean.

## Benchmarks

Apple M1, Go bindings at `precompute=6`, interleaved prebuilt binaries, medians of 6:

| | main | this PR | |
|---|---:|---:|---|
| `fr_fft`, n=8192 (C, `-O2`) | 0.95 ms | **0.82 ms** | −14% |
| `fr_ifft`, n=8192 | 1.05 ms | **0.93 ms** | −11% |
| `ComputeCells` | 2.504 ms | **2.323 ms** | −7.2% |
| `ComputeCellsAndKZGProofs` | 206.1 ms | 206.5 ms | ~ |
| `RecoverCellsAndKZGProofs` | 224.9 ms | 225.7 ms | ~ |

The last two *should* be unchanged — they are EC-dominated — and that they are is a check on the measurement.

## Limits

- Measured on one machine, `darwin/arm64`. Not reproduced elsewhere.
- This is a minor win stated as such: ~14% of the transform, −7% on the one API call that is FFT-bound.
- Independent of the recovery PR from the same investigation: the two merge cleanly (no shared hunks), and
  measured together recovery-plus-proofs goes 224.9 → 208.9 ms (the recovery PR's contribution; this PR's share
  there is within noise).
