### PR TITLE
Reformulate verify_kzg_proof to drop the G2 scalar multiplication

### DIFF
--- a/src/eip4844/eip4844.c
+++ b/src/eip4844/eip4844.c
@@ -105,32 +105,6 @@ static C_KZG_RET fr_batch_inv(fr_t *out, const fr_t *a, int len) {
     return C_KZG_OK;
 }
 
-/**
- * Multiply a G2 group element by a field element.
- *
- * @param[out]  out The result, `a * b`
- * @param[in]   a   The G2 group element
- * @param[in]   b   The multiplier
- */
-static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
-    blst_scalar s;
-    blst_scalar_from_fr(&s, b);
-    blst_p2_mult(out, a, s.b, BITS_PER_FIELD_ELEMENT);
-}
-
-/**
- * Subtraction of G2 group elements.
- *
- * @param[out]  out The result, `a - b`
- * @param[in]   a   A G2 group element
- * @param[in]   b   The G2 group element to be subtracted
- */
-static void g2_sub(g2_t *out, const g2_t *a, const g2_t *b) {
-    g2_t bneg = *b;
-    blst_p2_cneg(&bneg, true);
-    blst_p2_add_or_double(out, a, &bneg);
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // BLS12-381 Helper Functions
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -348,19 +322,31 @@ static C_KZG_RET verify_kzg_proof_impl(
     const g1_t *proof,
     const KZGSettings *s
 ) {
-    g2_t x_g2, X_minus_z;
-    g1_t y_g1, P_minus_y;
+    g1_t y_g1, P_minus_y, z_proof, rhs_g1;
 
-    /* Calculate: X_minus_z */
-    g2_mul(&x_g2, blst_p2_generator(), z);
-    g2_sub(&X_minus_z, &s->g2_values_monomial[1], &x_g2);
+    /*
+     * Verify: P - y = Q * (X - z)
+     *
+     * The straightforward pairing check e(P - [y], [1]) == e(Q, [X] - [z]) needs a per-call G2
+     * scalar multiplication to compute [z]. Moving z to the G1 side via bilinearity,
+     * e(Q, -[z]) == e(-z * Q, [1]), gives the equivalent check
+     *
+     *   e(P - [y] + z * Q, [1]) == e(Q, [X])
+     *
+     * whose G2 inputs are both constants, replacing the G2 scalar multiplication (and G2
+     * subtraction) with a cheaper G1 one. This is the same form used by verify_kzg_proof_batch().
+     */
 
     /* Calculate: P_minus_y */
     g1_mul(&y_g1, blst_p1_generator(), y);
     g1_sub(&P_minus_y, commitment, &y_g1);
 
-    /* Verify: P - y = Q * (X - z) */
-    *ok = pairings_verify(&P_minus_y, blst_p2_generator(), proof, &X_minus_z);
+    /* Calculate: P_minus_y + z * Q */
+    g1_mul(&z_proof, proof, z);
+    g1_add(&rhs_g1, &P_minus_y, &z_proof);
+
+    /* Verify: e(Q, [X]) == e(P - [y] + z * Q, [1]) */
+    *ok = pairings_verify(proof, &s->g2_values_monomial[1], &rhs_g1, blst_p2_generator());
 
     return C_KZG_OK;
 }

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -83,6 +83,13 @@ static void get_rand_g2(g2_t *out) {
     blst_hash_to_g2(out, tmp_bytes.bytes, 32, NULL, 0, NULL, 0);
 }
 
+/** Multiply a G2 group element by a field element. */
+static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
+    blst_scalar s;
+    blst_scalar_from_fr(&s, b);
+    blst_p2_mult(out, a, s.b, BITS_PER_FIELD_ELEMENT);
+}
+
 static void bytes32_from_hex(Bytes32 *out, const char *hex) {
     int matches;
     for (size_t i = 0; i < sizeof(Bytes32); i++) {
@@ -1330,6 +1337,65 @@ static void test_verify_kzg_proof__fails_y_not_field_element(void) {
     ASSERT_EQUALS(ret, C_KZG_BADARGS);
 }
 
+static void test_verify_kzg_proof__fails_tampered_y(void) {
+    C_KZG_RET ret;
+    Bytes48 proof;
+    Bytes32 z, y;
+    KZGCommitment c;
+    Blob blob;
+    bool ok;
+
+    get_rand_field_element(&z);
+    get_rand_blob(&blob);
+
+    /* Get a commitment to that particular blob */
+    ret = blob_to_kzg_commitment(&c, &blob, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    /* Compute the proof and the correct evaluation y */
+    ret = compute_kzg_proof(&proof, &y, &blob, &z, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    /*
+     * Flip the lowest bit of the correct evaluation. The result is still canonical (only
+     * y == BLS_MODULUS - 1 could overflow, which a random y is not), so it must be rejected by the
+     * pairing check itself, not the field-element check. All points are finite, so this pins the
+     * pairing check to the exact evaluation relation.
+     */
+    y.bytes[31] ^= 1;
+
+    ret = verify_kzg_proof(&ok, &c, &z, &y, &proof, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+    ASSERT_EQUALS(ok, false);
+}
+
+static void test_verify_kzg_proof__fails_infinity_rhs_finite_proof(void) {
+    C_KZG_RET ret;
+    Bytes48 proof;
+    KZGCommitment c;
+    Bytes32 z, y;
+    bool ok;
+
+    /*
+     * With commitment = proof = the G1 generator, y = 0 and z = BLS_MODULUS - 1, the pairing-check
+     * point commitment - [y] + z * proof = G1 + [BLS_MODULUS - 1]G1 is the point at infinity while
+     * the proof is finite. Such a claim is only valid if the proof is infinity too, so this must
+     * be rejected: it exercises the infinity handling of the G1-side pairing input.
+     */
+    bytes48_from_hex(
+        &c,
+        "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905"
+        "a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+    );
+    proof = c;
+    bytes32_from_hex(&z, "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000");
+    bytes32_from_hex(&y, "0000000000000000000000000000000000000000000000000000000000000000");
+
+    ret = verify_kzg_proof(&ok, &c, &z, &y, &proof, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+    ASSERT_EQUALS(ok, false);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Tests for compute_blob_kzg_proof
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2343,6 +2409,8 @@ int main(void) {
     RUN(test_verify_kzg_proof__fails_commitment_not_in_g1);
     RUN(test_verify_kzg_proof__fails_z_not_field_element);
     RUN(test_verify_kzg_proof__fails_y_not_field_element);
+    RUN(test_verify_kzg_proof__fails_tampered_y);
+    RUN(test_verify_kzg_proof__fails_infinity_rhs_finite_proof);
     RUN(test_compute_and_verify_blob_kzg_proof__succeeds_round_trip);
     RUN(test_compute_and_verify_blob_kzg_proof__fails_incorrect_proof);
     RUN(test_compute_and_verify_blob_kzg_proof__fails_proof_not_in_g1);

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -85,9 +85,9 @@ static void get_rand_g2(g2_t *out) {
 
 /** Multiply a G2 group element by a field element. */
 static void g2_mul(g2_t *out, const g2_t *a, const fr_t *b) {
-    blst_scalar s;
-    blst_scalar_from_fr(&s, b);
-    blst_p2_mult(out, a, s.b, BITS_PER_FIELD_ELEMENT);
+    blst_scalar scalar;
+    blst_scalar_from_fr(&scalar, b);
+    blst_p2_mult(out, a, scalar.b, BITS_PER_FIELD_ELEMENT);
 }
 
 static void bytes32_from_hex(Bytes32 *out, const char *hex) {


### PR DESCRIPTION
Move `z` from G2 to G1 in the single-proof pairing check via bilinearity `e(Q, -[z]) = e(-z·Q, [1])`, so both G2 pairing inputs collapse to constants (the G2 generator and `[X] = s->g2_values_monomial[1]`):

```
e(P - [y] + z·Q, [1]) == e(Q, [X])
```

This replaces the per-call G2 scalar multiplication (and the G2 subtraction) with a single cheaper G1 scalar multiplication.

Notably, c-kzg already uses this reformulation in one place: [`verify_kzg_proof_batch`](https://github.com/ethereum/c-kzg-4844/blob/b7e4098813e02c866d8def4e88524be8a6bedc7f/src/eip4844/eip4844.c#L733-L751) computes `rhs = Σ rⁱ(Cᵢ - [yᵢ]) + Σ rⁱzᵢQᵢ` and checks `e(Σ rⁱQᵢ, [X]) == e(rhs, [1])`. The new single-proof code mirrors it completely — same helpers (`g1_mul` on the generator for `[y]`, `g1_sub`, `g1_add`), same operand order, same two constant G2 inputs, and the same `pairings_verify` argument order — making it exactly the n = 1 specialization (where r⁰ = 1, and the one-element lincomb is a direct scalar multiplication). So the single-proof and batch paths now perform the same check, and the now-dead `g2_mul`/`g2_sub` helpers are removed from `eip4844.c` (`g2_mul` moves into `tests.c`, which still uses it for the `pairings_verify` tests).

Infinity semantics are unchanged: `pairings_verify` uses the per-pair `blst_miller_loop`, which handles infinity, and an infinity proof still degenerates to the same `commitment == [y]` condition as before.

Tests: adds an all-finite tampered-`y` rejection (pins the pairing check to the exact evaluation relation rather than the field-element guards) and an infinity-rhs/finite-proof rejection (commitment = proof = G1 generator, `y = 0`, `z = r - 1`, making `P - [y] + z·Q` the point at infinity while the proof is finite — valid only if the proof is infinity too, so it must be rejected). Full unit suite and the official reference vectors (via the Rust bindings) pass.

Quick benchmark (portable blst build, 2000 iters on the reference vector, interleaved runs): ~632–639 µs/op before, ~590–615 µs/op after, roughly a 4–7% speedup of the full `verify_kzg_proof` call. A natural follow-up would be caching Miller-loop line preparation for the two now-constant G2 points.

This mirrors the equivalent change made in revm (bluealloy/revm#3836).