### PR TITLE
perf(eip7594): compute the extension with a half-size coset FFT

### DIFF
--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -64,7 +64,6 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     C_KZG_RET ret;
     fr_t *poly_monomial = NULL;
     fr_t *poly_lagrange = NULL;
-    fr_t *poly_shifted = NULL;
     fr_t *data_fr = NULL;
     g1_t *proofs_g1 = NULL;
     blst_p1_affine *proofs_affine = NULL;
@@ -112,14 +111,17 @@ C_KZG_RET compute_cells_and_kzg_proofs(
         /* The first half of the data points is the blob's own evaluations */
         memcpy(data_fr, poly_lagrange, FIELD_ELEMENTS_PER_BLOB * sizeof(fr_t));
 
-        /* Scale each coefficient by successive powers of w to shift the evaluation domain */
-        ret = new_fr_array(&poly_shifted, FIELD_ELEMENTS_PER_BLOB);
-        if (ret != C_KZG_OK) goto out;
-        memcpy(poly_shifted, poly_monomial, FIELD_ELEMENTS_PER_BLOB * sizeof(fr_t));
-        shift_poly(poly_shifted, FIELD_ELEMENTS_PER_BLOB, &s->roots_of_unity[1]);
+        /*
+         * Scale each coefficient by successive powers of w to shift the evaluation domain. The
+         * lagrange-form buffer is dead after the copy above, so reuse it as scratch for the
+         * shifted coefficients instead of allocating a new array. Proof generation below only
+         * reads poly_monomial, which stays unmodified.
+         */
+        memcpy(poly_lagrange, poly_monomial, FIELD_ELEMENTS_PER_BLOB * sizeof(fr_t));
+        shift_poly(poly_lagrange, FIELD_ELEMENTS_PER_BLOB, &s->roots_of_unity[1]);
 
         /* Evaluate over the coset with a half-size transformation */
-        ret = fr_fft(&data_fr[FIELD_ELEMENTS_PER_BLOB], poly_shifted, FIELD_ELEMENTS_PER_BLOB, s);
+        ret = fr_fft(&data_fr[FIELD_ELEMENTS_PER_BLOB], poly_lagrange, FIELD_ELEMENTS_PER_BLOB, s);
         if (ret != C_KZG_OK) goto out;
 
         /* Bit-reverse the coset evaluations; the first half is already bit-reversed */
@@ -168,7 +170,6 @@ C_KZG_RET compute_cells_and_kzg_proofs(
 out:
     c_kzg_free(poly_monomial);
     c_kzg_free(poly_lagrange);
-    c_kzg_free(poly_shifted);
     c_kzg_free(data_fr);
     c_kzg_free(proofs_g1);
     c_kzg_free(proofs_affine);

--- a/src/eip7594/eip7594.c
+++ b/src/eip7594/eip7594.c
@@ -64,6 +64,7 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     C_KZG_RET ret;
     fr_t *poly_monomial = NULL;
     fr_t *poly_lagrange = NULL;
+    fr_t *poly_shifted = NULL;
     fr_t *data_fr = NULL;
     g1_t *proofs_g1 = NULL;
     blst_p1_affine *proofs_affine = NULL;
@@ -74,17 +75,12 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     }
 
     /* Allocate space fr-form arrays */
-    ret = new_fr_array(&poly_monomial, FIELD_ELEMENTS_PER_EXT_BLOB);
+    ret = new_fr_array(&poly_monomial, FIELD_ELEMENTS_PER_BLOB);
     if (ret != C_KZG_OK) goto out;
-    ret = new_fr_array(&poly_lagrange, FIELD_ELEMENTS_PER_EXT_BLOB);
+    ret = new_fr_array(&poly_lagrange, FIELD_ELEMENTS_PER_BLOB);
     if (ret != C_KZG_OK) goto out;
 
-    /*
-     * Convert the blob to a polynomial in lagrange form. Note that only the first 4096 fields of
-     * the polynomial will be set. The upper 4096 fields will remain zero. The extra space is
-     * required because the polynomial will be evaluated to the extended domain (8192 roots of
-     * unity).
-     */
+    /* Convert the blob to a polynomial in lagrange form */
     ret = blob_to_polynomial(poly_lagrange, blob);
     if (ret != C_KZG_OK) goto out;
 
@@ -92,22 +88,44 @@ C_KZG_RET compute_cells_and_kzg_proofs(
     ret = poly_lagrange_to_monomial(poly_monomial, poly_lagrange, FIELD_ELEMENTS_PER_BLOB, s);
     if (ret != C_KZG_OK) goto out;
 
-    /* Ensure that only the first FIELD_ELEMENTS_PER_BLOB elements can be non-zero */
-    for (size_t i = FIELD_ELEMENTS_PER_BLOB; i < FIELD_ELEMENTS_PER_EXT_BLOB; i++) {
-        assert(fr_equal(&poly_monomial[i], &FR_ZERO));
-    }
-
     if (cells != NULL) {
         /* Allocate space for our data points */
         ret = new_fr_array(&data_fr, FIELD_ELEMENTS_PER_EXT_BLOB);
         if (ret != C_KZG_OK) goto out;
 
-        /* Get the data points via forward transformation */
-        ret = fr_fft(data_fr, poly_monomial, FIELD_ELEMENTS_PER_EXT_BLOB, s);
+        /*
+         * Evaluate the polynomial over the extended domain (the 8192nd roots of unity). Doing
+         * this directly would be a size-8192 FFT of the zero-padded polynomial, but the extended
+         * domain is the disjoint union of the blob's own domain (the 4096th roots of unity, i.e.
+         * the even powers of w = roots_of_unity[1]) and its coset (the odd powers of w). In the
+         * bit-reversed ordering used for cells, the evaluations over the even powers form the
+         * first half of the output and those over the odd powers form the second half. So:
+         *
+         *   - The first half is the blob itself: its lagrange form is these very evaluations,
+         *     already in bit-reversed order.
+         *   - The second half is a single size-4096 coset FFT: scale coefficient k by w^k, then
+         *     apply a forward FFT over the blob's domain.
+         *
+         * This produces output that is bit-identical to the full-size FFT.
+         */
+
+        /* The first half of the data points is the blob's own evaluations */
+        memcpy(data_fr, poly_lagrange, FIELD_ELEMENTS_PER_BLOB * sizeof(fr_t));
+
+        /* Scale each coefficient by successive powers of w to shift the evaluation domain */
+        ret = new_fr_array(&poly_shifted, FIELD_ELEMENTS_PER_BLOB);
+        if (ret != C_KZG_OK) goto out;
+        memcpy(poly_shifted, poly_monomial, FIELD_ELEMENTS_PER_BLOB * sizeof(fr_t));
+        shift_poly(poly_shifted, FIELD_ELEMENTS_PER_BLOB, &s->roots_of_unity[1]);
+
+        /* Evaluate over the coset with a half-size transformation */
+        ret = fr_fft(&data_fr[FIELD_ELEMENTS_PER_BLOB], poly_shifted, FIELD_ELEMENTS_PER_BLOB, s);
         if (ret != C_KZG_OK) goto out;
 
-        /* Bit-reverse the data points */
-        ret = bit_reversal_permutation(data_fr, sizeof(fr_t), FIELD_ELEMENTS_PER_EXT_BLOB);
+        /* Bit-reverse the coset evaluations; the first half is already bit-reversed */
+        ret = bit_reversal_permutation(
+            &data_fr[FIELD_ELEMENTS_PER_BLOB], sizeof(fr_t), FIELD_ELEMENTS_PER_BLOB
+        );
         if (ret != C_KZG_OK) goto out;
 
         /* Convert all of the cells to byte-form */
@@ -150,6 +168,7 @@ C_KZG_RET compute_cells_and_kzg_proofs(
 out:
     c_kzg_free(poly_monomial);
     c_kzg_free(poly_lagrange);
+    c_kzg_free(poly_shifted);
     c_kzg_free(data_fr);
     c_kzg_free(proofs_g1);
     c_kzg_free(proofs_affine);

--- a/src/test/tests.c
+++ b/src/test/tests.c
@@ -1891,6 +1891,110 @@ static void test_shift_factors__succeeds(void) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Tests for compute_cells_and_kzg_proofs
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Reference implementation of the cell computation, the shape used before the half-FFT
+ * optimization: convert the blob to monomial form, zero-pad to the extended domain, apply a full
+ * size-8192 FFT, and bit-reverse the result.
+ */
+static C_KZG_RET reference_compute_cells(Cell *cells, const Blob *blob) {
+    C_KZG_RET ret;
+    fr_t *poly_monomial = NULL;
+    fr_t *poly_lagrange = NULL;
+    fr_t *data_fr = NULL;
+
+    /* new_fr_array zero-initializes, so the upper half of poly_monomial stays zero */
+    ret = new_fr_array(&poly_monomial, FIELD_ELEMENTS_PER_EXT_BLOB);
+    if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&poly_lagrange, FIELD_ELEMENTS_PER_EXT_BLOB);
+    if (ret != C_KZG_OK) goto out;
+    ret = new_fr_array(&data_fr, FIELD_ELEMENTS_PER_EXT_BLOB);
+    if (ret != C_KZG_OK) goto out;
+
+    /* Convert the blob to monomial form */
+    ret = blob_to_polynomial(poly_lagrange, blob);
+    if (ret != C_KZG_OK) goto out;
+    ret = poly_lagrange_to_monomial(poly_monomial, poly_lagrange, FIELD_ELEMENTS_PER_BLOB, &s);
+    if (ret != C_KZG_OK) goto out;
+
+    /* Evaluate over the extended domain with a full-size FFT */
+    ret = fr_fft(data_fr, poly_monomial, FIELD_ELEMENTS_PER_EXT_BLOB, &s);
+    if (ret != C_KZG_OK) goto out;
+    ret = bit_reversal_permutation(data_fr, sizeof(fr_t), FIELD_ELEMENTS_PER_EXT_BLOB);
+    if (ret != C_KZG_OK) goto out;
+
+    /* Convert all of the cells to byte-form */
+    for (size_t i = 0; i < CELLS_PER_EXT_BLOB; i++) {
+        for (size_t j = 0; j < FIELD_ELEMENTS_PER_CELL; j++) {
+            size_t index = i * FIELD_ELEMENTS_PER_CELL + j;
+            size_t offset = j * BYTES_PER_FIELD_ELEMENT;
+            bytes_from_bls_field((Bytes32 *)&cells[i].bytes[offset], &data_fr[index]);
+        }
+    }
+
+out:
+    c_kzg_free(poly_monomial);
+    c_kzg_free(poly_lagrange);
+    c_kzg_free(data_fr);
+    return ret;
+}
+
+static void test_compute_cells_and_kzg_proofs__matches_full_fft_reference(void) {
+    C_KZG_RET ret;
+    Blob blob;
+    Cell cells[CELLS_PER_EXT_BLOB];
+    Cell expected_cells[CELLS_PER_EXT_BLOB];
+    KZGProof proofs[CELLS_PER_EXT_BLOB];
+    int diff;
+
+    for (size_t trial = 0; trial < 4; trial++) {
+        /* Get a random blob */
+        get_rand_blob(&blob);
+
+        /* Compute the cells via the half-FFT path, with and without proofs */
+        ret = compute_cells_and_kzg_proofs(cells, proofs, &blob, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+
+        /* Compute the cells via the full-size FFT reference */
+        ret = reference_compute_cells(expected_cells, &blob);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+
+        /* The two paths must produce byte-identical cells */
+        diff = memcmp(cells, expected_cells, sizeof(cells));
+        ASSERT_EQUALS(diff, 0);
+
+        /* The cells-only variant must match too */
+        memset(cells, 0, sizeof(cells));
+        ret = compute_cells_and_kzg_proofs(cells, NULL, &blob, &s);
+        ASSERT_EQUALS(ret, C_KZG_OK);
+        diff = memcmp(cells, expected_cells, sizeof(cells));
+        ASSERT_EQUALS(diff, 0);
+    }
+}
+
+static void test_compute_cells_and_kzg_proofs__first_half_is_blob(void) {
+    C_KZG_RET ret;
+    Blob blob;
+    Cell cells[CELLS_PER_EXT_BLOB];
+    int diff;
+
+    /* Get a random blob */
+    get_rand_blob(&blob);
+
+    /* Compute the cells */
+    ret = compute_cells_and_kzg_proofs(cells, NULL, &blob, &s);
+    ASSERT_EQUALS(ret, C_KZG_OK);
+
+    /* The first half of the extension is the blob itself */
+    for (size_t i = 0; i < CELLS_PER_BLOB; i++) {
+        diff = memcmp(cells[i].bytes, &blob.bytes[i * BYTES_PER_CELL], BYTES_PER_CELL);
+        ASSERT_EQUALS(diff, 0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 // Tests for recover_cells_and_kzg_proofs
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2365,6 +2469,8 @@ int main(void) {
     RUN(test_deduplicate_commitments__all_duplicates);
     RUN(test_deduplicate_commitments__no_commitments);
     RUN(test_deduplicate_commitments__one_commitment);
+    RUN(test_compute_cells_and_kzg_proofs__matches_full_fft_reference);
+    RUN(test_compute_cells_and_kzg_proofs__first_half_is_blob);
     RUN(test_recover_cells_and_kzg_proofs__succeeds_random_blob);
     RUN(test_shift_factors__succeeds);
     RUN(test_compute_vanishing_polynomial_from_roots);


### PR DESCRIPTION
Note: this PR is part of a set of changes coming out of my AI-assisted performance investigation of the
EIP-7594 libraries. The analysis and implementation were done with Anthropic's Claude (Opus/Fable), and
cross-reviewed with OpenAI's Codex (GPT-5.6). The change is differential-tested against the previous
implementation — the full-size-FFT shape is reconstructed as a reference in the test suite and compared
byte-for-byte — mutation-checked (breaking the coset scaling makes the differential test fail), clean under
the sanitizers and the static analyzer, and the consensus spec vectors pass through the bindings.

This is a small PR, and it only touches how `compute_cells` evaluates the extension:
`ComputeCells`: **2.59 ms → 2.01 ms** (−22%); the extension step itself (C, `-O2`): **1.26 ms → 0.72 ms**
(−43%). The proof-bearing calls are EC-dominated and do not move.

## Attribution

The trick is from [mratsim/constantine](https://github.com/mratsim/constantine)

## Summary

`compute_cells_and_kzg_proofs` extends the blob by converting it to coefficient form, zero-padding from 4096
to 8192 coefficients, and running a size-8192 FFT — then bit-reversing the result. Half of that FFT's input is
zeros, and half of its output is something we already have.

The extended evaluation domain G (the 8192nd roots of unity) is the disjoint union of the blob's own domain H
(the even powers of `w = roots_of_unity[1]`, i.e. the 4096th roots of unity) and the coset `w·H` (the odd
powers). Bit-reversal on 13 bits sends even indices to the first half and odd indices to the second half, so
in the bit-reversed ordering the spec uses for cells:

- **the first half of the extension is the blob itself** — its lagrange form is exactly the evaluations over
  H, already in bit-reversed order, so it is a `memcpy`;
- **the second half is a size-4096 coset FFT** — scale coefficient k by `w^k` (the existing `shift_poly`, an
  O(n) pass), run a size-4096 forward FFT, and bit-reverse that half.

The two schedules are different arithmetic circuits, but they compute the same field elements — field
arithmetic is exact and the serialization is canonical — so the output is byte-identical, not merely
equivalent. One 8192-point transform plus an 8192-element permutation becomes one
4096-point transform, a 4096-element scaling pass, and a 4096-element permutation.

Two allocations also shrink from 8192 to 4096 elements (`poly_monomial`, `poly_lagrange`): nothing reads their
upper halves anymore — `compute_fk20_cell_proofs` documents that it only uses the lower 4096 coefficients —
and the `assert` loop that pinned the upper half to zero goes with them. A follow-up commit from the
cross-review reuses the then-dead lagrange buffer as scratch for the shifted coefficients instead of
allocating a fresh 4096-element array, dropping peak live field-element storage in this path from 24,576
elements on `main` to 16,384; timings are unchanged within noise.

## Correctness

- **Byte-identical by construction, and differential-tested.** The argument is the domain split above plus the
  fact that field operations are exact, so recomputing the same values along a different schedule yields the
  same canonical representation. The test pins it: `reference_compute_cells` in `tests.c` reconstructs the
  previous shape (IFFT to monomial form, zero-pad, size-8192 FFT, full bit-reversal), and
  `test_compute_cells_and_kzg_proofs__matches_full_fft_reference` compares it against the new path with
  `memcmp` over all 128 cells, for both the cells-only and cells-plus-proofs variants, over several blobs from
  the suite's deterministic RNG.
- **The structural identity is asserted separately**:
  `test_compute_cells_and_kzg_proofs__first_half_is_blob` checks that cells 0..63 are byte-for-byte the blob.
- **Mutation-checked**: perturbing the coset shift (using `roots_of_unity[2]` instead of `[1]`) fails the
  differential test (and the recovery round-trip test downstream); the structural first-half test correctly
  still passes, since the mutation only affects the coset half.
- **The consensus spec vectors pass** through the Go bindings (run with a fresh build cache).
- `make test` 95/95; address and undefined sanitizers pass (clang); `make analyze` clean; clang-format clean.

## Benchmarks

Apple M1, Go bindings, interleaved prebuilt binaries, medians of 7 runs of 10 iterations each:

| | main | this PR | |
|---|---:|---:|---|
| extension step (C, `-O2`, median of 50) | 1.256 ms | **0.721 ms** | −43% |
| `ComputeCells` | 2.585 ms | **2.012 ms** | −22% |
| `ComputeCellsAndKZGProofs` (precompute=6) | 208.2 ms | 211.4 ms | ~ |
| `RecoverCellsAndKZGProofs` (missing=50%) | 198.4 ms | 194.6 ms | ~ |
| `VerifyCellKZGProofBatch` (128 blobs × 128 cells) | 1329 ms | 1315 ms | ~ |

The last three *should* be unchanged — recovery and verification are untouched, and the proof computation
dominates `ComputeCellsAndKZGProofs` — and that they are is a check on the measurement.